### PR TITLE
feat(ci): add monorepo-aware CI pipeline + repo guardrails

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Default owners for everything in the repo. Adjust per subsystem
+# once each team member's GitHub handle is wired up here.
+*               @AET-DevOps26/team-bnd
+
+# Subsystem ownership (uncomment and fill in once roles are final)
+# /services/spring/    @teammate-server
+# /services/genai/     @teammate-genai
+# /web-client/         @teammate-client
+# /api/                @AET-DevOps26/team-bnd
+# /.github/            @AET-DevOps26/team-bnd
+# /infra/              @AET-DevOps26/team-bnd

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,5 @@
-# Default owners for everything in the repo. Adjust per subsystem
-# once each team member's GitHub handle is wired up here.
-*               @AET-DevOps26/team-bnd
+*					@BjarneHa @DoPri @ladu-tu
 
-# Subsystem ownership (uncomment and fill in once roles are final)
-# /services/spring/    @teammate-server
-# /services/genai/     @teammate-genai
-# /web-client/         @teammate-client
-# /api/                @AET-DevOps26/team-bnd
-# /.github/            @AET-DevOps26/team-bnd
-# /infra/              @AET-DevOps26/team-bnd
+/services/genai/	@DoPri
+/services/spring/	@ladu-tu
+/services/client/	@BjarneHa

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug report
+about: Something doesn't work as expected
+title: "[Bug] "
+labels: bug
+---
+
+## What happened
+
+<!-- short description -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected vs actual
+
+**Expected:**
+
+**Actual:**
+
+## Environment
+
+- Component (server / client / genai / infra):
+- Branch / commit:
+- Local or k8s:
+
+## Logs / screenshots
+
+```
+paste relevant log lines here
+```

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,28 @@
+---
+name: Feature request
+about: Propose a new feature or improvement
+title: "[Feature] "
+labels: enhancement
+---
+
+## Motivation
+
+<!-- why do we need this? user story / problem statement -->
+
+## Proposed change
+
+<!-- what should we build? rough scope, no need to fully design here -->
+
+## Affects
+
+- [ ] Server (Spring)
+- [ ] Client
+- [ ] GenAI
+- [ ] API spec
+- [ ] CI / CD
+- [ ] Docs
+
+## Definition of Done
+
+- [ ]
+- [ ]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      gha-minor:
+        update-types: [minor, patch]
+
+  - package-ecosystem: gradle
+    directory: "/services/spring/app"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      spring-boot:
+        patterns:
+          - "org.springframework.boot:*"
+          - "org.springframework:*"
+      misc-minor:
+        update-types: [minor, patch]
+
+  - package-ecosystem: docker
+    directory: "/services/spring"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## What does this PR do?
+
+<!-- Short description of the change. Reference any related issue: Closes #123 -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor / cleanup
+- [ ] Docs
+- [ ] CI / infra
+
+## Definition of Done
+
+- [ ] CI is green
+- [ ] If the API changed: `api/openapi.yaml` is updated and lint passes
+- [ ] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
+- [ ] Tests added or updated for the changed behaviour
+- [ ] Docs updated where it matters (README, ADRs, comments)
+
+## Notes for the reviewer
+
+<!-- Anything they should look at first, gotchas, screenshots, ... -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,326 @@
+# Main CI pipeline.
+#
+# Goals:
+# - Fail fast and fail loud when something is broken.
+# - Stay fast on PRs by only running jobs whose paths actually changed.
+# - Stay extensible: when web-client and the GenAI service land,
+#   they slot in as new jobs / matrix entries without rewriting this file.
+#
+# CD (push images, deploy to k8s) lives in a separate workflow once we
+# have a target cluster. This file is CI-only on purpose.
+
+name: ci
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Cancel superseded runs on the same branch / PR. Saves runner minutes
+# and means the latest commit is always the one that gets verified.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  JAVA_VERSION: "21"
+  JAVA_DISTRIBUTION: "temurin"
+  REGISTRY: ghcr.io
+  IMAGE_NAMESPACE: ${{ github.repository }}
+
+jobs:
+  # ---------------------------------------------------------------------
+  # Detect what changed so downstream jobs can self-skip cleanly.
+  # ---------------------------------------------------------------------
+  changes:
+    name: detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      api: ${{ steps.filter.outputs.api }}
+      spring: ${{ steps.filter.outputs.spring }}
+      docker: ${{ steps.filter.outputs.docker }}
+      workflows: ${{ steps.filter.outputs.workflows }}
+      docs: ${{ steps.filter.outputs.docs }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            api:
+              - 'api/**'
+            spring:
+              - 'services/spring/**'
+              - 'api/openapi.yaml'
+            docker:
+              - '**/Dockerfile'
+              - '**/Dockerfile.*'
+              - 'docker-compose.yml'
+              - 'docker-compose.*.yml'
+            workflows:
+              - '.github/workflows/**'
+            docs:
+              - 'docs/**'
+              - '**/*.md'
+
+  # ---------------------------------------------------------------------
+  # OpenAPI spec linting. Single source of truth must always be valid.
+  # ---------------------------------------------------------------------
+  lint-openapi:
+    name: lint openapi spec
+    needs: changes
+    if: needs.changes.outputs.api == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: redocly lint
+        run: npx --yes @redocly/cli@latest lint api/openapi.yaml
+
+  # ---------------------------------------------------------------------
+  # Dockerfile linting. Catches non-pinned base images, root user, etc.
+  # ---------------------------------------------------------------------
+  lint-dockerfiles:
+    name: lint dockerfiles
+    needs: changes
+    if: needs.changes.outputs.docker == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        dockerfile:
+          - services/spring/Dockerfile
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: ${{ matrix.dockerfile }}
+          # The repo-wide config defines our shared rules / ignores.
+          config: .hadolint.yaml
+          format: tty
+          failure-threshold: warning
+
+  # ---------------------------------------------------------------------
+  # Workflow file linting. Catches typos and bad action refs early.
+  # ---------------------------------------------------------------------
+  lint-workflows:
+    name: lint workflows
+    needs: changes
+    if: needs.changes.outputs.workflows == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: actionlint
+        # Pinned to the project's actionlint container so the version is reproducible.
+        run: |
+          bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          ./actionlint -color
+
+  # ---------------------------------------------------------------------
+  # Spring service: compile, test, package. Matrix-ready for when there
+  # are multiple Spring microservices.
+  # ---------------------------------------------------------------------
+  build-spring:
+    name: build & test ${{ matrix.service.name }}
+    needs: changes
+    if: needs.changes.outputs.spring == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - name: spring
+            path: services/spring/app
+    permissions:
+      contents: read
+      checks: write   # for test report annotations
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: setup java
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+
+      - name: setup gradle (with build cache)
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: ${{ github.event_name == 'pull_request' }}
+
+      - name: build & test
+        working-directory: ${{ matrix.service.path }}
+        run: ./gradlew --no-daemon --stacktrace build
+
+      - name: upload test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports-${{ matrix.service.name }}
+          path: |
+            ${{ matrix.service.path }}/build/reports/tests/**
+            ${{ matrix.service.path }}/build/test-results/**
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: upload jar
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jar-${{ matrix.service.name }}
+          path: ${{ matrix.service.path }}/build/libs/*.jar
+          if-no-files-found: warn
+          retention-days: 7
+
+  # ---------------------------------------------------------------------
+  # Build docker images for changed services. Only push on main.
+  # Image is also fed into Trivy for vuln scanning.
+  # ---------------------------------------------------------------------
+  build-image:
+    name: build image ${{ matrix.service.name }}
+    needs: [changes, build-spring, lint-dockerfiles]
+    if: |
+      always() &&
+      (needs.build-spring.result == 'success' || needs.build-spring.result == 'skipped') &&
+      (needs.lint-dockerfiles.result == 'success' || needs.lint-dockerfiles.result == 'skipped') &&
+      (needs.changes.outputs.spring == 'true' || needs.changes.outputs.docker == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - name: spring
+            context: services/spring
+            dockerfile: services/spring/Dockerfile
+    permissions:
+      contents: read
+      packages: write   # needed to push to GHCR on main
+      security-events: write   # for Trivy SARIF upload
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: setup buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.service.name }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha,format=short
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+
+      - name: login to ghcr
+        if: github.event_name == 'push'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: build (and push on main)
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.service.context }}
+          file: ${{ matrix.service.dockerfile }}
+          push: ${{ github.event_name == 'push' }}
+          load: ${{ github.event_name != 'push' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.service.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.service.name }}
+          provenance: false
+
+      - name: trivy scan (image)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
+          format: sarif
+          output: trivy-${{ matrix.service.name }}.sarif
+          severity: CRITICAL,HIGH
+          exit-code: "0"   # don't fail PRs on vulns yet, just report
+          ignore-unfixed: true
+
+      - name: upload trivy sarif
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-${{ matrix.service.name }}.sarif
+          category: trivy-${{ matrix.service.name }}
+
+  # ---------------------------------------------------------------------
+  # docker compose smoke test: bring the whole system up and curl the
+  # public endpoint. Catches integration regressions that unit tests miss.
+  # ---------------------------------------------------------------------
+  compose-smoke:
+    name: compose smoke test
+    needs: [changes, build-spring]
+    if: |
+      always() &&
+      needs.build-spring.result != 'failure' &&
+      (needs.changes.outputs.spring == 'true' || needs.changes.outputs.docker == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: bring stack up
+        run: docker compose up -d --build --wait --wait-timeout 180
+
+      - name: hit /hello
+        run: |
+          for i in 1 2 3 4 5 6 7 8 9 10; do
+            if curl -fsS http://localhost:8080/hello | grep -q "Hello World"; then
+              echo "ok"; exit 0
+            fi
+            echo "waiting for spring service... ($i/10)"
+            sleep 3
+          done
+          echo "service did not become ready"
+          docker compose logs
+          exit 1
+
+      - name: tear stack down
+        if: always()
+        run: docker compose down -v --remove-orphans
+
+  # ---------------------------------------------------------------------
+  # Aggregate gate: branch protection should require this single check.
+  # If anything upstream failed, this fails.
+  # ---------------------------------------------------------------------
+  ci-summary:
+    name: ci summary
+    if: always()
+    needs:
+      - lint-openapi
+      - lint-dockerfiles
+      - lint-workflows
+      - build-spring
+      - build-image
+      - compose-smoke
+    runs-on: ubuntu-latest
+    steps:
+      - name: fail if any required job failed
+        env:
+          RESULTS: ${{ toJSON(needs) }}
+        run: |
+          echo "$RESULTS" | jq .
+          # A 'failure' or 'cancelled' anywhere in the dag flips this to red.
+          if echo "$RESULTS" | jq -e 'to_entries | map(.value.result) | any(. == "failure" or . == "cancelled")' > /dev/null; then
+            echo "one or more upstream jobs failed"
+            exit 1
+          fi
+          echo "all good"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,9 @@ jobs:
       workflows: ${{ steps.filter.outputs.workflows }}
       docs: ${{ steps.filter.outputs.docs }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           filters: |
             api:
@@ -77,12 +77,12 @@ jobs:
     if: needs.changes.outputs.api == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: redocly lint
         run: npx --yes @redocly/cli@latest lint api/openapi.yaml
@@ -101,8 +101,8 @@ jobs:
         dockerfile:
           - services/spring/Dockerfile
     steps:
-      - uses: actions/checkout@v4
-      - uses: hadolint/hadolint-action@v3.1.0
+      - uses: actions/checkout@v6
+      - uses: hadolint/hadolint-action@v3.3.0
         with:
           dockerfile: ${{ matrix.dockerfile }}
           # The repo-wide config defines our shared rules / ignores.
@@ -119,7 +119,7 @@ jobs:
     if: needs.changes.outputs.workflows == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: actionlint
         # Pinned to the project's actionlint container so the version is reproducible.
         run: |
@@ -145,16 +145,16 @@ jobs:
       contents: read
       checks: write   # for test report annotations
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: setup java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}
 
       - name: setup gradle (with build cache)
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
         with:
           cache-read-only: ${{ github.event_name == 'pull_request' }}
 
@@ -164,7 +164,7 @@ jobs:
 
       - name: upload test reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-reports-${{ matrix.service.name }}
           path: |
@@ -175,7 +175,7 @@ jobs:
 
       - name: upload jar
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: jar-${{ matrix.service.name }}
           path: ${{ matrix.service.path }}/build/libs/*.jar
@@ -207,14 +207,14 @@ jobs:
       packages: write   # needed to push to GHCR on main
       security-events: write   # for Trivy SARIF upload
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: setup buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: extract image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.service.name }}
           tags: |
@@ -225,7 +225,7 @@ jobs:
 
       - name: login to ghcr
         if: github.event_name == 'push'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -233,7 +233,7 @@ jobs:
 
       - name: build (and push on main)
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ matrix.service.context }}
           file: ${{ matrix.service.dockerfile }}
@@ -246,7 +246,7 @@ jobs:
           provenance: false
 
       - name: trivy scan (image)
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
           format: sarif
@@ -275,7 +275,7 @@ jobs:
       (needs.changes.outputs.spring == 'true' || needs.changes.outputs.docker == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: bring stack up
         run: docker compose up -d --build --wait --wait-timeout 180

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,10 +38,10 @@ jobs:
       matrix:
         language: [java-kotlin]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: setup java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,62 @@
+# Static security analysis via GitHub CodeQL. Runs on PRs touching
+# code, on every push to main, and weekly so we catch advisories on
+# dependencies that didn't change in our code.
+
+name: codeql
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'services/spring/**'
+      - '.github/workflows/codeql.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'services/spring/**'
+  schedule:
+    - cron: '17 4 * * 1'
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: analyze ${{ matrix.language }}
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [java-kotlin]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: setup java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: init codeql
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+
+      - name: build (manual mode for reliability)
+        working-directory: services/spring/app
+        run: ./gradlew --no-daemon assemble
+
+      - name: analyze
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:${{ matrix.language }}

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,15 @@
+# hadolint config. Tweak as we add more services.
+failure-threshold: warning
+
+# DL3008: pin apt versions - too noisy on slim images we don't fully control.
+# DL3018: pin apk versions in Alpine - same reason.
+# Reconsider both once we standardise on a hardened base image.
+ignored:
+  - DL3008
+  - DL3018
+
+trustedRegistries:
+  - docker.io
+  - ghcr.io
+  - registry.access.redhat.com
+  - mcr.microsoft.com

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,40 @@
+# Local guardrails. Run `pre-commit install` after cloning.
+# CI runs the same checks, so local hooks just speed up the feedback loop.
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+        args: [--allow-multiple-documents]
+        exclude: '\.github/workflows/.*\.ya?ml$'
+      - id: check-added-large-files
+        args: [--maxkb=1024]
+      - id: check-merge-conflict
+      - id: mixed-line-ending
+
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.35.1
+    hooks:
+      - id: yamllint
+        args: [-c=.yamllint.yaml]
+
+  - repo: https://github.com/hadolint/hadolint
+    rev: v2.13.1-beta
+    hooks:
+      - id: hadolint-docker
+        args: [--config, .hadolint.yaml]
+
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.7
+    hooks:
+      - id: actionlint
+
+  - repo: https://github.com/redocly/redocly-cli
+    rev: v1.34.5
+    hooks:
+      - id: redocly-lint
+        files: '^api/.*\.ya?ml$'
+        args: ['lint', 'api/openapi.yaml']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -16,25 +16,27 @@ repos:
       - id: mixed-line-ending
 
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.35.1
+    rev: v1.38.0
     hooks:
       - id: yamllint
         args: [-c=.yamllint.yaml]
 
   - repo: https://github.com/hadolint/hadolint
-    rev: v2.13.1-beta
+    rev: v2.14.0
     hooks:
       - id: hadolint-docker
         args: [--config, .hadolint.yaml]
 
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.7
+    rev: v1.7.12
     hooks:
       - id: actionlint
 
-  - repo: https://github.com/redocly/redocly-cli
-    rev: v1.34.5
+  - repo: local
     hooks:
       - id: redocly-lint
+        name: redocly-lint
+        entry: npx --yes @redocly/cli@2.30.3 lint api/openapi.yaml
+        language: system
         files: '^api/.*\.ya?ml$'
-        args: ['lint', 'api/openapi.yaml']
+        pass_filenames: false

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,20 @@
+extends: default
+
+rules:
+  line-length:
+    max: 200
+    level: warning
+  document-start: disable
+  truthy:
+    allowed-values: ['true', 'false', 'on', 'off']
+    check-keys: false
+  comments:
+    min-spaces-from-content: 1
+  indentation:
+    spaces: 2
+    indent-sequences: consistent
+
+ignore: |
+  services/spring/app/build/
+  **/node_modules/
+  **/build/

--- a/README.md
+++ b/README.md
@@ -12,8 +12,22 @@ TODO
 ## Setup
 
 ### Git Repository
-This repository uses pre-commit hooks. Install [pre-commit](https://pre-commit.com/) and run `pre-commit install`. This will automatically run these scripts on each `git commit`:
-- TODO
+This repository uses pre-commit hooks. Install [pre-commit](https://pre-commit.com/) and run `pre-commit install` after cloning.
+
+On every `git commit`, these checks run automatically:
+- `trailing-whitespace`
+- `end-of-file-fixer`
+- `check-yaml` (except GitHub workflow files)
+- `check-added-large-files` (max 1024 KB)
+- `check-merge-conflict`
+- `mixed-line-ending`
+- `yamllint` with `.yamllint.yaml`
+- `hadolint-docker` with `.hadolint.yaml`
+- `actionlint`
+- `redocly-lint` via `npx --yes @redocly/cli@2.30.3 lint api/openapi.yaml` for files under `api/`
+
+To run the full hook set manually:
+`pre-commit run --all-files`
 
 ### Server
 To start up the spring-boot service, a Dockerfile is provided. To use it:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,18 +1,25 @@
 openapi: 3.2.0
 info:
-  title: Alexandria - OpenAPI 3.2
-  description: This is the OpenAPI 3.2 specification for the Alexandria project.
+  title: Alexandria
+  description: API specification for the Alexandria document management and knowledge extraction platform.
   version: 0.0.1
+  license:
+    name: MIT
+    identifier: MIT
+servers:
+  - url: http://localhost:8080
+    description: Local dev server
 tags:
   - name: hello
-    summary: Hello World 
-    description: A simple hello world endpoint.
+    description: Liveness / smoke endpoints used during early bring-up.
 paths:
   /hello:
     get:
-      tags: 
+      tags:
         - hello
+      operationId: getHello
       summary: Returns Hello World
+      security: []
       responses:
         '200':
           description: Successful response
@@ -21,3 +28,27 @@ paths:
               schema:
                 type: string
                 example: Hello World!
+        '500':
+          description: Unexpected server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+components:
+  schemas:
+    ApiError:
+      type: object
+      description: Unified error envelope used across all services.
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+          example: INTERNAL_ERROR
+        message:
+          type: string
+          example: Something went wrong while processing the request.
+        details:
+          type: object
+          additionalProperties: true

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -1,0 +1,17 @@
+# Redocly config used by both pre-commit and CI to lint api/openapi.yaml.
+extends:
+  - recommended
+
+apis:
+  alexandria@v1:
+    root: api/openapi.yaml
+
+rules:
+  # Relaxed until we have a real hosted URL. Localhost still trips this rule;
+  # flip back to error once we have a staging server in the spec.
+  no-server-example.com: warn
+  no-empty-servers: warn
+  operation-operationId: warn
+  operation-summary: warn
+  operation-4xx-response: warn
+  tags-alphabetical: off

--- a/services/spring/.dockerignore
+++ b/services/spring/.dockerignore
@@ -1,0 +1,18 @@
+# Keep the build context lean so docker build is fast and reproducible.
+.git
+.gitignore
+.gradle
+build/
+**/build/
+**/.gradle/
+out/
+.idea/
+*.iml
+.vscode/
+.env
+.env.*
+*.log
+**/test-results/
+**/reports/
+README.md
+HELP.md


### PR DESCRIPTION
## What does this PR do?

Sets up the first proper CI pipeline for the repo, plus the repo hygiene that goes with it. Monorepo-aware (paths-filter), matrix-ready for the upcoming client / GenAI services, and keeps actions/hooks up to date.

Pulled out CD on purpose - this PR is CI-only. Image push to GHCR happens on merge to main, but actual k8s deploy will land in a separate workflow once we have a target cluster.

Also includes follow-up CI maintenance:
- fixed Trivy action ref to a resolvable tag (`aquasecurity/trivy-action@v0.36.0`)
- bumped workflow actions in `.github/workflows/ci.yml` and `.github/workflows/codeql.yml`
- moved OpenAPI lint job to Node 24 in CI

## Workflows added

- ci.yml
  - changes - detect which paths a PR touches, gate everything else on it
  - lint-openapi - redocly lint on api/openapi.yaml (recommended ruleset, slightly relaxed where we don't have prod URLs yet)
  - lint-dockerfiles - hadolint matrix (one entry per Dockerfile)
  - lint-workflows - actionlint to catch typos in our own workflow files
  - build-spring - gradle build + test, matrix-ready, with build cache, uploads test reports + jar
  - build-image - buildx + docker/build-push, push to ghcr only on main, trivy scan with SARIF upload
  - compose-smoke - bring stack up via docker compose, curl /hello, tear down
  - ci-summary - single aggregate gate so branch protection only needs one required check
- codeql.yml - Java SAST, runs on PR + push + weekly cron

## Repo guardrails

- dependabot.yml for github-actions, gradle, docker
- .pre-commit-config.yaml + .yamllint.yaml so local hooks match CI
  - pre-commit-hooks: v6.0.0
  - yamllint: v1.38.0
  - hadolint: v2.14.0
  - actionlint: v1.7.12
  - replaced broken Redocly upstream hook with a local hook:
    `npx --yes @redocly/cli@2.30.3 lint api/openapi.yaml`
- redocly.yaml + .hadolint.yaml so the same rules run locally and in CI
- PR template, issue templates, CODEOWNERS skeleton
- .dockerignore for the spring service to keep build context lean

## Docs

- Updated README pre-commit section with the actual active hooks
- Added manual command: `pre-commit run --all-files`

## Drive-by fix

Patched api/openapi.yaml just enough to pass redocly recommended: server, license, operationId, ApiError envelope, explicit empty security on the public hello endpoint. Otherwise the very first PR running this CI would fail.

## Notes for the reviewer

- Branch protection: once this is green on main, please require ci-summary as the only check. Saves having to update protection every time we add a job.
- Trivy is set to exit-code 0 on purpose - we want vuln visibility before we start failing PRs on it. Flip that to 1 once base images are pinned and clean.
- Image push uses GITHUB_TOKEN to ghcr.io so no extra secret needed.
- I deliberately did not add CD here. Separate PR once we agree on the target cluster (Rancher vs Azure).

Ref. Issue #4 
