### PR TITLE
fix(helm): fix keycloak deployment loading resources from incorrect host

### DIFF
--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -7,6 +7,16 @@ A Helm chart is provided in `infra/k8s/alexandria/`.
 - A running Kubernetes cluster (Rancher, Azure AKS, minikube, etc.)
 - `helm` and `kubectl` configured to access the cluster
 
+## Deploy in one command:
+
+**WARNING**: This is insecure as the deployed pods will use default secrets.
+
+```bash
+helm install alexandria infra/k8s/alexandria \
+  --namespace alexandria --create-namespace \
+  --dependency-update
+```
+
 ## Secrets Setup:
 
 1. Copy the secrets template:

--- a/infra/k8s/alexandria/values-secrets.yaml.example
+++ b/infra/k8s/alexandria/values-secrets.yaml.example
@@ -9,14 +9,14 @@ postgresPassword: &postgresPassword "postgres-password" # Change this!
 
 spring:
   database:
-    password: *postgres-password
+    password: *postgresPassword
 
 keycloak:
   keycloak:
     adminPassword: *keycloakAdminPassword
   database:
-    password: *postgres-password
+    password: *postgresPassword
 
 postgres-db:
   auth:
-    password: *postgres-password
+    password: *postgresPassword

--- a/infra/k8s/alexandria/values-secrets.yaml.example
+++ b/infra/k8s/alexandria/values-secrets.yaml.example
@@ -1,15 +1,22 @@
 # Secrets for Alexandria Helm chart
 # Copy this file and fill in your actual secrets
 
+keycloakAdminPassword: &keycloakAdminPassword "secure-admin-password" # Change this!
+postgresPassword: &postgresPassword "postgres-password" # Change this!
+
+
+# Do not change this!
+
 spring:
   database:
-    password: "postgres-password" # Change this!
+    password: *postgres-password
 
 keycloak:
-  adminPassword: "secure-admin-password" # Change this!
+  keycloak:
+    adminPassword: *keycloakAdminPassword
   database:
-    password: "postgres-password" # Change this!
+    password: *postgres-password
 
 postgres-db:
   auth:
-    password: "postgres-password" # Change this!
+    password: *postgres-password

--- a/infra/k8s/alexandria/values.yaml
+++ b/infra/k8s/alexandria/values.yaml
@@ -52,9 +52,10 @@ ingress:
   host: alexandria.stud.k8s.aet.cit.tum.de
 
 keycloak:
-  adminPassword: "admin"
-  proxyHeaders: "xforwarded"
   keycloak:
+    adminPassword: "admin"
+    proxyHeaders: "xforwarded"
+    hostname: "https://alexandria.stud.k8s.aet.cit.tum.de/keycloak"
     httpRelativePath: /keycloak
   database:
     type: postgres


### PR DESCRIPTION
## What does this PR do?

Closes #128.
Additionally, there are some other chores included in this PR:
1. an update to the README, showing deployment in one command as required. 
2. an update to the `values-secrets.yaml.example` reducing redundancy.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [x] CI / infra

## Definition of Done

- [x] CI is green
- [x] If the API changed: `api/openapi.yaml` is updated and lint passes
- [x] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [x] Tests added or updated for the changed behaviour
- [x] Docs updated where it matters (README, ADRs, comments)
