### PR TITLE
Add prometheus endpoint to spring service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,8 @@ services:
           memory: 512M
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.spring.rule=PathPrefix(`/api`) || PathPrefix(`/swagger-ui`) || PathPrefix(`/v3/api-docs`) || PathPrefix(`/actuator`) || PathPrefix(`/hello`)"
+      # /actuator/ endpoints only exposed internally, not visible to the outside
+      - "traefik.http.routers.spring.rule=PathPrefix(`/api`) || PathPrefix(`/swagger-ui`) || PathPrefix(`/v3/api-docs`) || PathPrefix(`/hello`)"
       - "traefik.http.routers.spring.entrypoints=web"
       - "traefik.http.routers.spring.priority=10"
       - "traefik.http.services.spring.loadbalancer.server.port=8080"

--- a/docs/traefik.md
+++ b/docs/traefik.md
@@ -44,7 +44,6 @@ Alexandria uses [Traefik](https://traefik.io/) as the reverse proxy and API gate
 | `/api/*` | Spring | 8080 | REST API |
 | `/swagger-ui/*` | Spring | 8080 | API documentation UI |
 | `/v3/api-docs` | Spring | 8080 | OpenAPI spec |
-| `/actuator/*` | Spring | 8080 | Health and metrics |
 | `/hello` | Spring | 8080 | Smoke test endpoint |
 | `/auth/*` | Keycloak | 8180 | OIDC provider |
 | `/genai/health` | GenAI | 8000 | Health check |

--- a/infra/k8s/alexandria/templates/ingress.yaml
+++ b/infra/k8s/alexandria/templates/ingress.yaml
@@ -45,13 +45,6 @@ spec:
                 name: {{ include "alexandria.fullname" . }}-spring
                 port:
                   number: 8080
-          - path: /actuator
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ include "alexandria.fullname" . }}-spring
-                port:
-                  number: 8080
           - path: /hello
             pathType: Prefix
             backend:

--- a/services/spring/Dockerfile
+++ b/services/spring/Dockerfile
@@ -38,6 +38,6 @@ EXPOSE 8080
 
 # Healthcheck against actuator
 HEALTHCHECK --interval=10s --timeout=5s --start-period=80s --retries=3 \
-    CMD wget --quiet --tries=1 --spider http://localhost:8080/actuator/health || exit 1
+    CMD wget --quiet --tries=1 --spider http://localhost:8080/actuator/health/readiness || exit 1
 
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/services/spring/app/build.gradle
+++ b/services/spring/app/build.gradle
@@ -30,6 +30,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.micrometer:micrometer-registry-prometheus'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.3'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/services/spring/app/src/main/resources/application.properties
+++ b/services/spring/app/src/main/resources/application.properties
@@ -20,3 +20,10 @@ app.auth.roles-claim=${OIDC_ROLES_CLAIM}
 
 # GenAI service
 genai.base-url=${GENAI_BASE_URL}
+
+# Prometheus metrics
+# Refer to https://grafana.com/docs/grafana-cloud/knowledge-graph/advanced-configuration/enable-prom-metrics-collection/application-frameworks/springboot/
+management.endpoint.prometheus.enabled=true
+management.endpoints.web.exposure.include=prometheus,health,info,metrics
+management.metrics.distribution.percentiles-histogram.http.server.requests=true
+management.metrics.distribution.percentiles-histogram.http.client.requests=true


### PR DESCRIPTION
## What does this PR do?

<!-- Short description of the change. Reference any related issue: Closes #123 -->
This PR adds the prometheus/metrics entpoint to the spring service and thus closes #140. Additionally, the `/actuator/` endpoints are no longer exposed publicly, as otherwise possibly sensitive metrics would be readable by anyone. These endpoints can still be queried from the internal network (behind traefik) however, to allow for healthchecks and metrics collection (to be implemented with #138). This lead to some minor changes for the k8s infrastructure, namely I removed the `/actuator/` ingress.

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [X] CI / infra

## Definition of Done

- [x] CI is green
- [ ] If the API changed: `api/openapi.yaml` is updated and lint passes
- [X] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [ ] Tests added or updated for the changed behaviour
- [X] Docs updated where it matters (README, ADRs, comments)

## Notes for the reviewer

<!-- Anything they should look at first, gotchas, screenshots, ... -->
