### PR TITLE
fix(auth): fix broken jwt validation due to missing configuration of keycloak backchannel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,7 +38,7 @@
 # ----------------------------------------------------------------------------------
 
 # OIDC_ISSUER_URI=http://localhost/auth/realms/alexandria
-# OIDC_JWK_SET_URI=http://localhost/auth/realms/alexandria/protocol/openid-connect/certs
+# OIDC_JWK_SET_URI=http://keycloak:8180/auth/realms/alexandria/protocol/openid-connect/certs
 # OIDC_USER_ID_CLAIM=sub
 # OIDC_USERNAME_CLAIM=preferred_username
 # OIDC_ROLES_CLAIM=roles

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     environment:
       GENAI_BASE_URL: ${GENAI_BASE_URL:-http://genai:8000}
       OIDC_ISSUER_URI: ${OIDC_ISSUER_URI:-http://localhost/auth/realms/alexandria}
-      OIDC_JWK_SET_URI: ${OIDC_JWK_SET_URI:-http://localhost/auth/realms/alexandria/protocol/openid-connect/certs}
+      OIDC_JWK_SET_URI: ${OIDC_JWK_SET_URI:-http://keycloak:8180/auth/realms/alexandria/protocol/openid-connect/certs}
       OIDC_USER_ID_CLAIM: ${OIDC_USER_ID_CLAIM:-sub}
       OIDC_USERNAME_CLAIM: ${OIDC_USERNAME_CLAIM:-preferred_username}
       OIDC_ROLES_CLAIM: ${OIDC_ROLES_CLAIM:-roles}
@@ -94,10 +94,10 @@ services:
       KC_BOOTSTRAP_ADMIN_USERNAME: ${KC_BOOTSTRAP_ADMIN_USERNAME:-admin}
       KC_BOOTSTRAP_ADMIN_PASSWORD: ${KC_BOOTSTRAP_ADMIN_PASSWORD:-localkcpassword}
       KC_HTTP_PORT: 8180
-      KC_HOSTNAME: localhost
-      KC_HOSTNAME_PORT: 80
+      KC_HOSTNAME: http://localhost/auth
       KC_PROXY_HEADERS: xforwarded
       KC_HTTP_RELATIVE_PATH: /auth
+      KC_HOSTNAME_BACKCHANNEL_DYNAMIC: true
     restart: unless-stopped
     networks:
       - alexandria

--- a/infra/k8s/alexandria/values.yaml
+++ b/infra/k8s/alexandria/values.yaml
@@ -21,7 +21,7 @@ spring:
     username: "postgres"
     password: "postgres-password"
   oidc:
-    issuerUri: "http://alexandria-keycloak:8080/keycloak/realms/alexandria"
+    issuerUri: "https://alexandria.stud.k8s.aet.cit.tum.de/keycloak/realms/alexandria"
     jwkSetUri: "http://alexandria-keycloak:8080/keycloak/realms/alexandria/protocol/openid-connect/certs"
     userIdClaim: "sub"
     usernameClaim: "preferred_username"
@@ -56,6 +56,7 @@ keycloak:
     adminPassword: "admin"
     proxyHeaders: "xforwarded"
     hostname: "https://alexandria.stud.k8s.aet.cit.tum.de/keycloak"
+    hostnameBackchannel: "http://alexandria-keycloak:8080/keycloak"
     httpRelativePath: /keycloak
   database:
     type: postgres


### PR DESCRIPTION
## What does this PR do?

Closes #151. Configures the keycloak backchannel for use in private networks (docker network, local network of k8s) and sets `OIDC_JWK_SET_URI` appropriately.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] CI / infra

## Definition of Done

- [x] CI is green
- [x] If the API changed: `api/openapi.yaml` is updated and lint passes
- [x] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [x] Tests added or updated for the changed behaviour
- [x] Docs updated where it matters (README, ADRs, comments)
