### PR TITLE
feat(client): implement OIDC flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,13 @@
 
 # Keycloak (OIDC provider)
 
+# Keycloak OIDC client redirect URI (allowed callback URL after login)
+# Override for non-localhost deployments (e.g. https://your-domain.com/*)
+# KEYCLOAK_REDIRECT_URI="http://localhost/*"
+# Keycloak OIDC client web origin (for CORS)
+# Override for non-localhost deployments (e.g. https://your-domain.com)
+# KEYCLOAK_WEB_ORIGIN="http://localhost"
+
 # KC_BOOTSTRAP_ADMIN_USERNAME="admin"
 # KC_BOOTSTRAP_ADMIN_PASSWORD="secret-with-64-bit-entropy-eg-16-hex-chars"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,6 +99,8 @@ services:
       KC_PROXY_HEADERS: xforwarded
       KC_HTTP_RELATIVE_PATH: /auth
       KC_HOSTNAME_BACKCHANNEL_DYNAMIC: true
+      KEYCLOAK_REDIRECT_URI: ${KEYCLOAK_REDIRECT_URI:-http://localhost/*}
+      KEYCLOAK_WEB_ORIGIN: ${KEYCLOAK_WEB_ORIGIN:-http://localhost}
     restart: unless-stopped
     networks:
       - alexandria

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,22 @@ services:
     depends_on:
       - traefik
 
+  client-dev:
+    build:
+      context: services/client/
+      dockerfile: Dockerfile.dev
+    container_name: client-dev
+    restart: unless-stopped
+    profiles:
+      - dev
+    networks:
+      - alexandria
+    ports:
+      - 5173:5173
+    volumes:
+      - ./services/client:/app
+      - /app/node_modules
+
   spring:
     image: ghcr.io/aet-devops26/team-bnd/spring:latest
     build: services/spring/

--- a/infra/k8s/alexandria/templates/ingress.yaml
+++ b/infra/k8s/alexandria/templates/ingress.yaml
@@ -73,7 +73,7 @@ spec:
                 name: {{ include "alexandria.fullname" . }}-genai
                 port:
                   number: 8000
-          - path: /keycloak
+          - path: /auth
             pathType: Prefix
             backend:
               service:

--- a/infra/k8s/alexandria/values.yaml
+++ b/infra/k8s/alexandria/values.yaml
@@ -62,6 +62,11 @@ keycloak:
   realm:
     import: true
     existingSecret: alexandria-oidc-realm
+  extraEnvVars:
+    - name: KEYCLOAK_REDIRECT_URI
+      value: "https://alexandria.stud.k8s.aet.cit.tum.de/*"
+    - name: KEYCLOAK_WEB_ORIGIN
+      value: "https://alexandria.stud.k8s.aet.cit.tum.de"
   database:
     type: postgres
     host: "alexandria-postgres-db"

--- a/infra/k8s/alexandria/values.yaml
+++ b/infra/k8s/alexandria/values.yaml
@@ -21,8 +21,8 @@ spring:
     username: "postgres"
     password: "postgres-password"
   oidc:
-    issuerUri: "https://alexandria.stud.k8s.aet.cit.tum.de/keycloak/realms/alexandria"
-    jwkSetUri: "http://alexandria-keycloak:8080/keycloak/realms/alexandria/protocol/openid-connect/certs"
+    issuerUri: "https://alexandria.stud.k8s.aet.cit.tum.de/auth/realms/alexandria"
+    jwkSetUri: "http://alexandria-keycloak:8080/auth/realms/alexandria/protocol/openid-connect/certs"
     userIdClaim: "sub"
     usernameClaim: "preferred_username"
     rolesClaim: "roles"
@@ -55,8 +55,8 @@ keycloak:
   keycloak:
     adminPassword: "admin"
     proxyHeaders: "xforwarded"
-    hostname: "https://alexandria.stud.k8s.aet.cit.tum.de/keycloak"
-    httpRelativePath: /keycloak
+    hostname: "https://alexandria.stud.k8s.aet.cit.tum.de/auth"
+    httpRelativePath: /auth
     extraArgs:
       - "--hostname-backchannel-dynamic=true"
   realm:

--- a/infra/oidc/realm.json
+++ b/infra/oidc/realm.json
@@ -27,7 +27,7 @@
   "oauth2DevicePollingInterval": 5,
   "enabled": true,
   "sslRequired": "external",
-  "registrationAllowed": false,
+  "registrationAllowed": true,
   "registrationEmailAsUsername": false,
   "rememberMe": false,
   "verifyEmail": false,
@@ -639,12 +639,8 @@
       "enabled": true,
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
-      "redirectUris": [
-        "http://localhost:8082/*"
-      ],
-      "webOrigins": [
-        ""
-      ],
+      "redirectUris": ["${KEYCLOAK_REDIRECT_URI}"],
+      "webOrigins": ["${KEYCLOAK_WEB_ORIGIN}"],
       "notBefore": 0,
       "bearerOnly": false,
       "consentRequired": false,

--- a/services/client/README.md
+++ b/services/client/README.md
@@ -16,33 +16,21 @@ docker run -p 8082:80 team-bnd-client
 Or with docker-compose (builds the image and serves it with nginx):
 
 ```bash
-docker compose up -d client
-# then open http://localhost:8082
+docker compose up -d client --build
+# then open http://localhost/
 ```
 
 Development
 -----------
 
-A development image is provided which runs the Vite dev server inside the container. It is useful for working in a containerised dev environment and supports live reload.
+A development image is provided which runs the Vite dev server inside the container. It is useful for working in a containerised dev environment and supports live reload. The Spring server and Keycloak are proxied at `http://localhost:5173/api` and `http://localhost:5173/auth`.
 
 ```bash
-# build the dev image
-docker build -f services/client/Dockerfile.dev -t team-bnd-client-dev ./services/client
-
-# run the dev container (mount the source for live edits)
-docker run -p 5173:5173 -v $(pwd)/services/client:/app -v /app/node_modules -w /app team-bnd-client-dev
+# bring up entire stack
+docker compose up -d
+# build and start dev image (has to be executed again when deps are added)
+docker compose --profile dev up client-dev -d --build --renew-anon-volumes
 # then open http://localhost:5173
-```
-
-Local (native) development
---------------------------
-
-Alternatively, for quickest iteration on a machine with Node.js installed:
-
-```bash
-cd services/client
-npm install
-npm run dev
 ```
 
 Testing
@@ -67,3 +55,4 @@ Notes
 -----
 - The dev Dockerfile starts Vite with --host 0.0.0.0 so the dev server is reachable from the host when running in a container.
 - The production image serves the built files with nginx on port 80 inside the container (host port 8082 by default in docker-compose).
+- When starting the development server, `--build --renew-anon-volumes` has to be specified.

--- a/services/client/package-lock.json
+++ b/services/client/package-lock.json
@@ -8,8 +8,10 @@
       "name": "alexandria-client",
       "version": "0.1.0",
       "dependencies": {
+        "oidc-client-ts": "^3.5.0",
         "react": "^19.2.0",
-        "react-dom": "^19.2.0"
+        "react-dom": "^19.2.0",
+        "react-oidc-context": "^3.3.1"
       },
       "devDependencies": {
         "@playwright/test": "~1.60.0",
@@ -460,6 +462,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/lightningcss": {
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
@@ -752,6 +763,18 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/oidc-client-ts": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/oidc-client-ts/-/oidc-client-ts-3.5.0.tgz",
+      "integrity": "sha512-l2q8l9CTCTOlbX+AnK4p3M+4CEpKpyQhle6blQkdFhm0IsBqsxm15bYaSa11G7pWdsYr6epdsRZxJpCyCRbT8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jwt-decode": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -852,6 +875,19 @@
       },
       "peerDependencies": {
         "react": "^19.2.7"
+      }
+    },
+    "node_modules/react-oidc-context": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/react-oidc-context/-/react-oidc-context-3.3.1.tgz",
+      "integrity": "sha512-/Azvm9W4DhhOtSDBE73kFInh1b6zZRRfILKbgmk2syExMF0PCYJOn/dGdOOi2BFX8x0rCeUe45NXHU+/+xDcrQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "oidc-client-ts": "^3.1.0",
+        "react": ">=16.14.0"
       }
     },
     "node_modules/rolldown": {

--- a/services/client/package.json
+++ b/services/client/package.json
@@ -12,8 +12,10 @@
     "test:e2e": "PW_TEST_CONNECT_WS_ENDPOINT=ws://127.0.0.1:3000/ playwright test"
   },
   "dependencies": {
+    "oidc-client-ts": "^3.5.0",
     "react": "^19.2.0",
-    "react-dom": "^19.2.0"
+    "react-dom": "^19.2.0",
+    "react-oidc-context": "^3.3.1"
   },
   "devDependencies": {
     "@playwright/test": "~1.60.0",

--- a/services/client/src/App.tsx
+++ b/services/client/src/App.tsx
@@ -1,9 +1,54 @@
 import React from "react";
+import { useAuth } from "react-oidc-context";
 
 export default function App() {
+  const auth = useAuth();
+
+  if (auth.isLoading) {
+    return (
+      <div className="app">
+        <p>Loading...</p>
+      </div>
+    );
+  }
+
+  if (auth.error) {
+    return (
+      <div className="app">
+        <p>Authentication error: {auth.error.message}</p>
+        <button onClick={() => auth.signinRedirect()}>Try again</button>
+      </div>
+    );
+  }
+
+  if (!auth.isAuthenticated) {
+    return (
+      <div className="app">
+        <h1>Alexandria — Document Summarization</h1>
+        <p>
+          Alexandria helps users upload documents and get concise summaries,
+          extracted tags, and searchable knowledge — so reading a 40-page report
+          is no longer necessary.
+        </p>
+        <button onClick={() => auth.signinRedirect()}>Login</button>
+      </div>
+    );
+  }
+
   return (
     <div className="app">
-      <h1>Alexandria — Document Summarization</h1>
+      <header className="app-header">
+        <h1>Alexandria — Document Summarization</h1>
+        <div className="user-info">
+          <span>
+            Logged in as{" "}
+            <strong>
+              {auth.user?.profile.preferred_username ?? auth.user?.profile.sub}
+            </strong>
+          </span>
+          <button onClick={() => auth.removeUser()}>Logout</button>
+        </div>
+      </header>
       <p>
         Alexandria helps users upload documents and get concise summaries,
         extracted tags, and searchable knowledge — so reading a 40-page report

--- a/services/client/src/main.tsx
+++ b/services/client/src/main.tsx
@@ -1,10 +1,16 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
+import { AuthProvider } from "react-oidc-context";
 import App from "./App";
+import { oidcConfig } from "./oidcConfig";
 import "./styles.css";
 
 const rootElement = document.getElementById("root");
 if (!rootElement) throw new Error("Root element not found");
 
 const root = createRoot(rootElement);
-root.render(<App />);
+root.render(
+  <AuthProvider {...oidcConfig}>
+    <App />
+  </AuthProvider>
+);

--- a/services/client/src/oidcConfig.ts
+++ b/services/client/src/oidcConfig.ts
@@ -1,0 +1,13 @@
+import { AuthProviderProps } from "react-oidc-context";
+
+export const oidcConfig: AuthProviderProps = {
+  authority: `${window.location.origin}/auth/realms/alexandria`,
+  client_id: "alexandria-client",
+  redirect_uri: `${window.location.origin}/`,
+  post_logout_redirect_uri: `${window.location.origin}/`,
+  scope: "openid profile",
+  onSigninCallback: () => {
+    // Remove OIDC query params from URL after successful login
+    window.history.replaceState({}, document.title, window.location.pathname);
+  },
+};

--- a/services/client/src/oidcConfig.ts
+++ b/services/client/src/oidcConfig.ts
@@ -5,6 +5,7 @@ export const oidcConfig: AuthProviderProps = {
   client_id: "alexandria-client",
   redirect_uri: `${window.location.origin}/`,
   post_logout_redirect_uri: `${window.location.origin}/`,
+  prompt: "login",
   scope: "openid profile",
   onSigninCallback: () => {
     // Remove OIDC query params from URL after successful login

--- a/services/client/vite.config.ts
+++ b/services/client/vite.config.ts
@@ -1,0 +1,13 @@
+import { UserConfig } from "vite";
+
+export default {
+  server: {
+    proxy: {
+      "/api": "http://spring:8080",
+      "/auth": {
+        target: "http://keycloak:8180",
+        xfwd: true,
+      },
+    },
+  },
+} satisfies UserConfig;


### PR DESCRIPTION
## What does this PR do?

Implements basic OIDC flow for the client. Closes #6.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [x] Docs
- [ ] CI / infra

## Definition of Done

- [ ] CI is green
- [ ] If the API changed: `api/openapi.yaml` is updated and lint passes
- [ ] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [ ] Tests added or updated for the changed behaviour
- [ ] Docs updated where it matters (README, ADRs, comments)

## Notes for the reviewer

Should the development server live in the `docker-compose.yaml` which we use for production? Instead of using `profiles`, we could also provide a separate `docker-compose.dev.yaml`. 