### PR TITLE
Task: Fix Spring Service Document API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,13 @@
 # respective line.
 
 # ----------------------------------------------------------------------------------
+# Spring Service
+# ----------------------------------------------------------------------------------
+
+# One of ERROR, WARN, INFO, DEBUG, or TRACE
+# SPRING_LOG_LEVEL=INFO
+
+# ----------------------------------------------------------------------------------
 # GenAI Service
 # ----------------------------------------------------------------------------------
 
@@ -21,7 +28,7 @@
 # LLM provider: "logos" (default, TUM-provided), "openai", or "ollama" (local)
 # LLM_PROVIDER=logos
 
-#LLM_BASE_URL=https://logos.aet.cit.tum.de/v1
+# LLM_BASE_URL=https://logos.aet.cit.tum.de/v1
 # LLM_MODEL=openai/gpt-oss-120b
 
 # For Ollama local dev (set LLM_PROVIDER=ollama):

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -29,43 +29,6 @@ tags:
     name: ai
     x-displayName: ai
 paths:
-  /api/v1/knowledgebase/documents:
-    get:
-      tags:
-        - KnowledgeBase
-      summary: List all documents
-      operationId: listDocuments
-      responses:
-        '200':
-          description: Documents retrieved
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Document'
-      security:
-        - bearerAuth: []
-    post:
-      tags:
-        - KnowledgeBase
-      summary: Create a new document with text content
-      operationId: createDocument
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CreateDocumentRequest'
-        required: true
-      responses:
-        '201':
-          description: Document created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Document'
-      security:
-        - bearerAuth: []
   /api/v1/knowledgebase/documents/{id}/tags:
     post:
       tags:
@@ -118,6 +81,27 @@ paths:
                 $ref: '#/components/schemas/Document'
         '400':
           description: Invalid file
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Document'
+      security:
+        - bearerAuth: []
+  /api/v1/knowledgebase/documents/create:
+    post:
+      tags:
+        - KnowledgeBase
+      summary: Create a new document with text content
+      operationId: createDocument
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateDocumentRequest'
+        required: true
+      responses:
+        '201':
+          description: Document created
           content:
             application/json:
               schema:
@@ -223,6 +207,23 @@ paths:
                   $ref: '#/components/schemas/QAInteraction'
       security:
         - bearerAuth: []
+  /api/v1/knowledgebase/documents:
+    get:
+      tags:
+        - KnowledgeBase
+      summary: List all documents
+      operationId: listDocuments
+      responses:
+        '200':
+          description: Documents retrieved
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Document'
+      security:
+        - bearerAuth: []
   /api/v1/knowledgebase/documents/{id}:
     get:
       tags:
@@ -268,6 +269,36 @@ paths:
           description: Document deleted
         '404':
           description: Document not found
+      security:
+        - bearerAuth: []
+  /api/v1/knowledgebase/documents/{id}/download:
+    get:
+      tags:
+        - KnowledgeBase
+      summary: Download document file
+      operationId: downloadDocument
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: File content
+          content:
+            application/json:
+              schema:
+                type: string
+                format: byte
+        '404':
+          description: Document not found
+          content:
+            application/json:
+              schema:
+                type: string
+                format: byte
       security:
         - bearerAuth: []
   /api/v1/users/{id}:
@@ -445,19 +476,10 @@ paths:
         - ai
 components:
   schemas:
-    CreateDocumentRequest:
+    AddTagRequest:
       type: object
       properties:
-        fileName:
-          type: string
-        filePath:
-          type: string
-        fileType:
-          type: string
-        fileSize:
-          type: integer
-          format: int64
-        textContent:
+        label:
           type: string
     Document:
       type: object
@@ -476,8 +498,6 @@ components:
         fileSize:
           type: integer
           format: int64
-        rawTextContent:
-          type: string
         createdAt:
           type: string
           format: date-time
@@ -522,10 +542,6 @@ components:
           format: uuid
         document:
           $ref: '#/components/schemas/Document'
-        fileContent:
-          type: object
-          properties:
-            binaryStream: {}
     Summary:
       type: object
       properties:
@@ -576,10 +592,19 @@ components:
           format: date-time
         preferences:
           type: string
-    AddTagRequest:
+    CreateDocumentRequest:
       type: object
       properties:
-        label:
+        fileName:
+          type: string
+        filePath:
+          type: string
+        fileType:
+          type: string
+        fileSize:
+          type: integer
+          format: int64
+        textContent:
           type: string
     AskRequest:
       type: object

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -321,15 +321,7 @@ paths:
         - bearerAuth: []
   /genai/ask:
     post:
-      description: >-
-        Answer a natural language question about a set of documents.
-
-
-        If documentContents is provided, the answer is grounded in the actual
-        document text.
-
-        Without it, the model answers from general knowledge and returns all
-        documentIds as sources.
+      description: Answer a question based on the provided documents.
       operationId: ask_genai_ask_post
       requestBody:
         content:
@@ -356,9 +348,7 @@ paths:
         - ai
   /genai/extract:
     post:
-      description: >-
-        Extract named entities (people, dates, topics, organizations) from
-        document text.
+      description: Extract entities from the provided content.
       operationId: extract_genai_extract_post
       requestBody:
         content:
@@ -418,8 +408,8 @@ paths:
         - hello
   /genai/summarize:
     post:
-      description: Generate a concise summary of the provided document text.
-      operationId: summarize_document_genai_summarize_post
+      description: Generate a summary of the provided content.
+      operationId: summarize_genai_summarize_post
       requestBody:
         content:
           application/json:
@@ -440,7 +430,7 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
       security: []
-      summary: Summarize Document
+      summary: Summarize
       tags:
         - ai
 components:
@@ -624,28 +614,8 @@ components:
         resultCount:
           type: integer
           format: int32
-    DocumentContent:
-      properties:
-        content:
-          title: Content
-          type: string
-        id:
-          title: Id
-          type: string
-      required:
-        - id
-        - content
-      title: DocumentContent
-      type: object
     GenAiAskRequest:
       properties:
-        documentContents:
-          anyOf:
-            - items:
-                $ref: '#/components/schemas/DocumentContent'
-              type: array
-            - type: 'null'
-          title: Documentcontents
         documentIds:
           items:
             type: string

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -321,7 +321,15 @@ paths:
         - bearerAuth: []
   /genai/ask:
     post:
-      description: Answer a question based on the provided documents.
+      description: >-
+        Answer a natural language question about a set of documents.
+
+
+        If documentContents is provided, the answer is grounded in the actual
+        document text.
+
+        Without it, the model answers from general knowledge and returns all
+        documentIds as sources.
       operationId: ask_genai_ask_post
       requestBody:
         content:
@@ -348,7 +356,9 @@ paths:
         - ai
   /genai/extract:
     post:
-      description: Extract entities from the provided content.
+      description: >-
+        Extract named entities (people, dates, topics, organizations) from
+        document text.
       operationId: extract_genai_extract_post
       requestBody:
         content:
@@ -408,8 +418,8 @@ paths:
         - hello
   /genai/summarize:
     post:
-      description: Generate a summary of the provided content.
-      operationId: summarize_genai_summarize_post
+      description: Generate a concise summary of the provided document text.
+      operationId: summarize_document_genai_summarize_post
       requestBody:
         content:
           application/json:
@@ -430,7 +440,7 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
       security: []
-      summary: Summarize
+      summary: Summarize Document
       tags:
         - ai
 components:
@@ -614,8 +624,28 @@ components:
         resultCount:
           type: integer
           format: int32
+    DocumentContent:
+      properties:
+        content:
+          title: Content
+          type: string
+        id:
+          title: Id
+          type: string
+      required:
+        - id
+        - content
+      title: DocumentContent
+      type: object
     GenAiAskRequest:
       properties:
+        documentContents:
+          anyOf:
+            - items:
+                $ref: '#/components/schemas/DocumentContent'
+              type: array
+            - type: 'null'
+          title: Documentcontents
         documentIds:
           items:
             type: string

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -5,7 +5,7 @@ info:
   license:
     name: MIT
     identifier: MIT
-  version: 0.2.0
+  version: 0.3.0
 servers:
   - url: /
     description: Current server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
     build: services/spring/
     container_name: spring
     environment:
+      SPRING_LOG_LEVEL: ${SPRING_LOG_LEVEL:-INFO}
       GENAI_BASE_URL: ${GENAI_BASE_URL:-http://genai:8000}
       OIDC_ISSUER_URI: ${OIDC_ISSUER_URI:-http://localhost/auth/realms/alexandria}
       OIDC_JWK_SET_URI: ${OIDC_JWK_SET_URI:-http://keycloak:8180/auth/realms/alexandria/protocol/openid-connect/certs}

--- a/services/spring/README.md
+++ b/services/spring/README.md
@@ -35,7 +35,7 @@ docker compose up -d spring --build
 
 ## Testing
 
-### Performing individual API calls
+### Performing individual API Calls
 For most API endpoints, a Bearer auth token is required, which can be requested from keycloak:
 ```bash
 TOKEN=$(curl -s -X POST "http://localhost/auth/realms/alexandria/protocol/openid-connect/token" \
@@ -48,3 +48,11 @@ TOKEN=$(curl -s -X POST "http://localhost/auth/realms/alexandria/protocol/openid
 # Then you can perform API calls using the $TOKEN shell variable, e.g.,
 curl -i -H "Authorization: Bearer $TOKEN" http://localhost/api/v1/knowledgebase/documents
 ```
+### Run all Test Cases
+If you want to run the test cases for the spring service locally, you can do it as follows:
+```bash
+# execute in services/spring/app/
+./gradlew test --no-daemon
+```
+
+The generated report can then be found at `build/reports/tests/test/index.html`.

--- a/services/spring/README.md
+++ b/services/spring/README.md
@@ -1,0 +1,50 @@
+# Alexandria Spring Service
+
+This directory contains the code for the spring service for the Alexandria project.
+
+## Endpoints
+Refer to [`api/openapi.yaml`](../../api/openapi.yaml) for the Spring and GenAI API endpoints documentation.
+
+Additional endpoints:
+
+| URL | Service |
+|-----|---------|
+| http://localhost/api/... | Spring API |
+| http://localhost/swagger-ui/index.html | Spring API documentation |
+| http://localhost/v3/api-docs| Spring API documentation |
+| http://localhost/hello | Spring health check |
+
+
+## Production
+
+Build and run the production image with docker-compose:
+```bash
+docker compose up -d spring
+# then open e.g. http://localhost/hello
+```
+
+## Local Development
+
+If you are actively developing the spring service, you might want to rebuild the image with
+your local changes instead of pulling the latest image from the repository:
+
+```bash
+docker compose up -d spring --build
+# then open e.g. http://localhost/hello
+```
+
+## Testing
+
+### Performing individual API calls
+For most API endpoints, a Bearer auth token is required, which can be requested from keycloak:
+```bash
+TOKEN=$(curl -s -X POST "http://localhost/auth/realms/alexandria/protocol/openid-connect/token" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=password" \
+  -d "client_id=alexandria-client" \
+  -d "username=<insert-username-here>" \
+  -d "password=<insert-password-here>" | jq -r '.access_token')
+
+# Then you can perform API calls using the $TOKEN shell variable, e.g.,
+curl -i -H "Authorization: Bearer $TOKEN" http://localhost/api/v1/knowledgebase/documents
+```

--- a/services/spring/app/build.gradle
+++ b/services/spring/app/build.gradle
@@ -43,6 +43,8 @@ dependencies {
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	testImplementation 'org.springframework.boot:spring-boot-webmvc-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 	testImplementation 'com.h2database:h2'
 
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/services/spring/app/src/main/java/com/alexandria/app/config/OpenApiConfig.java
+++ b/services/spring/app/src/main/java/com/alexandria/app/config/OpenApiConfig.java
@@ -12,7 +12,7 @@ import org.springframework.context.annotation.Configuration;
 @OpenAPIDefinition(
         info = @Info(
                 title = "Alexandria API",
-                version = "0.2.0",
+                version = "0.3.0",
                 description = "Document management and knowledge extraction platform",
                 license = @License(name = "MIT", identifier = "MIT")
         ),

--- a/services/spring/app/src/main/java/com/alexandria/app/document/Document.java
+++ b/services/spring/app/src/main/java/com/alexandria/app/document/Document.java
@@ -1,6 +1,7 @@
 package com.alexandria.app.document;
 
 import com.alexandria.app.user.User;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 
 import java.time.Instant;
@@ -34,6 +35,7 @@ public class Document {
     private Long fileSize;
 
     @Column(columnDefinition = "TEXT")
+    @JsonIgnore
     private String rawTextContent;
 
     @Column(nullable = false)

--- a/services/spring/app/src/main/java/com/alexandria/app/document/ExtractedEntity.java
+++ b/services/spring/app/src/main/java/com/alexandria/app/document/ExtractedEntity.java
@@ -1,5 +1,6 @@
 package com.alexandria.app.document;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
 
 import java.util.UUID;
@@ -13,6 +14,7 @@ public class ExtractedEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "document_id", nullable = false)
+    @JsonBackReference
     private Document document;
 
     @Column(nullable = false)

--- a/services/spring/app/src/main/java/com/alexandria/app/document/FileContent.java
+++ b/services/spring/app/src/main/java/com/alexandria/app/document/FileContent.java
@@ -1,6 +1,7 @@
 package com.alexandria.app.document;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 
 import java.sql.Blob;
@@ -22,6 +23,7 @@ public class FileContent {
 
     @Lob
     @Column(nullable = false)
+    @JsonIgnore
     private Blob fileContent;
 
     // Getters & Setters

--- a/services/spring/app/src/main/java/com/alexandria/app/document/FileContent.java
+++ b/services/spring/app/src/main/java/com/alexandria/app/document/FileContent.java
@@ -1,5 +1,6 @@
 package com.alexandria.app.document;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
 
 import java.sql.Blob;
@@ -16,6 +17,7 @@ public class FileContent {
     @OneToOne
     @MapsId
     @JoinColumn(name = "id")
+    @JsonBackReference
     private Document document;
 
     @Lob

--- a/services/spring/app/src/main/java/com/alexandria/app/document/Summary.java
+++ b/services/spring/app/src/main/java/com/alexandria/app/document/Summary.java
@@ -1,5 +1,6 @@
 package com.alexandria.app.document;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
 
 import java.time.Instant;
@@ -14,6 +15,7 @@ public class Summary {
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "document_id", nullable = false)
+    @JsonBackReference
     private Document document;
 
     @Column(nullable = false, columnDefinition = "TEXT")

--- a/services/spring/app/src/main/java/com/alexandria/app/document/Tag.java
+++ b/services/spring/app/src/main/java/com/alexandria/app/document/Tag.java
@@ -1,5 +1,6 @@
 package com.alexandria.app.document;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
 
 import java.util.HashSet;
@@ -21,6 +22,7 @@ public class Tag {
     private TagSource source;
 
     @ManyToMany(mappedBy = "tags")
+    @JsonBackReference
     private Set<Document> documents = new HashSet<>();
 
     public Tag() {

--- a/services/spring/app/src/main/java/com/alexandria/app/knowledgebase/GenAiClient.java
+++ b/services/spring/app/src/main/java/com/alexandria/app/knowledgebase/GenAiClient.java
@@ -2,6 +2,7 @@ package com.alexandria.app.knowledgebase;
 
 import com.alexandria.app.document.EntityType;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
@@ -16,6 +17,7 @@ public class GenAiClient {
     public GenAiClient(@Value("${genai.base-url:http://localhost:8000}") String baseUrl) {
         this.restClient = RestClient.builder()
                 .baseUrl(baseUrl)
+                .defaultHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
                 .build();
     }
 

--- a/services/spring/app/src/main/java/com/alexandria/app/knowledgebase/GenAiClient.java
+++ b/services/spring/app/src/main/java/com/alexandria/app/knowledgebase/GenAiClient.java
@@ -17,13 +17,13 @@ public class GenAiClient {
     public GenAiClient(@Value("${genai.base-url:http://localhost:8000}") String baseUrl) {
         this.restClient = RestClient.builder()
                 .baseUrl(baseUrl)
-                .defaultHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
                 .build();
     }
 
     public SummarizeResponse summarize(String content) {
         return restClient.post()
                 .uri("/genai/summarize")
+                .contentType(MediaType.APPLICATION_JSON)
                 .body(new SummarizeRequest(content))
                 .retrieve()
                 .body(SummarizeResponse.class);
@@ -32,6 +32,7 @@ public class GenAiClient {
     public ExtractResponse extract(String content) {
         return restClient.post()
                 .uri("/genai/extract")
+                .contentType(MediaType.APPLICATION_JSON)
                 .body(new ExtractRequest(content))
                 .retrieve()
                 .body(ExtractResponse.class);
@@ -40,6 +41,7 @@ public class GenAiClient {
     public AskResponse ask(String question, List<UUID> documentIds) {
         return restClient.post()
                 .uri("/genai/ask")
+                .contentType(MediaType.APPLICATION_JSON)
                 .body(new AskRequest(question, documentIds))
                 .retrieve()
                 .body(AskResponse.class);

--- a/services/spring/app/src/main/java/com/alexandria/app/knowledgebase/KnowledgeBaseController.java
+++ b/services/spring/app/src/main/java/com/alexandria/app/knowledgebase/KnowledgeBaseController.java
@@ -16,6 +16,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.http.HttpHeaders;
 
 import java.security.Principal;
 import java.util.List;
@@ -43,7 +44,7 @@ public class KnowledgeBaseController {
         return ResponseEntity.ok(knowledgeBaseService.getDocuments(user.getId()));
     }
 
-    @PostMapping(value = "/documents", consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(value = "/documents/create", consumes = MediaType.APPLICATION_JSON_VALUE)
     @Operation(summary = "Create a new document with text content")
     @ApiResponse(responseCode = "201", description = "Document created")
     public ResponseEntity<Document> createDocument(@RequestBody CreateDocumentRequest request, Principal principal) {
@@ -88,6 +89,27 @@ public class KnowledgeBaseController {
         User user = getCurrentUser(principal);
         knowledgeBaseService.deleteDocument(id, user.getId());
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/documents/{id}/download")
+    @Operation(summary = "Download document file")
+    @ApiResponse(responseCode = "200", description = "File content")
+    @ApiResponse(responseCode = "404", description = "Document not found")
+    public ResponseEntity<byte[]> downloadDocument(@PathVariable UUID id, Principal principal) {
+        User user = getCurrentUser(principal);
+        Document document = knowledgeBaseService.getDocument(id, user.getId());
+
+        return knowledgeBaseService.getFileContent(id)
+                .map(bytes -> {
+                    HttpHeaders headers = new HttpHeaders();
+                    headers.setContentType(MediaType.parseMediaType(document.getFileType()));
+                    headers.setContentDispositionFormData("attachment", document.getFileName());
+                    headers.setContentLength(bytes.length);
+                    return ResponseEntity.ok()
+                            .headers(headers)
+                            .body(bytes);
+                })
+                .orElse(ResponseEntity.notFound().build());
     }
 
     @GetMapping("/search")

--- a/services/spring/app/src/main/java/com/alexandria/app/knowledgebase/KnowledgeBaseService.java
+++ b/services/spring/app/src/main/java/com/alexandria/app/knowledgebase/KnowledgeBaseService.java
@@ -15,8 +15,10 @@ import org.springframework.web.multipart.MultipartFile;
 
 import javax.sql.rowset.serial.SerialBlob;
 import java.io.IOException;
+import java.io.InputStream;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -131,6 +133,20 @@ public class KnowledgeBaseService {
             throw new DocumentNotFoundException(id);
         }
         return document;
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<byte[]> getFileContent(UUID documentId) {
+        return documentRepository.findById(documentId)
+                .map(Document::getFileContent)
+                .map(fileContent -> {
+                    try {
+                        return fileContent.getFileContent().getBinaryStream().readAllBytes();
+                    } catch (SQLException | IOException e) {
+                        log.warn("Failed to read file content for document {}: {}", documentId, e.getMessage());
+                        return null;
+                    }
+                });
     }
 
     @Transactional

--- a/services/spring/app/src/main/java/com/alexandria/app/knowledgebase/TextExtractor.java
+++ b/services/spring/app/src/main/java/com/alexandria/app/knowledgebase/TextExtractor.java
@@ -25,11 +25,13 @@ public class TextExtractor {
         }
 
         try {
+            String text = null;
             if (contentType.equals("application/pdf")) {
-                return extractFromPdf(file);
+                text = extractFromPdf(file);
             } else if (contentType.startsWith("text/")) {
-                return new String(file.getBytes(), StandardCharsets.UTF_8);
+                text = new String(file.getBytes(), StandardCharsets.UTF_8);
             }
+            return sanitizeText(text);
         } catch (IOException e) {
             String safeFilename = sanitizeForLog(file.getOriginalFilename());
             log.warn("Failed to extract text from file {}: {}", safeFilename, e.getMessage());
@@ -41,10 +43,15 @@ public class TextExtractor {
     private String extractFromPdf(MultipartFile file) throws IOException {
         try (PDDocument document = Loader.loadPDF(file.getBytes())) {
             PDFTextStripper stripper = new PDFTextStripper();
-            String text = stripper.getText(document);
-            // Remove null bytes that postgres won't store in text columns
-            return text != null ? text.replace("\u0000", "") : null;
+            return stripper.getText(document);
         }
+    }
+
+    private String sanitizeText(String text) {
+        if (text == null) {
+            return null;
+        }
+        return text.replace("\u0000", "");
     }
 
     private String sanitizeForLog(String value) {

--- a/services/spring/app/src/main/java/com/alexandria/app/knowledgebase/TextExtractor.java
+++ b/services/spring/app/src/main/java/com/alexandria/app/knowledgebase/TextExtractor.java
@@ -41,7 +41,9 @@ public class TextExtractor {
     private String extractFromPdf(MultipartFile file) throws IOException {
         try (PDDocument document = Loader.loadPDF(file.getBytes())) {
             PDFTextStripper stripper = new PDFTextStripper();
-            return stripper.getText(document);
+            String text = stripper.getText(document);
+            // Remove null bytes that postgres won't store in text columns
+            return text != null ? text.replace("\u0000", "") : null;
         }
     }
 

--- a/services/spring/app/src/main/java/com/alexandria/app/user/UserService.java
+++ b/services/spring/app/src/main/java/com/alexandria/app/user/UserService.java
@@ -2,6 +2,7 @@ package com.alexandria.app.user;
 
 import com.alexandria.app.exception.UserNotFoundException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -25,6 +26,7 @@ public class UserService {
      * @param email       E-mail of user.
      * @return
      */
+    @Transactional
     public User findOrCreateByOidcSubject(String oidcSubject, String username, String email) {
         Optional<User> existing = repository.findByOidcSubject(oidcSubject);
         if (existing.isPresent()) {

--- a/services/spring/app/src/main/java/com/alexandria/app/user/UserService.java
+++ b/services/spring/app/src/main/java/com/alexandria/app/user/UserService.java
@@ -28,10 +28,18 @@ public class UserService {
      */
     @Transactional
     public User findOrCreateByOidcSubject(String oidcSubject, String username, String email) {
-        Optional<User> existing = repository.findByOidcSubject(oidcSubject);
-        if (existing.isPresent()) {
-            return existing.get();
+        Optional<User> bySubject = repository.findByOidcSubject(oidcSubject);
+        if (bySubject.isPresent()) {
+            return bySubject.get();
         }
+
+        Optional<User> byEmail = repository.findByEmail(email);
+        if (byEmail.isPresent()) {
+            User user = byEmail.get();
+            user.setOidcSubject(oidcSubject);
+            return repository.save(user);
+        }
+
         return repository.save(new User(oidcSubject, username, email));
     }
 

--- a/services/spring/app/src/main/resources/application-openapi.properties
+++ b/services/spring/app/src/main/resources/application-openapi.properties
@@ -1,5 +1,6 @@
 # Properties for OpenAPI spec generation
 spring.application.name=alexandria
+logging.level.root=WARN
 
 # API docs
 springdoc.api-docs.enabled=true

--- a/services/spring/app/src/main/resources/application.properties
+++ b/services/spring/app/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 spring.application.name=alexandria
+logging.level.root=${SPRING_LOG_LEVEL}
 
 # API docs
 springdoc.api-docs.enabled=true

--- a/services/spring/app/src/test/java/com/alexandria/app/knowledgebase/FileHandlingIntegrationTest.java
+++ b/services/spring/app/src/test/java/com/alexandria/app/knowledgebase/FileHandlingIntegrationTest.java
@@ -1,0 +1,81 @@
+package com.alexandria.app.knowledgebase;
+
+import com.alexandria.app.document.Document;
+import com.alexandria.app.document.DocumentRepository;
+import com.alexandria.app.user.User;
+import com.alexandria.app.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class FileHandlingIntegrationTest {
+
+    @Autowired
+    private KnowledgeBaseService knowledgeBaseService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private User testUser;
+
+    @BeforeEach
+    void setup() {
+        testUser = userRepository.save(new User("oidc|file_test", "fileuser", "fileuser@example.com"));
+    }
+
+    @Test
+    void integration_file_uploadTextFileStoresContentAndText() {
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "test.txt", "text/plain", "Hello World".getBytes());
+
+        Document doc = knowledgeBaseService.uploadDocument(testUser, file);
+
+        assertThat(doc.getId()).isNotNull();
+        assertThat(doc.getFileName()).isEqualTo("test.txt");
+        assertThat(doc.getFileType()).isEqualTo("text/plain");
+        assertThat(doc.getRawTextContent()).isEqualTo("Hello World");
+        assertThat(doc.getFileContent()).isNotNull();
+    }
+
+    @Test
+    void integration_file_downloadReturnsUploadedBytes() {
+        byte[] content = "Test content for download".getBytes();
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "download.txt", "text/plain", content);
+
+        Document doc = knowledgeBaseService.uploadDocument(testUser, file);
+        Optional<byte[]> downloaded = knowledgeBaseService.getFileContent(doc.getId());
+
+        assertThat(downloaded).isPresent();
+        assertThat(downloaded.get()).isEqualTo(content);
+    }
+
+    @Test
+    void integration_file_uploadWithNullBytesInTextStripsNulls() {
+        byte[] content = "Text\u0000with\u0000nulls".getBytes();
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "nulls.txt", "text/plain", content);
+
+        Document doc = knowledgeBaseService.uploadDocument(testUser, file);
+
+        assertThat(doc.getRawTextContent()).doesNotContain("\u0000");
+    }
+
+    @Test
+    void integration_file_getFileContentReturnsEmptyForNonexistent() {
+        Optional<byte[]> content = knowledgeBaseService.getFileContent(java.util.UUID.randomUUID());
+
+        assertThat(content).isEmpty();
+    }
+}

--- a/services/spring/app/src/test/java/com/alexandria/app/knowledgebase/KnowledgeBaseControllerTest.java
+++ b/services/spring/app/src/test/java/com/alexandria/app/knowledgebase/KnowledgeBaseControllerTest.java
@@ -1,0 +1,87 @@
+package com.alexandria.app.knowledgebase;
+
+import com.alexandria.app.document.Document;
+import com.alexandria.app.user.User;
+import com.alexandria.app.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class KnowledgeBaseControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private KnowledgeBaseService knowledgeBaseService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private User testUser;
+
+    @BeforeEach
+    void setup() {
+        testUser = userRepository.save(new User("sub123", "testuser", "test@example.com"));
+    }
+
+    @Test
+    void integration_controller_listDocumentsReturnsJson() throws Exception {
+        knowledgeBaseService.createDocument(
+                testUser, "test.pdf", "/files/test.pdf", "application/pdf", 1024L, "Sample text");
+
+        mockMvc.perform(get("/api/v1/knowledgebase/documents")
+                        .with(jwt().jwt(j -> j.subject("sub123"))))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$[0].fileName").value("test.pdf"))
+                .andExpect(jsonPath("$[0].fileContent").doesNotExist());
+    }
+
+    @Test
+    void integration_controller_getDocumentReturnsJson() throws Exception {
+        Document doc = knowledgeBaseService.createDocument(
+                testUser, "report.pdf", "/files/report.pdf", "application/pdf", 2048L, "Report content");
+
+        mockMvc.perform(get("/api/v1/knowledgebase/documents/" + doc.getId())
+                        .with(jwt().jwt(j -> j.subject("sub123"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.fileName").value("report.pdf"))
+                .andExpect(jsonPath("$.fileType").value("application/pdf"));
+    }
+
+    @Test
+    void integration_controller_getDocumentReturns404ForNonexistent() throws Exception {
+        mockMvc.perform(get("/api/v1/knowledgebase/documents/" + java.util.UUID.randomUUID())
+                        .with(jwt().jwt(j -> j.subject("sub123"))))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void integration_controller_downloadReturnsFileBytes() throws Exception {
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "download.txt", "text/plain", "hello world".getBytes());
+        Document doc = knowledgeBaseService.uploadDocument(testUser, file);
+
+        mockMvc.perform(get("/api/v1/knowledgebase/documents/" + doc.getId() + "/download")
+                        .with(jwt().jwt(j -> j.subject("sub123"))))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Content-Type", "text/plain"))
+                .andExpect(content().bytes("hello world".getBytes()));
+    }
+}

--- a/services/spring/app/src/test/resources/application.properties
+++ b/services/spring/app/src/test/resources/application.properties
@@ -1,4 +1,6 @@
 # Properties for test cases
+spring.application.name=alexandria
+logging.level.root=WARN
 
 # Database (in-memory so no cleanup needed after all testcase have been run)
 spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE


### PR DESCRIPTION
## What does this PR do?

<!-- Short description of the change. Reference any related issue: Closes #123 -->
This PR is related to issues reported by @BjarneHa regarding file uploads failing. This PR splits up bidirectional references in the JPA schema, which previously lead to an error due to unbounded recursion. Additionally this PR includes some improvements for text extraction (remove null bytes which can't be stored by PostgreSQL), user lookup (overwrite oicdSubject if it changed, e.g. because of a different keycloak session) and the GenAI interaction (explicit content type) that were made during debug.

Furthermore, documentation for the spring service was added under `services/spring/README.md` and additional test cases for the KnowledgeBase related classes have been added.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Docs
- [ ] CI / infra

## Definition of Done

- [x] CI is green
- [X] If the API changed: `api/openapi.yaml` is updated and lint passes
- [X] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [x] Tests added or updated for the changed behaviour
- [x] Docs updated where it matters (README, ADRs, comments)

## Notes for the reviewer

<!-- Anything they should look at first, gotchas, screenshots, ... -->
