### PR TITLE
Docs: Clean up and complete the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,19 @@
 # team-bnd
 
 ## Project summary
+
 Alexandria is a document management and knowledge extraction platform. Users upload documents, e.g., research papers, reports, manuals, meeting notes, and the system automatically organizes, tags, and summarizes them.
 Users get a concise summary and can ask questions about their documents, instead of having to read through a 40-page report to find what they need.
 
 The core workflow is: Upload a document, get an auto-generated summary with extracted key entities, browse and search your knowledge base, and optionally query the GenAI for specific answers concerning your uploaded content.
 
 ## Overview
-TODO
+
+Alexandria consists of three main subsystems orchestrated via Docker Compose and Traefik:
+
+- **Client**: A React SPA serving as the web interface.
+- **Server**: A Spring Boot application handling core logic, user management, and the PostgreSQL database.
+- **GenAI**: A Python/FastAPI service using LangChain to extract entities and summarize uploaded documents.
 
 ## Setup
 
@@ -20,126 +26,44 @@ All services are accessed through Traefik as the reverse proxy. See [`docs/traef
 |-----|---------|
 | http://localhost/ | Client (frontend) |
 | http://localhost/api/v1/... | Spring API |
-| http://localhost/swagger-ui/ | API documentation |
+| http://localhost/swagger-ui/ | Spring API documentation |
+| http://localhost/genai/docs | GenAI API documentation |
 | http://localhost/auth/ | Keycloak |
 
-### Infrastructure (Terraform + Ansible)
+### Infrastructure & Deployment
 
-Provisioning for Azure VM deployment lives under [`infra/azure/`](infra/azure/README.md).
+- **Azure VM (Terraform + Ansible)**: Provisioning details live under [`infra/azure/README.md`](infra/azure/README.md).
+- **Kubernetes (Helm)**: Cluster deployment and troubleshooting details live under [`infra/k8s/README.md`](infra/k8s/README.md).
 
 ### Git Repository
-This repository uses pre-commit hooks. Install [pre-commit](https://pre-commit.com/) and run `pre-commit install` after cloning.
 
-On every `git commit`, these checks run automatically:
-- `trailing-whitespace`
-- `end-of-file-fixer`
-- `check-yaml` (except GitHub workflow files)
-- `check-added-large-files` (max 1024 KB)
-- `check-merge-conflict`
-- `mixed-line-ending`
-- `yamllint` with `.yamllint.yaml`
-- `hadolint-docker` with `.hadolint.yaml`
-- `actionlint`
-- `redocly-lint` via `npx --yes @redocly/cli@2.30.3 lint api/openapi.yaml` for files under `api/`
-- `redocly-join` via `npx --yes @redocly/cli@2.30.3 join api/spring-openapi.yaml api/genai-openapi.yaml -o api/openapi.yaml` to merge generated OpenAPI specs into a unified YAML.
+This repository uses pre-commit hooks to enforce code quality, formatting, and OpenAPI spec validity. Install [pre-commit](https://pre-commit.com/) and run `pre-commit install` after cloning.
+
+On every `git commit`, these checks run automatically. For a full list of enforced hooks and their configurations, refer to [`.pre-commit-config.yaml`](.pre-commit-config.yaml).
 
 To run the full hook set manually:
 `pre-commit run --all-files`
 
-### Server
-Spring Boot lives under `services/spring/`.
-Quickest way:
-1. `docker compose up -d spring`
-2. Perform API calls, e.g., `curl http://localhost/hello`
+### Local Quickstart
 
-To force a fresh gradle build, run `docker compose up --build --force-recreate --no-deps spring`.
+To start all services together locally:
 
-### Client
-Client assets live under `services/client/` and are served as a static frontend.
-
-Quickest way:
-1. `docker compose up -d client`
+1. `docker compose up -d`
 2. Open http://localhost/ to view the site.
 
-To force a fresh build: `docker compose up --build --force-recreate --no-deps client`.
+To force a fresh build of all services: `docker compose up --build --force-recreate`
 
-For local frontend development (hot-reload, tests, linting), see `services/client/README.md`.
+### Server
+
+Spring Boot application handling the core backend logic and database.
+For local backend development, see [`services/spring/README.md`](services/spring/README.md).
+
+### Client
+
+React SPA serving as the web frontend.
+For local frontend development, see [`services/client/README.md`](services/client/README.md).
 
 ### GenAI
-Python/FastAPI under `services/genai/`.
 
-Quickest way:
-1. `docker compose up -d genai`
-2. `curl http://localhost/genai/hello`
-
-For local Python dev (tests, autoreload), see [`services/genai/README.md`](services/genai/README.md).
-
-### Kubernetes Deployment
-
-A Helm chart is provided in `infra/k8s/alexandria/`.
-
-Prerequisites:
-- A running Kubernetes cluster (Rancher, Azure AKS, minikube, etc.)
-- `helm` and `kubectl` configured to access the cluster
-
-Secrets Setup:
-1. Copy the secrets template:
-   ```bash
-   cp infra/k8s/alexandria/values-secrets.yaml.example infra/k8s/alexandria/values-secrets.yaml
-   ```
-2. Edit `values-secrets.yaml` and set your actual passwords (this file is gitignored)
-
-Deploy:
-```bash
-helm install alexandria infra/k8s/alexandria \
-  --namespace alexandria --create-namespace \
-  --dependency-update \
-  -f infra/k8s/alexandria/values-secrets.yaml
-```
-
-Upgrade after changes:
-```bash
-helm upgrade alexandria infra/k8s/alexandria \
-  --namespace alexandria \
-  --dependency-update \
-  -f infra/k8s/alexandria/values-secrets.yaml
-```
-
-Uninstall:
-```bash
-helm uninstall alexandria --namespace alexandria
-```
-
-Override values (e.g., different image tag):
-```bash
-helm install alexandria infra/k8s/alexandria \
-  --namespace alexandria --create-namespace \
-  --dependency-update \
-  -f infra/k8s/alexandria/values-secrets.yaml \
-  --set image.tag=sha-abc123 \
-  --set ingress.host=alexandria.example.com
-```
-
-Check status:
-```bash
-kubectl -n alexandria get pods
-kubectl -n alexandria get svc
-kubectl -n alexandria get ingress
-```
-
-### Kubernetes Troubleshooting
-
-**Spring or Keycloak fail postgres password authentication after a reinstall**
-
-The postgres subchart creates a PersistentVolumeClaim that survives `helm uninstall`. On a subsequent install, postgres reuses the existing data directory (with the old password) and ignores the new `POSTGRES_PASSWORD` value, causing spring and keycloak to fail authentication.
-
-Fix: delete the PVC before reinstalling.
-
-```bash
-helm uninstall alexandria --namespace alexandria
-kubectl -n alexandria delete pvc --all
-helm install alexandria infra/k8s/alexandria \
-  --namespace alexandria --create-namespace \
-  --dependency-update \
-  -f infra/k8s/alexandria/values-secrets.yaml
-```
+Python/FastAPI service using LangChain to extract entities and summarize documents.
+For local Python dev, see [`services/genai/README.md`](services/genai/README.md).

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ All services are accessed through Traefik as the reverse proxy. See [`docs/traef
 **Quick reference:**
 | URL | Service |
 |-----|---------|
-| http://localhost/ | Client (frontend) |
+| http://localhost/ | Client |
 | http://localhost/api/v1/... | Spring API |
 | http://localhost/swagger-ui/ | Spring API documentation |
 | http://localhost/genai/docs | GenAI API documentation |
@@ -55,13 +55,13 @@ To force a fresh build of all services: `docker compose up --build --force-recre
 
 ### Server
 
-Spring Boot application handling the core backend logic and database.
-For local backend development, see [`services/spring/README.md`](services/spring/README.md).
+Spring Boot application handling the core server logic and database.
+For local server development, see [`services/spring/README.md`](services/spring/README.md).
 
 ### Client
 
-React SPA serving as the web frontend.
-For local frontend development, see [`services/client/README.md`](services/client/README.md).
+React SPA serving as the web client.
+For local client development, see [`services/client/README.md`](services/client/README.md).
 
 ### GenAI
 

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -1,0 +1,76 @@
+# Kubernetes Deployment
+
+A Helm chart is provided in `infra/k8s/alexandria/`.
+
+## Prerequisites:
+
+- A running Kubernetes cluster (Rancher, Azure AKS, minikube, etc.)
+- `helm` and `kubectl` configured to access the cluster
+
+## Secrets Setup:
+
+1. Copy the secrets template:
+   ```bash
+   cp infra/k8s/alexandria/values-secrets.yaml.example infra/k8s/alexandria/values-secrets.yaml
+   ```
+2. Edit `values-secrets.yaml` and set your actual passwords (this file is gitignored)
+
+## Deploy:
+
+```bash
+helm install alexandria infra/k8s/alexandria \
+  --namespace alexandria --create-namespace \
+  --dependency-update \
+  -f infra/k8s/alexandria/values-secrets.yaml
+```
+
+## Upgrade after changes:
+
+```bash
+helm upgrade alexandria infra/k8s/alexandria \
+  --namespace alexandria \
+  --dependency-update \
+  -f infra/k8s/alexandria/values-secrets.yaml
+```
+
+## Uninstall:
+
+```bash
+helm uninstall alexandria --namespace alexandria
+```
+
+## Override values (e.g., different image tag):
+
+```bash
+helm install alexandria infra/k8s/alexandria \
+  --namespace alexandria --create-namespace \
+  --dependency-update \
+  -f infra/k8s/alexandria/values-secrets.yaml \
+  --set image.tag=sha-abc123 \
+  --set ingress.host=alexandria.example.com
+```
+
+## Check status:
+
+```bash
+kubectl -n alexandria get pods
+kubectl -n alexandria get svc
+kubectl -n alexandria get ingress
+```
+
+# Kubernetes Troubleshooting
+
+**Spring or Keycloak fail postgres password authentication after a reinstall**
+
+The postgres subchart creates a PersistentVolumeClaim that survives `helm uninstall`. On a subsequent install, postgres reuses the existing data directory (with the old password) and ignores the new `POSTGRES_PASSWORD` value, causing spring and keycloak to fail authentication.
+
+Fix: delete the PVC before reinstalling.
+
+```bash
+helm uninstall alexandria --namespace alexandria
+kubectl -n alexandria delete pvc --all
+helm install alexandria infra/k8s/alexandria \
+  --namespace alexandria --create-namespace \
+  --dependency-update \
+  -f infra/k8s/alexandria/values-secrets.yaml
+```


### PR DESCRIPTION
## What does this PR do?

Closes #115

This fixes the rough edges in the README we discussed in the issue. I've filled out the overview with a short architecture summary so there are no more TODOs. I also removed the huge list of git hooks since it just duplicates the config file anyway and added a simple pointer to `.pre-commit-config.yaml`.
Based on feedback, I consolidated the `docker compose` commands into a single "Local Quickstart" section, and significantly shortened the Server, Client, and GenAI descriptions to just brief summaries linking to their respective `README.md` files for deeper documentation.

Additionally, I grouped the Terraform+Ansible and Kubernetes sections together into an "Infrastructure & Deployment" section, and moved the extensive Kubernetes details into `infra/k8s/README.md` to keep the main README concise. Finally, I updated the Traefik Quick reference table in the main `README.md` to properly list both the Spring and GenAI API documentation endpoints.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / cleanup
- [x] Docs
- [ ] CI / infra

## Definition of Done

- [x] CI is green
- [ ] If the API changed: `api/openapi.yaml` is updated and lint passes
- [ ] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [ ] Tests added or updated for the changed behaviour
- [x] Docs updated where it matters (README, ADRs, comments)

## Notes for the reviewer

The extensive Kubernetes setup details are now fully documented under `infra/k8s/README.md`. 

**Blockers:**
- Depends on #121 (GenAI documentation routing) being merged first.

Let me know if anything looks off!
