### PR TITLE
infra(k8s): edit helm chart to be deployable on AET cluster

### DIFF
--- a/infra/k8s/alexandria/templates/ingress.yaml
+++ b/infra/k8s/alexandria/templates/ingress.yaml
@@ -3,10 +3,16 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "alexandria.fullname" . }}
+  annotations:
+      cert-manager.io/cluster-issuer: "letsencrypt-prod"
   labels:
     {{- include "alexandria.labels" . | nindent 4 }}
 spec:
   ingressClassName: {{ .Values.ingress.className }}
+  tls:
+    - hosts:
+      - {{ .Values.ingress.host }}
+      secretName: "alexandria-tls"
   rules:
     - host: {{ .Values.ingress.host }}
       http:

--- a/infra/k8s/alexandria/templates/spring-deployment.yaml
+++ b/infra/k8s/alexandria/templates/spring-deployment.yaml
@@ -35,6 +35,8 @@ spec:
                 sleep 2
               done
               echo "database is ready"
+          resources:
+            {{- toYaml .Values.spring.resources | nindent 12 }}
       containers:
         - name: spring
           image: {{ include "alexandria.image" (dict "Values" .Values "service" "spring") }}

--- a/infra/k8s/alexandria/values.yaml
+++ b/infra/k8s/alexandria/values.yaml
@@ -48,7 +48,7 @@ genai:
 ingress:
   enabled: true
   className: nginx
-  host: alexandria.local
+  host: alexandria.stud.k8s.aet.cit.tum.de
 
 keycloak:
   adminPassword: "admin"
@@ -64,6 +64,22 @@ keycloak:
     password: "postgres-password"
   postgres:
     enabled: false
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  initContainers:
+    copyQuarkusLib:
+      resources:
+        requests:
+          cpu: 20m
+          memory: 32Mi
+        limits:
+          cpu: 40m
+          memory: 64Mi
   extraInitContainers:
     - name: wait-for-postgres
       image: postgres:16-alpine
@@ -76,6 +92,13 @@ keycloak:
             sleep 2
           done
           echo "database is ready"
+      resources:
+        requests:
+          cpu: 20m
+          memory: 32Mi
+        limits:
+          cpu: 40m
+          memory: 64Mi
 
 postgres-db:
   auth:
@@ -86,3 +109,10 @@ postgres-db:
     scripts:
       create-alexandria-db.sql: |
         CREATE DATABASE alexandria;
+  resources:
+    requests:
+      memory: "1Gi"
+      cpu: "500m"
+    limits:
+      memory: "2Gi"
+      cpu: "1000m"


### PR DESCRIPTION
## What does this PR do?

This PR makes various small changes to the Helm chart such that it is deployable on the AET cluster.
It closes #84, #85, #72.

This PR:
- adds resource limits to all pods
- uses LetsEncrypt cert for ingress
- changes ingress to use cluster domain name as host


## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [x] CI / infra

