### PR TITLE
[Infra] Harden docker-compose for local development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# GenAI service
+GENAI_LOG_LEVEL=info

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,13 +5,41 @@ services:
       dockerfile: Dockerfile
     ports:
       - 8082:80
+    restart: unless-stopped
+    networks:
+      - alexandria
+    deploy:
+      resources:
+        limits:
+          cpus: "0.25"
+          memory: 128M
+
   spring:
     build: services/spring/
     ports:
       - 8080:8080
+    restart: unless-stopped
+    networks:
+      - alexandria
+    deploy:
+      resources:
+        limits:
+          cpus: "0.50"
+          memory: 512M
+
   genai:
     build: services/genai/
     ports:
       - 8000:8000
-    environment:
-      - GENAI_LOG_LEVEL=info
+    restart: unless-stopped
+    networks:
+      - alexandria
+    deploy:
+      resources:
+        limits:
+          cpus: "0.50"
+          memory: 512M
+
+networks:
+  alexandria:
+    driver: bridge


### PR DESCRIPTION
## What does this PR do?

Hardens docker-compose so adding new services is mechanical and the local stack is more resilient. Removes the inline environment block from genai in favour of .env auto-loading.

Related issues:
- #39 (restart policy + explicit network)
- #40 (.env.example + env convention)
- #41 (resource limits)

Closes #39, closes #40, closes #41.

## Type of change

- [x] CI / infra

## Definition of Done

- [x] CI is green
- [ ] If the API changed: `api/openapi.yaml` is updated and lint passes
- [x] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [ ] Tests added or updated for the changed behaviour
- [x] Docs updated where it matters (README, ADRs, comments)

## Notes for the reviewer

- .env is auto-loaded by compose, so no explicit env_file directive needed.
- resource limits are conservative defaults (128M for client, 512M for spring/genai). Adjust if something OOMs locally.
- pre-commit hooks and docker compose config both pass.