### PR TITLE
infra(ci): automatically deploy helm chart to stud cluster

### DIFF
--- a/.github/workflows/deploy-stud.yml
+++ b/.github/workflows/deploy-stud.yml
@@ -1,7 +1,9 @@
 name: deploy-stud
 
 on:
-  push:
+  workflow_run:
+    workflows: [ci]
+    types: [completed]
     branches: [main]
   workflow_dispatch:
 
@@ -18,6 +20,7 @@ jobs:
   deploy:
     name: deploy to stud cluster
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/deploy-stud.yml
+++ b/.github/workflows/deploy-stud.yml
@@ -1,0 +1,62 @@
+name: deploy-stud
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAMESPACE: ${{ github.repository }}
+  IMAGE_TAG: ${{ github.sha }}
+
+jobs:
+  deploy:
+    name: deploy to stud cluster
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: setup helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.18.4
+
+      - name: setup kubectl
+        uses: azure/setup-kubectl@v4
+        with:
+          version: v1.32.4
+
+      - name: configure kubeconfig
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBE_CONFIG }}" > ~/.kube/config
+          chmod 600 ~/.kube/config
+
+      - name: update helm dependencies
+        working-directory: infra/k8s/alexandria
+        run: helm dependency update
+
+      - name: deploy with helm
+        working-directory: infra/k8s/alexandria
+        run: |
+          helm upgrade --install alexandria . \
+            --namespace alexandria \
+            --set image.tag="${{ env.IMAGE_TAG }}" \
+            --set spring.database.password="${{ secrets.POSTGRES_PASSWORD }}" \
+            --set keycloak.adminUser="${{ secrets.KC_BOOTSTRAP_ADMIN_USERNAME }}" \
+            --set keycloak.adminPassword="${{ secrets.KC_BOOTSTRAP_ADMIN_PASSWORD }}" \
+            --set keycloak.database.password="${{ secrets.POSTGRES_PASSWORD }}" \
+            --set postgres-db.auth.password="${{ secrets.POSTGRES_PASSWORD }}" \
+            --wait \
+            --timeout 5m
+
+      - name: verify deployment
+        run: |
+          kubectl -n alexandria get pods
+          kubectl -n alexandria get svc
+          kubectl -n alexandria get ingress


### PR DESCRIPTION
## What does this PR do?

This PR adds a CI job which automatically deploys new container builds to the AET stud cluster.
Closes #72.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [x] CI / infra

## Definition of Done

- [ ] CI is green
- [ ] If the API changed: `api/openapi.yaml` is updated and lint passes
- [ ] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [ ] Tests added or updated for the changed behaviour
- [ ] Docs updated where it matters (README, ADRs, comments)
