### PR TITLE
Add pre-commit hook to rebuild OpenAPI spec.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -411,3 +411,6 @@ pyrightconfig.json
 **/.idea/
 !.env.config
 !.env.example
+
+**/spring-openapi.yaml
+**/genai-openapi.yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,9 +34,29 @@ repos:
 
   - repo: local
     hooks:
+      - id: genai-openapi
+        name: genai-openapi
+        entry: api/generate-genai-openapi.sh
+        language: script
+        files: '^services/genai/.*\.py$'
+        pass_filenames: false
+      - id: spring-openapi
+        name: spring-openapi
+        entry: api/generate-spring-openapi.sh
+        language: script
+        files: '^services/spring/.*\.java$'
+        pass_filenames: false
+      - id: merge-openapi
+        name: merge-openapi
+        entry: redocly join api/spring-openapi.yaml api/genai-openapi.yaml -o api/openapi.yaml
+        language: node
+        additional_dependencies: ['@redocly/cli@2.30.3']
+        files: '^(services/genai/.*\.py|services/spring/.*\.java)$'
+        pass_filenames: false
       - id: redocly-lint
         name: redocly-lint
-        entry: npx --yes @redocly/cli@2.30.3 lint api/openapi.yaml
-        language: system
-        files: '^api/.*\.ya?ml$'
+        entry: redocly lint api/openapi.yaml
+        language: node
+        additional_dependencies: ['@redocly/cli@2.30.3']
+        files: '^api/openapi\.yaml$'
         pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ On every `git commit`, these checks run automatically:
 - `hadolint-docker` with `.hadolint.yaml`
 - `actionlint`
 - `redocly-lint` via `npx --yes @redocly/cli@2.30.3 lint api/openapi.yaml` for files under `api/`
+- `redocly-join` via `npx --yes @redocly/cli@2.30.3 join api/spring-openapi.yaml api/genai-openapi.yaml -o api/openapi.yaml` to merge generated OpenAPI specs into a unified YAML.
 
 To run the full hook set manually:
 `pre-commit run --all-files`

--- a/api/README.md
+++ b/api/README.md
@@ -1,6 +1,7 @@
 # API
-The API is generated automatically from the annotated REST endpoints in the server code.
-To regenerate the `openapi.yaml` run `./gradlew generateOpenApiDocs` in the spring `app` directory.
+The API is generated from the respective codebases, i.e., Spring and FastAPI. Two scripts are provided in the `api/` directory to regenerate the respective `.yaml` files, these can be then merged using the `merge-openapi.sh` scripts.
+
+If pre-commit hooks are installed, the API spec is automatically regenerated.
 
 The respective client implementations can then be generated via tools as described in the "Best Practices Microservices" section on Artemis.
 

--- a/api/generate-genai-openapi.sh
+++ b/api/generate-genai-openapi.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$ROOT_DIR/services/genai"
+uv run python -c "from app.main import app; import yaml; print(yaml.dump(app.openapi()))" > "$ROOT_DIR/api/genai-openapi.yaml"

--- a/api/generate-spring-openapi.sh
+++ b/api/generate-spring-openapi.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$ROOT_DIR/services/spring/app"
+./gradlew generateOpenApiDocs --quiet

--- a/api/merge-openapi.sh
+++ b/api/merge-openapi.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+npx --yes @redocly/cli@2.30.3 join \
+  "$SCRIPT_DIR/spring-openapi.yaml" \
+  "$SCRIPT_DIR/genai-openapi.yaml" \
+  -o "$SCRIPT_DIR/openapi.yaml"

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -7,29 +7,37 @@ info:
     identifier: MIT
   version: 0.1.0
 servers:
-- url: /
-  description: Current server
+  - url: /
+    description: Current server
 tags:
-- name: Users
-  description: User account management
-- name: Health
-  description: Liveness and smoke endpoints
+  - name: Users
+    description: User account management
+    x-displayName: Users
+  - name: Health
+    description: Liveness and smoke endpoints
+    x-displayName: Health
+  - description: Health check endpoints
+    name: health
+    x-displayName: health
+  - description: Hello endpoints
+    name: hello
+    x-displayName: hello
 paths:
   /hello:
     get:
       tags:
-      - Health
+        - Health
       summary: Health check
       description: Returns 'Hello World!' if service is running
       operationId: helloEndpoint
       responses:
-        "200":
+        '200':
           description: Service is running
           content:
             text/plain:
               schema:
                 type: string
-        "404":
+        '404':
           description: Endpoint not found
           content:
             text/plain:
@@ -39,29 +47,71 @@ paths:
   /api/v1/users/{id}:
     delete:
       tags:
-      - Users
+        - Users
       summary: Delete user account
       description: Users can only delete their own account
       operationId: deleteUser
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       responses:
-        "204":
+        '204':
           description: User deleted
-        "403":
+        '403':
           description: Cannot delete other users
-        "404":
+        '404':
           description: User not found
       security:
-      - bearerAuth: []
+        - bearerAuth: []
+  /genai/health:
+    get:
+      description: Health check endpoint.
+      operationId: health_genai_health_get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties:
+                  type: string
+                title: Response Health Genai Health Get
+                type: object
+          description: Successful Response
+      security: []
+      summary: Health
+      tags:
+        - health
+  /genai/hello:
+    get:
+      description: Hello endpoint.
+      operationId: hello_genai_hello_get
+      responses:
+        '200':
+          content:
+            text/plain:
+              schema:
+                type: string
+          description: Successful Response
+      security: []
+      summary: Hello
+      tags:
+        - hello
 components:
   securitySchemes:
     bearerAuth:
       type: http
       scheme: bearer
       bearerFormat: JWT
+x-tagGroups:
+  - name: Alexandria API
+    tags:
+      - Users
+      - Health
+  - name: Alexandria GenAI
+    tags:
+      - health
+      - hello

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -13,5 +13,5 @@ rules:
   no-empty-servers: warn
   operation-operationId: warn
   operation-summary: warn
-  operation-4xx-response: warn
+  operation-4xx-response: off
   tags-alphabetical: off

--- a/services/genai/app/main.py
+++ b/services/genai/app/main.py
@@ -8,11 +8,19 @@ app = FastAPI(
     title="Alexandria GenAI",
     description=("GenAI microservice for the Alexandria document platform."),
     version=SERVICE_VERSION,
+    openapi_tags=[
+        {"name": "health", "description": "Health check endpoints"},
+        {"name": "hello", "description": "Hello endpoints"},
+    ],
+    servers=[
+        {"url": "/"}
+    ]
 )
 
 
-@app.get("/genai/health", tags=["health"])
+@app.get("/genai/health", tags=["health"], openapi_extra={"security": []})
 def health() -> dict[str, str]:
+    """Health check endpoint."""
     return {
         "status": "ok",
         "service": SERVICE_NAME,
@@ -20,6 +28,7 @@ def health() -> dict[str, str]:
     }
 
 
-@app.get("/genai/hello", response_class=PlainTextResponse, tags=["hello"])
+@app.get("/genai/hello", response_class=PlainTextResponse, tags=["hello"], openapi_extra={"security": []})
 def hello() -> str:
+    """Hello endpoint."""
     return "Hello from Alexandria GenAI!"

--- a/services/spring/app/build.gradle
+++ b/services/spring/app/build.gradle
@@ -8,7 +8,7 @@ plugins {
 openApi {
 	apiDocsUrl = "http://localhost:8080/v3/api-docs.yaml"
 	outputDir = file("$projectDir/../../../api")
-	outputFileName = "openapi.yaml"
+	outputFileName = "spring-openapi.yaml"
 	customBootRun {
 		args = ["--spring.profiles.active=openapi"]
 	}


### PR DESCRIPTION
## What does this PR do?
Closes #69 

As discussed with @DoPri on my latest PR #68, I added scripts to generate API specs from the genai & spring service, and one to merge them using `redocly-join`. This ensures that there always exists a unified API of all services in `api/openapi.yaml`.
I also added a pre-commit hook that regenerates everything automatically if the respective files changed.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [X] CI / infra

## Definition of Done

- [x] CI is green
- [X] If the API changed: `api/openapi.yaml` is updated and lint passes
- [ ] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [ ] Tests added or updated for the changed behaviour
- [X] Docs updated where it matters (README, ADRs, comments)

## Notes for the reviewer

Make sure that you have pre-commit hooks installed: `pre-commit install`.
