### PR TITLE
Feat: Add setup for E2E testing with Playwright

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -502,7 +502,7 @@ jobs:
 
       - name: install playwright browsers
         working-directory: services/client
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install --with-deps
 
       - name: run playwright tests
         working-directory: services/client

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -419,6 +419,113 @@ jobs:
         run: docker compose down -v --remove-orphans
 
   # ---------------------------------------------------------------------
+  # E2E tests: bring the full stack up with Docker Compose, provision a
+  # Keycloak test user via the Admin REST API, then run Playwright tests
+  # ---------------------------------------------------------------------
+  e2e:
+    name: e2e tests (playwright)
+    needs: [changes, build-spring, build-client, build-genai]
+    if: |
+      always() &&
+      needs.build-spring.result != 'failure' &&
+      needs.build-client.result != 'failure' &&
+      needs.build-genai.result != 'failure' &&
+      (needs.changes.outputs.spring == 'true' || needs.changes.outputs.client == 'true' || needs.changes.outputs.genai == 'true' || needs.changes.outputs.docker == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    runs-on: ubuntu-latest
+    env:
+      TEST_USER: ${{ vars.TEST_USER }}
+      TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: bring stack up
+        run: docker compose up -d --build --wait --wait-timeout 180
+
+      - name: wait for keycloak realm
+        run: |
+          for i in $(seq 1 20); do
+            if curl -fsS "http://localhost/auth/realms/alexandria" > /dev/null 2>&1; then
+              echo "keycloak realm ready"; break
+            fi
+            echo "waiting for keycloak... ($i/20)"
+            sleep 5
+          done
+
+      - name: provision test user via keycloak admin api
+        run: |
+          # Obtain an admin access token from the master realm
+          ADMIN_TOKEN=$(curl -fsS \
+            -d "client_id=admin-cli" \
+            -d "username=${KC_BOOTSTRAP_ADMIN_USERNAME}" \
+            -d "password=${KC_BOOTSTRAP_ADMIN_PASSWORD}" \
+            -d "grant_type=password" \
+            "http://localhost/auth/realms/master/protocol/openid-connect/token" \
+            | jq -r '.access_token')
+
+          # Create the test user in the alexandria realm
+          CREATE_RESPONSE=$(curl -sS -o /dev/null -w "%{http_code}" \
+            -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "{\"username\": \"${TEST_USER}\", \"enabled\": true, \"email\": \"${TEST_USER}@test.local\"}" \
+            "http://localhost/auth/admin/realms/alexandria/users")
+
+          if [ "$CREATE_RESPONSE" != "201" ] && [ "$CREATE_RESPONSE" != "409" ]; then
+            echo "Failed to create test user (HTTP $CREATE_RESPONSE)"
+            exit 1
+          fi
+
+          # Fetch the user ID
+          USER_ID=$(curl -fsS \
+            -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+            "http://localhost/auth/admin/realms/alexandria/users?username=${TEST_USER}&exact=true" \
+            | jq -r '.[0].id')
+
+          # Set the test user's password (temporary=false so no reset required)
+          curl -fsS -X PUT \
+            -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "{\"type\": \"password\", \"value\": \"${TEST_PASSWORD}\", \"temporary\": false}" \
+            "http://localhost/auth/admin/realms/alexandria/users/${USER_ID}/reset-password"
+
+          echo "test user provisioned (id: ${USER_ID})"
+
+      - name: setup node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: services/client/package-lock.json
+
+      - name: install dependencies
+        working-directory: services/client
+        run: npm ci
+
+      - name: install playwright browsers
+        working-directory: services/client
+        run: npx playwright install --with-deps chromium
+
+      - name: run playwright tests
+        working-directory: services/client
+        run: npx playwright test
+
+      - name: upload playwright report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report
+          path: services/client/playwright-report/
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: show logs on failure
+        if: failure()
+        run: docker compose logs
+
+      - name: tear stack down
+        if: always()
+        run: docker compose down -v --remove-orphans
+
+  # ---------------------------------------------------------------------
   # Aggregate gate: branch protection should require this single check.
   # If anything upstream failed, this fails.
   # ---------------------------------------------------------------------
@@ -434,6 +541,7 @@ jobs:
       - build-genai
       - build-image
       - compose-smoke
+      - e2e
     runs-on: ubuntu-latest
     steps:
       - name: fail if any required job failed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -439,7 +439,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: bring stack up
-        run: docker compose up -d --build --wait --wait-timeout 180
+        run: docker compose --profile e2e up -d --build --wait --wait-timeout 180
 
       - name: wait for keycloak realm
         run: |
@@ -500,13 +500,9 @@ jobs:
         working-directory: services/client
         run: npm ci
 
-      - name: install playwright browsers
-        working-directory: services/client
-        run: npx playwright install --with-deps
-
       - name: run playwright tests
         working-directory: services/client
-        run: npx playwright test
+        run: npm run test
 
       - name: upload playwright report
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -502,7 +502,7 @@ jobs:
 
       - name: run playwright tests
         working-directory: services/client
-        run: npm run test
+        run: npm run test:e2e
 
       - name: upload playwright report
         if: always()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -157,6 +157,18 @@ services:
       timeout: 3s
       retries: 3
       start_period: 5s
+  playwright:
+    container_name: playwright
+    image: mcr.microsoft.com/playwright:v1.60.0-noble
+    init: true
+    user: pwuser
+    networks:
+      - alexandria
+    ports:
+      - 3000:3000
+    profiles:
+      - e2e
+    command: '/bin/sh -c "npx -y playwright@1.60.0 run-server --port 3000 --host 0.0.0.0"'
 
 networks:
   alexandria:

--- a/services/client/.gitignore
+++ b/services/client/.gitignore
@@ -30,3 +30,10 @@ coverage/
 
 # Misc
 .Dockerfile.dev
+
+# Playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+/playwright/.auth/

--- a/services/client/README.md
+++ b/services/client/README.md
@@ -45,6 +45,24 @@ npm install
 npm run dev
 ```
 
+Testing
+-------
+
+Playwright is used for end-to-end tests. The tests run against a remote browser served by a Playwright Docker container.
+
+Start the Playwright server (once; runs in the background):
+
+```bash
+npm run test:server
+```
+
+Run the tests:
+
+```bash
+cd services/client
+npm run test
+```
+
 Notes
 -----
 - The dev Dockerfile starts Vite with --host 0.0.0.0 so the dev server is reachable from the host when running in a container.

--- a/services/client/README.md
+++ b/services/client/README.md
@@ -60,7 +60,7 @@ Run the tests:
 
 ```bash
 cd services/client
-npm run test
+npm run test:e2e
 ```
 
 Notes

--- a/services/client/README.md
+++ b/services/client/README.md
@@ -50,10 +50,10 @@ Testing
 
 Playwright is used for end-to-end tests. The tests run against a remote browser served by a Playwright Docker container.
 
-Start the Playwright server (once; runs in the background):
+Include the Playwright server when starting services:
 
 ```bash
-npm run test:server
+docker compose --profile e2e up
 ```
 
 Run the tests:

--- a/services/client/package-lock.json
+++ b/services/client/package-lock.json
@@ -1,17 +1,19 @@
 {
-  "name": "team-bnd-client",
+  "name": "alexandria-client",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "team-bnd-client",
+      "name": "alexandria-client",
       "version": "0.1.0",
       "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.60.0",
+        "@types/node": "^25.9.0",
         "vite": "^5.0.0"
       }
     },
@@ -404,6 +406,22 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -802,6 +820,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "25.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.0.tgz",
+      "integrity": "sha512-AOQwYUNolgy3VosiRqXrACUXTN8nJUtPl7FJXMqZVyxiiCLhQuG3jXKvCS1ALr+Y2OmZhzzLVlYPEqJaiqkaJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
     "node_modules/esbuild": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
@@ -899,6 +927,53 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.14",
@@ -1017,6 +1092,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "5.4.21",

--- a/services/client/package.json
+++ b/services/client/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview --port 5173",
-    "test": "PW_TEST_CONNECT_WS_ENDPOINT=ws://127.0.0.1:3000/ playwright test"
+    "test:e2e": "PW_TEST_CONNECT_WS_ENDPOINT=ws://127.0.0.1:3000/ playwright test"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/services/client/package.json
+++ b/services/client/package.json
@@ -6,8 +6,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview --port 5173",
-    "test": "PW_TEST_CONNECT_WS_ENDPOINT=ws://127.0.0.1:3000/ playwright test --config playwright.config.ts",
-    "test:server": "docker run --add-host=hostmachine:host-gateway -p 3000:3000 --rm --init -d --user pwuser mcr.microsoft.com/playwright:v1.60.0-noble /bin/sh -c \"npx -y playwright@1.60.0 run-server --port 3000 --host 0.0.0.0\""
+    "test": "PW_TEST_CONNECT_WS_ENDPOINT=ws://127.0.0.1:3000/ playwright test"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/services/client/package.json
+++ b/services/client/package.json
@@ -12,6 +12,8 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
+    "@types/node": "^25.9.0",
     "vite": "^5.0.0"
   }
 }

--- a/services/client/package.json
+++ b/services/client/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview --port 5173"
+    "preview": "vite preview --port 5173",
+    "test": "PW_TEST_CONNECT_WS_ENDPOINT=ws://127.0.0.1:3000/ playwright test --config playwright.config.ts",
+    "test:server": "docker run --add-host=hostmachine:host-gateway -p 3000:3000 --rm --init -d --user pwuser mcr.microsoft.com/playwright:v1.60.0-noble /bin/sh -c \"npx -y playwright@1.60.0 run-server --port 3000 --host 0.0.0.0\""
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/services/client/playwright.config.ts
+++ b/services/client/playwright.config.ts
@@ -1,0 +1,79 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// import dotenv from 'dotenv';
+// import path from 'path';
+// dotenv.config({ path: path.resolve(__dirname, '.env') });
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './tests',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('')`. */
+    // baseURL: 'http://localhost:3000',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  // webServer: {
+  //   command: 'npm run start',
+  //   url: 'http://localhost:3000',
+  //   reuseExistingServer: !process.env.CI,
+  // },
+});

--- a/services/client/playwright.config.ts
+++ b/services/client/playwright.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('')`. */
-    // baseURL: 'http://localhost:3000',
+    baseURL: 'http://localhost:5173',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
@@ -71,9 +71,9 @@ export default defineConfig({
   ],
 
   /* Run your local dev server before starting the tests */
-  // webServer: {
-  //   command: 'npm run start',
-  //   url: 'http://localhost:3000',
-  //   reuseExistingServer: !process.env.CI,
-  // },
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+  },
 });

--- a/services/client/playwright.config.ts
+++ b/services/client/playwright.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
   use: {
     /* Base URL to use in actions like `await page.goto('')`.
      * The full stack (local and CI) is served via Traefik on port 80. */
-    baseURL: 'http://localhost',
+    baseURL: process.env.CI ? 'http://localhost' : 'http://hostmachine',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',

--- a/services/client/playwright.config.ts
+++ b/services/client/playwright.config.ts
@@ -25,8 +25,9 @@ export default defineConfig({
   reporter: 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
-    /* Base URL to use in actions like `await page.goto('')`. */
-    baseURL: 'http://localhost:5173',
+    /* Base URL to use in actions like `await page.goto('')`.
+     * The full stack (local and CI) is served via Traefik on port 80. */
+    baseURL: 'http://localhost',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
@@ -69,11 +70,4 @@ export default defineConfig({
     //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
     // },
   ],
-
-  /* Run your local dev server before starting the tests */
-  webServer: {
-    command: 'npm run dev',
-    url: 'http://localhost:5173',
-    reuseExistingServer: !process.env.CI,
-  },
 });

--- a/services/client/playwright.config.ts
+++ b/services/client/playwright.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
   use: {
     /* Base URL to use in actions like `await page.goto('')`.
      * The full stack (local and CI) is served via Traefik on port 80. */
-    baseURL: process.env.CI ? 'http://localhost' : 'http://hostmachine',
+    baseURL: 'http://client',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',

--- a/services/client/tests/example.spec.ts
+++ b/services/client/tests/example.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Alexandria client", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+  });
+
+  test.describe("Page metadata", () => {
+    test("has correct document title", async ({ page }) => {
+      await expect(page).toHaveTitle("Alexandria");
+    });
+  });
+
+  test.describe("Landing page content", () => {
+    test("displays the main heading", async ({ page }) => {
+      const heading = page.getByRole("heading", { level: 1 });
+      await expect(heading).toBeVisible();
+      await expect(heading).toHaveText("Alexandria — Document Summarization");
+    });
+
+    test("displays the product description", async ({ page }) => {
+      const description = page.getByText(
+        "Alexandria helps users upload documents and get concise summaries",
+      );
+      await expect(description).toBeVisible();
+    });
+
+    test("description mentions key features", async ({ page }) => {
+      const body = page.locator("body");
+      await expect(body).toContainText("summaries");
+      await expect(body).toContainText("extracted tags");
+      await expect(body).toContainText("searchable knowledge");
+    });
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Adds the required setup for E2E testing with Playwright.
Closes #63, #64, #65, #66 and #67.
A CI job is added, which starts all services with docker-compose and then runs the Playwright test suite.
For local testing, npm scripts are provided, which run using a Playwright server in a Docker container.


## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [x] CI / infra

## Definition of Done

- [x] CI is green
- [x] If the API changed: `api/openapi.yaml` is updated and lint passes
- [x] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [x] Tests added or updated for the changed behaviour
- [x] Docs updated where it matters (README, ADRs, comments)
