### PR TITLE
infra(k8s): create Helm chart for the Alexandria project

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,13 +50,14 @@ repos:
         name: merge-openapi
         entry: redocly join api/spring-openapi.yaml api/genai-openapi.yaml -o api/openapi.yaml
         language: node
-        additional_dependencies: ['@redocly/cli@2.30.3']
+        additional_dependencies: ["@redocly/cli@2.30.3"]
         files: '^(services/genai/.*\.py|services/spring/.*\.java)$'
         pass_filenames: false
       - id: redocly-lint
         name: redocly-lint
         entry: redocly lint api/openapi.yaml
         language: node
-        additional_dependencies: ['@redocly/cli@2.30.3']
+        additional_dependencies: ["@redocly/cli@2.30.3"]
         files: '^api/openapi\.yaml$'
         pass_filenames: false
+exclude: "infra/.*/(templates|charts)"

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -18,3 +18,5 @@ ignore: |
   services/spring/app/build/
   **/node_modules/
   **/build/
+  **/templates/
+  **/charts/

--- a/README.md
+++ b/README.md
@@ -65,3 +65,41 @@ Quickest way:
 2. `curl http://localhost:8000/genai/hello`
 
 For local Python dev (tests, autoreload), see [`services/genai/README.md`](services/genai/README.md).
+
+### Kubernetes Deployment
+
+A Helm chart is provided in `infra/helm/alexandria/`.
+
+Prerequisites:
+- A running Kubernetes cluster (Rancher, Azure AKS, minikube, etc.)
+- `helm` and `kubectl` configured to access the cluster
+
+Deploy:
+```bash
+helm install alexandria infra/helm/alexandria --namespace alexandria --create-namespace
+```
+
+Upgrade after changes:
+```bash
+helm upgrade alexandria infra/helm/alexandria --namespace alexandria
+```
+
+Uninstall:
+```bash
+helm uninstall alexandria --namespace alexandria
+```
+
+Override values (e.g., different image tag):
+```bash
+helm install alexandria infra/helm/alexandria \
+  --namespace alexandria --create-namespace \
+  --set image.tag=sha-abc123 \
+  --set ingress.host=alexandria.example.com
+```
+
+Check status:
+```bash
+kubectl -n alexandria get pods
+kubectl -n alexandria get svc
+kubectl -n alexandria get ingress
+```

--- a/README.md
+++ b/README.md
@@ -68,20 +68,31 @@ For local Python dev (tests, autoreload), see [`services/genai/README.md`](servi
 
 ### Kubernetes Deployment
 
-A Helm chart is provided in `infra/helm/alexandria/`.
+A Helm chart is provided in `infra/k8s/alexandria/`.
 
 Prerequisites:
 - A running Kubernetes cluster (Rancher, Azure AKS, minikube, etc.)
 - `helm` and `kubectl` configured to access the cluster
 
+Secrets Setup:
+1. Copy the secrets template:
+   ```bash
+   cp infra/k8s/alexandria/values-secrets.yaml.example infra/k8s/alexandria/values-secrets.yaml
+   ```
+2. Edit `values-secrets.yaml` and set your actual passwords (this file is gitignored)
+
 Deploy:
 ```bash
-helm install alexandria infra/helm/alexandria --namespace alexandria --create-namespace
+helm install alexandria infra/k8s/alexandria \
+  --namespace alexandria --create-namespace \
+  -f infra/k8s/alexandria/values-secrets.yaml
 ```
 
 Upgrade after changes:
 ```bash
-helm upgrade alexandria infra/helm/alexandria --namespace alexandria
+helm upgrade alexandria infra/k8s/alexandria \
+  --namespace alexandria \
+  -f infra/k8s/alexandria/values-secrets.yaml
 ```
 
 Uninstall:
@@ -91,8 +102,9 @@ helm uninstall alexandria --namespace alexandria
 
 Override values (e.g., different image tag):
 ```bash
-helm install alexandria infra/helm/alexandria \
+helm install alexandria infra/k8s/alexandria \
   --namespace alexandria --create-namespace \
+  -f infra/k8s/alexandria/values-secrets.yaml \
   --set image.tag=sha-abc123 \
   --set ingress.host=alexandria.example.com
 ```

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Deploy:
 ```bash
 helm install alexandria infra/k8s/alexandria \
   --namespace alexandria --create-namespace \
+  --dependency-update \
   -f infra/k8s/alexandria/values-secrets.yaml
 ```
 
@@ -92,6 +93,7 @@ Upgrade after changes:
 ```bash
 helm upgrade alexandria infra/k8s/alexandria \
   --namespace alexandria \
+  --dependency-update \
   -f infra/k8s/alexandria/values-secrets.yaml
 ```
 
@@ -104,6 +106,7 @@ Override values (e.g., different image tag):
 ```bash
 helm install alexandria infra/k8s/alexandria \
   --namespace alexandria --create-namespace \
+  --dependency-update \
   -f infra/k8s/alexandria/values-secrets.yaml \
   --set image.tag=sha-abc123 \
   --set ingress.host=alexandria.example.com

--- a/infra/k8s/alexandria/.gitignore
+++ b/infra/k8s/alexandria/.gitignore
@@ -1,0 +1,1 @@
+**/charts/*.tgz

--- a/infra/k8s/alexandria/.gitignore
+++ b/infra/k8s/alexandria/.gitignore
@@ -1,1 +1,2 @@
 **/charts/*.tgz
+values-secrets.yaml

--- a/infra/k8s/alexandria/.helmignore
+++ b/infra/k8s/alexandria/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/infra/k8s/alexandria/Chart.lock
+++ b/infra/k8s/alexandria/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: keycloak
+  repository: oci://registry-1.docker.io/cloudpirates
+  version: 0.21.9
+- name: postgres
+  repository: oci://registry-1.docker.io/cloudpirates
+  version: 0.19.5
+digest: sha256:6513f06cd4a184113073a7f0e65c5f9aabeaa63f2e3c18ec6db7cbbd96a558f3
+generated: "2026-05-27T17:01:19.084076962+02:00"

--- a/infra/k8s/alexandria/Chart.yaml
+++ b/infra/k8s/alexandria/Chart.yaml
@@ -6,3 +6,12 @@ type: application
 version: 0.1.0
 
 appVersion: "1.16.0"
+dependencies:
+  - name: keycloak
+    version: 0.21.9
+    repository: oci://registry-1.docker.io/cloudpirates
+    condition: keycloak.enabled
+  - name: postgres
+    version: 0.19.5
+    repository: oci://registry-1.docker.io/cloudpirates
+    alias: postgres-db

--- a/infra/k8s/alexandria/Chart.yaml
+++ b/infra/k8s/alexandria/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: alexandria
+description: A Helm chart for Kubernetes
+type: application
+
+version: 0.1.0
+
+appVersion: "1.16.0"

--- a/infra/k8s/alexandria/templates/NOTES.txt
+++ b/infra/k8s/alexandria/templates/NOTES.txt
@@ -1,0 +1,31 @@
+Alexandria has been deployed to namespace {{ .Release.Namespace }}.
+
+{{- $insecure := list }}
+{{- if eq .Values.spring.database.password "postgres-password" }}
+{{- $insecure = append $insecure "spring.database.password" }}
+{{- end }}
+{{- if eq .Values.keycloak.adminPassword "admin" }}
+{{- $insecure = append $insecure "keycloak.adminPassword" }}
+{{- end }}
+{{- if eq .Values.keycloak.database.password "postgres-password" }}
+{{- $insecure = append $insecure "keycloak.database.password" }}
+{{- end }}
+{{- if eq (index .Values "postgres-db" "auth" "password") "postgres-password" }}
+{{- $insecure = append $insecure "postgres-db.auth.password" }}
+{{- end }}
+
+{{- if $insecure }}
+
+===========================================================================
+ SECURITY WARNING: You are using default passwords for the following values:
+{{- range $insecure }}
+   - {{ . }}
+{{- end }}
+
+ To set secure passwords, create a values-secrets.yaml file:
+   cp infra/k8s/alexandria/values-secrets.yaml.example infra/k8s/alexandria/values-secrets.yaml
+
+ Then deploy with:
+   helm upgrade {{ .Release.Name }} infra/k8s/alexandria -f infra/k8s/alexandria/values-secrets.yaml
+===========================================================================
+{{- end }}

--- a/infra/k8s/alexandria/templates/NOTES.txt
+++ b/infra/k8s/alexandria/templates/NOTES.txt
@@ -26,6 +26,6 @@ Alexandria has been deployed to namespace {{ .Release.Namespace }}.
    cp infra/k8s/alexandria/values-secrets.yaml.example infra/k8s/alexandria/values-secrets.yaml
 
  Then deploy with:
-   helm upgrade {{ .Release.Name }} infra/k8s/alexandria -f infra/k8s/alexandria/values-secrets.yaml
+   helm upgrade {{ .Release.Name }} infra/k8s/alexandria --dependency-update -f infra/k8s/alexandria/values-secrets.yaml
 ===========================================================================
 {{- end }}

--- a/infra/k8s/alexandria/templates/_helpers.tpl
+++ b/infra/k8s/alexandria/templates/_helpers.tpl
@@ -1,0 +1,46 @@
+{{- define "alexandria.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "alexandria.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "alexandria.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "alexandria.labels" -}}
+helm.sh/chart: {{ include "alexandria.chart" . }}
+{{ include "alexandria.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "alexandria.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "alexandria.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "alexandria.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "alexandria.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{- define "alexandria.image" -}}
+{{ .Values.image.registry }}/{{ .Values.image.repository }}/{{ .service }}:{{ .Values.image.tag }}
+{{- end }}

--- a/infra/k8s/alexandria/templates/client-deployment.yaml
+++ b/infra/k8s/alexandria/templates/client-deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "alexandria.fullname" . }}-client
+  labels:
+    {{- include "alexandria.labels" . | nindent 4 }}
+    app: client
+    app.kubernetes.io/component: frontend
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "alexandria.selectorLabels" . | nindent 6 }}
+      app: client
+  template:
+    metadata:
+      labels:
+        {{- include "alexandria.selectorLabels" . | nindent 8 }}
+        app: client
+        app.kubernetes.io/component: frontend
+    spec:
+      securityContext:
+        runAsNonRoot: false
+      containers:
+        - name: client
+          image: {{ include "alexandria.image" (dict "Values" .Values "service" "client") }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.client.resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 15
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3

--- a/infra/k8s/alexandria/templates/client-service.yaml
+++ b/infra/k8s/alexandria/templates/client-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "alexandria.fullname" . }}-client
+  labels:
+    {{- include "alexandria.labels" . | nindent 4 }}
+    app: client
+    app.kubernetes.io/component: frontend
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "alexandria.selectorLabels" . | nindent 4 }}
+    app: client
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+      protocol: TCP

--- a/infra/k8s/alexandria/templates/genai-deployment.yaml
+++ b/infra/k8s/alexandria/templates/genai-deployment.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "alexandria.fullname" . }}-genai
+  labels:
+    {{- include "alexandria.labels" . | nindent 4 }}
+    app: genai
+    app.kubernetes.io/component: ai-service
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "alexandria.selectorLabels" . | nindent 6 }}
+      app: genai
+  template:
+    metadata:
+      labels:
+        {{- include "alexandria.selectorLabels" . | nindent 8 }}
+        app: genai
+        app.kubernetes.io/component: ai-service
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+      containers:
+        - name: genai
+          image: {{ include "alexandria.image" (dict "Values" .Values "service" "genai") }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.genai.resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /genai/health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /genai/health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3

--- a/infra/k8s/alexandria/templates/genai-service.yaml
+++ b/infra/k8s/alexandria/templates/genai-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "alexandria.fullname" . }}-genai
+  labels:
+    {{- include "alexandria.labels" . | nindent 4 }}
+    app: genai
+    app.kubernetes.io/component: ai-service
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "alexandria.selectorLabels" . | nindent 4 }}
+    app: genai
+  ports:
+    - name: http
+      port: 8000
+      targetPort: http
+      protocol: TCP

--- a/infra/k8s/alexandria/templates/ingress.yaml
+++ b/infra/k8s/alexandria/templates/ingress.yaml
@@ -18,6 +18,13 @@ spec:
                 name: {{ include "alexandria.fullname" . }}-client
                 port:
                   number: 80
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "alexandria.fullname" . }}-spring
+                port:
+                  number: 8080
           - path: /genai
             pathType: Prefix
             backend:

--- a/infra/k8s/alexandria/templates/ingress.yaml
+++ b/infra/k8s/alexandria/templates/ingress.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "alexandria.fullname" . }}
+  labels:
+    {{- include "alexandria.labels" . | nindent 4 }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "alexandria.fullname" . }}-client
+                port:
+                  number: 80
+          - path: /genai
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "alexandria.fullname" . }}-genai
+                port:
+                  number: 8000
+{{- end }}

--- a/infra/k8s/alexandria/templates/ingress.yaml
+++ b/infra/k8s/alexandria/templates/ingress.yaml
@@ -25,4 +25,11 @@ spec:
                 name: {{ include "alexandria.fullname" . }}-genai
                 port:
                   number: 8000
+          - path: /keycloak
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "alexandria.fullname" . }}-keycloak
+                port:
+                  number: 8080
 {{- end }}

--- a/infra/k8s/alexandria/templates/spring-configmap.yaml
+++ b/infra/k8s/alexandria/templates/spring-configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "alexandria.fullname" . }}-spring-config
+  labels:
+    {{- include "alexandria.labels" . | nindent 4 }}
+    app: spring
+data:
+  POSTGRES_HOST: {{ .Values.spring.database.host | quote }}
+  POSTGRES_PORT: {{ .Values.spring.database.port | quote }}
+  POSTGRES_DB: {{ .Values.spring.database.name | quote }}
+  POSTGRES_USER: {{ .Values.spring.database.username | quote }}
+  OIDC_ISSUER_URI: {{ .Values.spring.oidc.issuerUri | quote }}
+  OIDC_JWK_SET_URI: {{ .Values.spring.oidc.jwkSetUri | quote }}
+  OIDC_USER_ID_CLAIM: {{ .Values.spring.oidc.userIdClaim | quote }}
+  OIDC_USERNAME_CLAIM: {{ .Values.spring.oidc.usernameClaim | quote }}
+  OIDC_ROLES_CLAIM: {{ .Values.spring.oidc.rolesClaim | quote }}

--- a/infra/k8s/alexandria/templates/spring-deployment.yaml
+++ b/infra/k8s/alexandria/templates/spring-deployment.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "alexandria.fullname" . }}-spring
+  labels:
+    {{- include "alexandria.labels" . | nindent 4 }}
+    app: spring
+    app.kubernetes.io/component: backend
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "alexandria.selectorLabels" . | nindent 6 }}
+      app: spring
+  template:
+    metadata:
+      labels:
+        {{- include "alexandria.selectorLabels" . | nindent 8 }}
+        app: spring
+        app.kubernetes.io/component: backend
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+      initContainers:
+        - name: wait-for-postgres
+          image: postgres:16-alpine
+          command:
+            - sh
+            - -c
+            - |
+              until pg_isready -h {{ .Values.spring.database.host }} -p 5432 -U postgres; do
+                echo "waiting for database..."
+                sleep 2
+              done
+              echo "database is ready"
+      containers:
+        - name: spring
+          image: {{ include "alexandria.image" (dict "Values" .Values "service" "spring") }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "alexandria.fullname" . }}-spring-config
+          env:
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "alexandria.fullname" . }}-spring-secrets
+                  key: postgres-password
+          resources:
+            {{- toYaml .Values.spring.resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3

--- a/infra/k8s/alexandria/templates/spring-secrets.yaml
+++ b/infra/k8s/alexandria/templates/spring-secrets.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "alexandria.fullname" . }}-spring-secrets
+  labels:
+    {{- include "alexandria.labels" . | nindent 4 }}
+    app: spring
+type: Opaque
+stringData:
+  postgres-password: {{ .Values.spring.database.password | quote }}

--- a/infra/k8s/alexandria/templates/spring-service.yaml
+++ b/infra/k8s/alexandria/templates/spring-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "alexandria.fullname" . }}-spring
+  labels:
+    {{- include "alexandria.labels" . | nindent 4 }}
+    app: spring
+    app.kubernetes.io/component: backend
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "alexandria.selectorLabels" . | nindent 4 }}
+    app: spring
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+      protocol: TCP

--- a/infra/k8s/alexandria/values-secrets.yaml.example
+++ b/infra/k8s/alexandria/values-secrets.yaml.example
@@ -1,0 +1,15 @@
+# Secrets for Alexandria Helm chart
+# Copy this file and fill in your actual secrets
+
+spring:
+  database:
+    password: "postgres-password" # Change this!
+
+keycloak:
+  adminPassword: "secure-admin-password" # Change this!
+  database:
+    password: "postgres-password" # Change this!
+
+postgres-db:
+  auth:
+    password: "postgres-password" # Change this!

--- a/infra/k8s/alexandria/values.yaml
+++ b/infra/k8s/alexandria/values.yaml
@@ -1,0 +1,29 @@
+replicaCount: 1
+
+image:
+  registry: ghcr.io
+  repository: aet-devops26/team-bnd
+  pullPolicy: Always
+  tag: "latest"
+
+client:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 250m
+      memory: 128Mi
+
+genai:
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+ingress:
+  enabled: true
+  className: nginx

--- a/infra/k8s/alexandria/values.yaml
+++ b/infra/k8s/alexandria/values.yaml
@@ -51,7 +51,7 @@ ingress:
   host: alexandria.local
 
 keycloak:
-  adminPassword: "secure-admin-password"
+  adminPassword: "admin"
   proxyHeaders: "xforwarded"
   keycloak:
     httpRelativePath: /keycloak

--- a/infra/k8s/alexandria/values.yaml
+++ b/infra/k8s/alexandria/values.yaml
@@ -6,6 +6,27 @@ image:
   pullPolicy: Always
   tag: "latest"
 
+spring:
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  database:
+    host: "alexandria-postgres-db"
+    port: "5432"
+    name: "alexandria"
+    username: "postgres"
+    password: "postgres-password"
+  oidc:
+    issuerUri: "http://alexandria-keycloak:8080/keycloak/realms/alexandria"
+    jwkSetUri: "http://alexandria-keycloak:8080/keycloak/realms/alexandria/protocol/openid-connect/certs"
+    userIdClaim: "sub"
+    usernameClaim: "preferred_username"
+    rolesClaim: "roles"
+
 client:
   resources:
     requests:
@@ -33,9 +54,34 @@ keycloak:
   proxyHeaders: "xforwarded"
   keycloak:
     httpRelativePath: /keycloak
+  database:
+    type: postgres
+    host: "alexandria-postgres-db"
+    port: "5432"
+    name: "keycloak"
+    username: "postgres"
+    password: "postgres-password"
+  postgres:
+    enabled: false
+  extraInitContainers:
+    - name: wait-for-postgres
+      image: postgres:16-alpine
+      command:
+        - sh
+        - -c
+        - |
+          until pg_isready -h alexandria-postgres-db -p 5432 -U postgres; do
+            echo "waiting for database..."
+            sleep 2
+          done
+          echo "database is ready"
 
 postgres-db:
   auth:
     username: "postgres"
-    password: "keycloak-db-password"
+    password: "postgres-password"
     database: "keycloak"
+  initdb:
+    scripts:
+      create-alexandria-db.sql: |
+        CREATE DATABASE alexandria;

--- a/infra/k8s/alexandria/values.yaml
+++ b/infra/k8s/alexandria/values.yaml
@@ -48,6 +48,7 @@ genai:
 ingress:
   enabled: true
   className: nginx
+  host: alexandria.local
 
 keycloak:
   adminPassword: "secure-admin-password"

--- a/infra/k8s/alexandria/values.yaml
+++ b/infra/k8s/alexandria/values.yaml
@@ -27,3 +27,15 @@ genai:
 ingress:
   enabled: true
   className: nginx
+
+keycloak:
+  adminPassword: "secure-admin-password"
+  proxyHeaders: "xforwarded"
+  keycloak:
+    httpRelativePath: /keycloak
+
+postgres-db:
+  auth:
+    username: "postgres"
+    password: "keycloak-db-password"
+    database: "keycloak"


### PR DESCRIPTION
## What does this PR do?

Closes #83.  Adds Helm configuration files to deploy Alexandria to a kubernetes cluster.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [x] CI / infra

## Definition of Done

- [ ] CI is green
- [ ] If the API changed: `api/openapi.yaml` is updated and lint passes
- [ ] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [ ] Tests added or updated for the changed behaviour
- [ ] Docs updated where it matters (README, ADRs, comments)

## Notes for the reviewer
