### PR TITLE
Infra: add Prometheus and Grafana monitoring to docker-compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,3 +70,10 @@
 # POSTGRES_USER="admin"
 # POSTGRES_PASSWORD="secret-with-64-bit-entropy-eg-16-hex-chars"
 # POSTGRES_PORT=5432
+
+# ----------------------------------------------------------------------------------
+# Monitoring (Prometheus / Grafana)
+# ----------------------------------------------------------------------------------
+
+# Grafana admin login. Defaults to "admin" / "admin" locally
+# GRAFANA_ADMIN_PASSWORD="secret-with-64-bit-entropy-eg-16-hex-chars"

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ All services are accessed through Traefik as the reverse proxy. See [`docs/traef
 | http://localhost/swagger-ui/ | Spring API documentation |
 | http://localhost/genai/docs | GenAI API documentation |
 | http://localhost/auth/ | Keycloak |
+| http://localhost/grafana/ | Grafana dashboards |
+| http://localhost/prometheus/ | Prometheus |
 
 ### Infrastructure & Deployment
 
@@ -77,3 +79,12 @@ For local client development, see [`services/client/README.md`](services/client/
 
 Python/FastAPI service using LangChain to extract entities and summarize documents.
 For local Python dev, see [`services/genai/README.md`](services/genai/README.md).
+
+### Monitoring
+
+Prometheus scrapes metrics from Spring (`/actuator/prometheus`), GenAI (`/genai/metrics`), and Traefik, and Grafana visualizes them. Both run as part of `docker compose up`.
+
+- Grafana: http://localhost/grafana/ (default login `admin` / `admin`, override with `GRAFANA_ADMIN_PASSWORD`)
+- Prometheus: http://localhost/prometheus/
+
+Three dashboards are provisioned automatically under the "Alexandria" folder: an overview (request rate, errors, latency across services), a Spring dashboard (JVM, GC, threads, DB pool), and a GenAI dashboard (request rate, latency, process memory). Dashboard JSON and the Prometheus scrape and alert config live under [`infra/prometheus`](infra/prometheus) and [`infra/grafana`](infra/grafana).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -165,6 +165,13 @@ services:
       - "--providers.docker=true"
       - "--providers.docker.exposedbydefault=false"
       - "--entrypoints.web.address=:80"
+      # Dedicated internal entrypoint for the Prometheus metrics endpoint so it
+      # is not reachable on the public web entrypoint.
+      - "--entrypoints.metrics.address=:8082"
+      - "--metrics.prometheus=true"
+      - "--metrics.prometheus.entrypoint=metrics"
+      - "--metrics.prometheus.addentrypointslabels=true"
+      - "--metrics.prometheus.addserviceslabels=true"
       - "--ping=true"
     ports:
       - "80:80"
@@ -191,6 +198,77 @@ services:
       retries: 3
       start_period: 5s
 
+  prometheus:
+    image: prom/prometheus:v3.12.0
+    container_name: prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--web.external-url=/prometheus"
+      - "--web.route-prefix=/prometheus"
+    volumes:
+      - ./infra/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./infra/prometheus/alert.rules.yml:/etc/prometheus/alert.rules.yml:ro
+      - prometheus_data:/prometheus
+    restart: unless-stopped
+    networks:
+      - alexandria
+    deploy:
+      resources:
+        limits:
+          cpus: "0.25"
+          memory: 256M
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.prometheus.rule=PathPrefix(`/prometheus`)"
+      - "traefik.http.routers.prometheus.entrypoints=web"
+      - "traefik.http.routers.prometheus.priority=10"
+      - "traefik.http.services.prometheus.loadbalancer.server.port=9090"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:9090/prometheus/-/healthy"]
+      interval: 30s
+      timeout: 3s
+      retries: 3
+      start_period: 10s
+    depends_on:
+      - traefik
+
+  grafana:
+    image: grafana/grafana:13.0.2
+    container_name: grafana
+    environment:
+      GF_SERVER_ROOT_URL: /grafana
+      GF_SERVER_SERVE_FROM_SUB_PATH: "true"
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
+      GF_USERS_ALLOW_SIGN_UP: "false"
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./infra/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./infra/grafana/dashboards:/var/lib/grafana/dashboards:ro
+    restart: unless-stopped
+    networks:
+      - alexandria
+    deploy:
+      resources:
+        limits:
+          cpus: "0.50"
+          memory: 512M
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.grafana.rule=PathPrefix(`/grafana`)"
+      - "traefik.http.routers.grafana.entrypoints=web"
+      - "traefik.http.routers.grafana.priority=10"
+      - "traefik.http.services.grafana.loadbalancer.server.port=3000"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3000/grafana/api/health"]
+      interval: 30s
+      timeout: 3s
+      retries: 3
+      start_period: 15s
+    depends_on:
+      - prometheus
+      - traefik
+
   playwright:
     container_name: playwright
     image: mcr.microsoft.com/playwright:v1.60.0-noble
@@ -210,3 +288,5 @@ networks:
 
 volumes:
   pgdata:
+  prometheus_data:
+  grafana_data:

--- a/docs/traefik.md
+++ b/docs/traefik.md
@@ -31,10 +31,13 @@ Alexandria uses [Traefik](https://traefik.io/) as the reverse proxy and API gate
 - Spring (REST API)
 - Keycloak (OIDC provider)
 - GenAI (health and docs endpoints only)
+- Grafana and Prometheus (monitoring)
 
 **Private services** (internal Docker network only):
 - PostgreSQL
 - GenAI (except health and docs endpoints)
+
+Traefik also exposes its own Prometheus metrics on a separate internal `metrics` entrypoint (`:8082`), which is only reachable inside the Docker network and is scraped by Prometheus. It is not bound to the public `web` entrypoint.
 
 ## Routing Table
 
@@ -49,6 +52,8 @@ Alexandria uses [Traefik](https://traefik.io/) as the reverse proxy and API gate
 | `/docs` | GenAI | 8000 | FastAPI documentation UI |
 | `/redoc` | GenAI | 8000 | FastAPI documentation UI (ReDoc) |
 | `/openapi.json` | GenAI | 8000 | FastAPI OpenAPI spec |
+| `/grafana/*` | Grafana | 3000 | Monitoring dashboards |
+| `/prometheus/*` | Prometheus | 9090 | Metrics store and query UI |
 
 ## Local Development
 
@@ -71,6 +76,8 @@ docker compose up -d
 | http://localhost/docs | GenAI API documentation |
 | http://localhost/redoc | GenAI API documentation (ReDoc) |
 | http://localhost/openapi.json | GenAI OpenAPI spec |
+| http://localhost/grafana/ | Grafana dashboards |
+| http://localhost/prometheus/ | Prometheus |
 
 ### Access Traefik Dashboard
 

--- a/infra/grafana/dashboards/genai.json
+++ b/infra/grafana/dashboards/genai.json
@@ -1,0 +1,165 @@
+{
+	"annotations": {
+		"list": [
+			{
+				"builtIn": 1,
+				"datasource": { "type": "grafana", "uid": "-- Grafana --" },
+				"enable": true,
+				"hide": true,
+				"iconColor": "rgba(0, 211, 255, 1)",
+				"name": "Annotations & Alerts",
+				"type": "dashboard"
+			}
+		]
+	},
+	"editable": true,
+	"fiscalYearStartMonth": 0,
+	"graphTooltip": 1,
+	"links": [],
+	"panels": [
+		{
+			"datasource": { "type": "prometheus", "uid": "prometheus" },
+			"fieldConfig": {
+				"defaults": {
+					"color": { "mode": "palette-classic" },
+					"custom": { "axisLabel": "req/s", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "showPoints": "never" },
+					"unit": "reqps"
+				},
+				"overrides": []
+			},
+			"gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+			"id": 1,
+			"options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+			"targets": [
+				{
+					"datasource": { "type": "prometheus", "uid": "prometheus" },
+					"expr": "sum(rate(http_requests_total{job=\"genai\"}[5m])) by (handler)",
+					"legendFormat": "{{handler}}",
+					"refId": "A"
+				}
+			],
+			"title": "Request rate by endpoint",
+			"type": "timeseries"
+		},
+		{
+			"datasource": { "type": "prometheus", "uid": "prometheus" },
+			"fieldConfig": {
+				"defaults": {
+					"color": { "mode": "palette-classic" },
+					"custom": { "axisLabel": "req/s", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "showPoints": "never" },
+					"unit": "reqps"
+				},
+				"overrides": []
+			},
+			"gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+			"id": 2,
+			"options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+			"targets": [
+				{
+					"datasource": { "type": "prometheus", "uid": "prometheus" },
+					"expr": "sum(rate(http_requests_total{job=\"genai\"}[5m])) by (status)",
+					"legendFormat": "{{status}}",
+					"refId": "A"
+				}
+			],
+			"title": "Request rate by status class",
+			"type": "timeseries"
+		},
+		{
+			"datasource": { "type": "prometheus", "uid": "prometheus" },
+			"fieldConfig": {
+				"defaults": {
+					"color": { "mode": "palette-classic" },
+					"custom": { "axisLabel": "seconds", "drawStyle": "line", "fillOpacity": 0, "lineWidth": 1, "showPoints": "never" },
+					"unit": "s"
+				},
+				"overrides": []
+			},
+			"gridPos": { "h": 8, "w": 24, "x": 0, "y": 8 },
+			"id": 3,
+			"options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+			"targets": [
+				{
+					"datasource": { "type": "prometheus", "uid": "prometheus" },
+					"expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket{job=\"genai\"}[5m])) by (le, handler))",
+					"legendFormat": "p50 {{handler}}",
+					"refId": "A"
+				},
+				{
+					"datasource": { "type": "prometheus", "uid": "prometheus" },
+					"expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{job=\"genai\"}[5m])) by (le, handler))",
+					"legendFormat": "p95 {{handler}}",
+					"refId": "B"
+				}
+			],
+			"title": "Request latency by endpoint",
+			"type": "timeseries"
+		},
+		{
+			"datasource": { "type": "prometheus", "uid": "prometheus" },
+			"fieldConfig": {
+				"defaults": {
+					"color": { "mode": "palette-classic" },
+					"custom": { "axisLabel": "bytes", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "showPoints": "never" },
+					"unit": "bytes"
+				},
+				"overrides": []
+			},
+			"gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+			"id": 4,
+			"options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+			"targets": [
+				{
+					"datasource": { "type": "prometheus", "uid": "prometheus" },
+					"expr": "process_resident_memory_bytes{job=\"genai\"}",
+					"legendFormat": "resident",
+					"refId": "A"
+				},
+				{
+					"datasource": { "type": "prometheus", "uid": "prometheus" },
+					"expr": "process_virtual_memory_bytes{job=\"genai\"}",
+					"legendFormat": "virtual",
+					"refId": "B"
+				}
+			],
+			"title": "Python process memory",
+			"type": "timeseries"
+		},
+		{
+			"datasource": { "type": "prometheus", "uid": "prometheus" },
+			"fieldConfig": {
+				"defaults": {
+					"color": { "mode": "palette-classic" },
+					"custom": { "axisLabel": "cores", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "showPoints": "never" },
+					"unit": "short"
+				},
+				"overrides": []
+			},
+			"gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+			"id": 5,
+			"options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+			"targets": [
+				{
+					"datasource": { "type": "prometheus", "uid": "prometheus" },
+					"expr": "rate(process_cpu_seconds_total{job=\"genai\"}[5m])",
+					"legendFormat": "cpu cores",
+					"refId": "A"
+				}
+			],
+			"title": "Python process CPU usage",
+			"type": "timeseries"
+		}
+	],
+	"preload": false,
+	"refresh": "30s",
+	"schemaVersion": 39,
+	"tags": ["alexandria", "genai"],
+	"templating": { "list": [] },
+	"time": { "from": "now-30m", "to": "now" },
+	"timepicker": {},
+	"timezone": "browser",
+	"title": "Alexandria GenAI",
+	"uid": "alexandria-genai",
+	"version": 1,
+	"weekStart": ""
+}

--- a/infra/grafana/dashboards/overview.json
+++ b/infra/grafana/dashboards/overview.json
@@ -1,0 +1,241 @@
+{
+	"annotations": {
+		"list": [
+			{
+				"builtIn": 1,
+				"datasource": { "type": "grafana", "uid": "-- Grafana --" },
+				"enable": true,
+				"hide": true,
+				"iconColor": "rgba(0, 211, 255, 1)",
+				"name": "Annotations & Alerts",
+				"type": "dashboard"
+			}
+		]
+	},
+	"editable": true,
+	"fiscalYearStartMonth": 0,
+	"graphTooltip": 1,
+	"links": [],
+	"panels": [
+		{
+			"datasource": { "type": "prometheus", "uid": "prometheus" },
+			"fieldConfig": {
+				"defaults": {
+					"mappings": [
+						{ "options": { "0": { "color": "red", "text": "DOWN" } }, "type": "value" },
+						{ "options": { "1": { "color": "green", "text": "UP" } }, "type": "value" }
+					],
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{ "color": "red", "value": null },
+							{ "color": "green", "value": 1 }
+						]
+					}
+				},
+				"overrides": []
+			},
+			"gridPos": { "h": 5, "w": 24, "x": 0, "y": 0 },
+			"id": 1,
+			"options": {
+				"colorMode": "background",
+				"graphMode": "none",
+				"justifyMode": "auto",
+				"orientation": "horizontal",
+				"reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+				"textMode": "value_and_name"
+			},
+			"pluginVersion": "11.6.7",
+			"targets": [
+				{
+					"datasource": { "type": "prometheus", "uid": "prometheus" },
+					"expr": "up",
+					"legendFormat": "{{job}}",
+					"refId": "A"
+				}
+			],
+			"title": "Target health",
+			"type": "stat"
+		},
+		{
+			"datasource": { "type": "prometheus", "uid": "prometheus" },
+			"fieldConfig": {
+				"defaults": {
+					"color": { "mode": "palette-classic" },
+					"custom": { "axisLabel": "req/s", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "showPoints": "never" },
+					"unit": "reqps"
+				},
+				"overrides": []
+			},
+			"gridPos": { "h": 8, "w": 12, "x": 0, "y": 5 },
+			"id": 2,
+			"options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+			"targets": [
+				{
+					"datasource": { "type": "prometheus", "uid": "prometheus" },
+					"expr": "sum(rate(http_server_requests_seconds_count{job=\"spring\"}[5m]))",
+					"legendFormat": "spring",
+					"refId": "A"
+				},
+				{
+					"datasource": { "type": "prometheus", "uid": "prometheus" },
+					"expr": "sum(rate(http_requests_total{job=\"genai\"}[5m]))",
+					"legendFormat": "genai",
+					"refId": "B"
+				}
+			],
+			"title": "Request rate per service",
+			"type": "timeseries"
+		},
+		{
+			"datasource": { "type": "prometheus", "uid": "prometheus" },
+			"fieldConfig": {
+				"defaults": {
+					"color": { "mode": "palette-classic" },
+					"custom": { "axisLabel": "errors/s", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "showPoints": "never" },
+					"unit": "reqps"
+				},
+				"overrides": []
+			},
+			"gridPos": { "h": 8, "w": 12, "x": 12, "y": 5 },
+			"id": 3,
+			"options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+			"targets": [
+				{
+					"datasource": { "type": "prometheus", "uid": "prometheus" },
+					"expr": "sum(rate(http_server_requests_seconds_count{job=\"spring\", status=~\"4..\"}[5m]))",
+					"legendFormat": "spring 4xx",
+					"refId": "A"
+				},
+				{
+					"datasource": { "type": "prometheus", "uid": "prometheus" },
+					"expr": "sum(rate(http_server_requests_seconds_count{job=\"spring\", status=~\"5..\"}[5m]))",
+					"legendFormat": "spring 5xx",
+					"refId": "B"
+				},
+				{
+					"datasource": { "type": "prometheus", "uid": "prometheus" },
+					"expr": "sum(rate(http_requests_total{job=\"genai\", status=~\"4xx\"}[5m]))",
+					"legendFormat": "genai 4xx",
+					"refId": "C"
+				},
+				{
+					"datasource": { "type": "prometheus", "uid": "prometheus" },
+					"expr": "sum(rate(http_requests_total{job=\"genai\", status=~\"5xx\"}[5m]))",
+					"legendFormat": "genai 5xx",
+					"refId": "D"
+				}
+			],
+			"title": "Error rate (4xx / 5xx)",
+			"type": "timeseries"
+		},
+		{
+			"datasource": { "type": "prometheus", "uid": "prometheus" },
+			"fieldConfig": {
+				"defaults": {
+					"color": { "mode": "palette-classic" },
+					"custom": { "axisLabel": "seconds", "drawStyle": "line", "fillOpacity": 0, "lineWidth": 1, "showPoints": "never" },
+					"unit": "s"
+				},
+				"overrides": []
+			},
+			"gridPos": { "h": 8, "w": 12, "x": 0, "y": 13 },
+			"id": 4,
+			"options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+			"targets": [
+				{
+					"datasource": { "type": "prometheus", "uid": "prometheus" },
+					"expr": "histogram_quantile(0.50, sum(rate(http_server_requests_seconds_bucket{job=\"spring\"}[5m])) by (le))",
+					"legendFormat": "spring p50",
+					"refId": "A"
+				},
+				{
+					"datasource": { "type": "prometheus", "uid": "prometheus" },
+					"expr": "histogram_quantile(0.95, sum(rate(http_server_requests_seconds_bucket{job=\"spring\"}[5m])) by (le))",
+					"legendFormat": "spring p95",
+					"refId": "B"
+				},
+				{
+					"datasource": { "type": "prometheus", "uid": "prometheus" },
+					"expr": "histogram_quantile(0.99, sum(rate(http_server_requests_seconds_bucket{job=\"spring\"}[5m])) by (le))",
+					"legendFormat": "spring p99",
+					"refId": "C"
+				}
+			],
+			"title": "Spring latency percentiles",
+			"type": "timeseries"
+		},
+		{
+			"datasource": { "type": "prometheus", "uid": "prometheus" },
+			"fieldConfig": {
+				"defaults": {
+					"color": { "mode": "palette-classic" },
+					"custom": { "axisLabel": "seconds", "drawStyle": "line", "fillOpacity": 0, "lineWidth": 1, "showPoints": "never" },
+					"unit": "s"
+				},
+				"overrides": []
+			},
+			"gridPos": { "h": 8, "w": 12, "x": 12, "y": 13 },
+			"id": 5,
+			"options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+			"targets": [
+				{
+					"datasource": { "type": "prometheus", "uid": "prometheus" },
+					"expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket{job=\"genai\"}[5m])) by (le))",
+					"legendFormat": "genai p50",
+					"refId": "A"
+				},
+				{
+					"datasource": { "type": "prometheus", "uid": "prometheus" },
+					"expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{job=\"genai\"}[5m])) by (le))",
+					"legendFormat": "genai p95",
+					"refId": "B"
+				},
+				{
+					"datasource": { "type": "prometheus", "uid": "prometheus" },
+					"expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{job=\"genai\"}[5m])) by (le))",
+					"legendFormat": "genai p99",
+					"refId": "C"
+				}
+			],
+			"title": "GenAI latency percentiles",
+			"type": "timeseries"
+		},
+		{
+			"datasource": { "type": "prometheus", "uid": "prometheus" },
+			"fieldConfig": {
+				"defaults": {
+					"color": { "mode": "palette-classic" },
+					"custom": { "axisLabel": "req/s", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "showPoints": "never" },
+					"unit": "reqps"
+				},
+				"overrides": []
+			},
+			"gridPos": { "h": 8, "w": 24, "x": 0, "y": 21 },
+			"id": 6,
+			"options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+			"targets": [
+				{
+					"datasource": { "type": "prometheus", "uid": "prometheus" },
+					"expr": "sum(rate(traefik_entrypoint_requests_total{entrypoint=\"web\"}[5m])) by (code)",
+					"legendFormat": "{{code}}",
+					"refId": "A"
+				}
+			],
+			"title": "Traefik web entrypoint requests by status code",
+			"type": "timeseries"
+		}
+	],
+	"preload": false,
+	"refresh": "30s",
+	"schemaVersion": 39,
+	"tags": ["alexandria"],
+	"templating": { "list": [] },
+	"time": { "from": "now-30m", "to": "now" },
+	"timepicker": {},
+	"timezone": "browser",
+	"title": "Alexandria Overview",
+	"uid": "alexandria-overview",
+	"version": 1,
+	"weekStart": ""
+}

--- a/infra/grafana/dashboards/spring.json
+++ b/infra/grafana/dashboards/spring.json
@@ -1,0 +1,201 @@
+{
+	"annotations": {
+		"list": [
+			{
+				"builtIn": 1,
+				"datasource": { "type": "grafana", "uid": "-- Grafana --" },
+				"enable": true,
+				"hide": true,
+				"iconColor": "rgba(0, 211, 255, 1)",
+				"name": "Annotations & Alerts",
+				"type": "dashboard"
+			}
+		]
+	},
+	"editable": true,
+	"fiscalYearStartMonth": 0,
+	"graphTooltip": 1,
+	"links": [],
+	"panels": [
+		{
+			"datasource": { "type": "prometheus", "uid": "prometheus" },
+			"fieldConfig": {
+				"defaults": {
+					"color": { "mode": "palette-classic" },
+					"custom": { "axisLabel": "bytes", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "showPoints": "never", "stacking": { "mode": "normal" } },
+					"unit": "bytes"
+				},
+				"overrides": []
+			},
+			"gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+			"id": 1,
+			"options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+			"targets": [
+				{
+					"datasource": { "type": "prometheus", "uid": "prometheus" },
+					"expr": "sum(jvm_memory_used_bytes{job=\"spring\", area=\"heap\"}) by (id)",
+					"legendFormat": "{{id}}",
+					"refId": "A"
+				}
+			],
+			"title": "JVM heap memory used",
+			"type": "timeseries"
+		},
+		{
+			"datasource": { "type": "prometheus", "uid": "prometheus" },
+			"fieldConfig": {
+				"defaults": {
+					"color": { "mode": "palette-classic" },
+					"custom": { "axisLabel": "bytes", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "showPoints": "never", "stacking": { "mode": "normal" } },
+					"unit": "bytes"
+				},
+				"overrides": []
+			},
+			"gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+			"id": 2,
+			"options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+			"targets": [
+				{
+					"datasource": { "type": "prometheus", "uid": "prometheus" },
+					"expr": "sum(jvm_memory_used_bytes{job=\"spring\", area=\"nonheap\"}) by (id)",
+					"legendFormat": "{{id}}",
+					"refId": "A"
+				}
+			],
+			"title": "JVM non-heap memory used",
+			"type": "timeseries"
+		},
+		{
+			"datasource": { "type": "prometheus", "uid": "prometheus" },
+			"fieldConfig": {
+				"defaults": {
+					"color": { "mode": "palette-classic" },
+					"custom": { "axisLabel": "seconds/s", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "showPoints": "never" },
+					"unit": "s"
+				},
+				"overrides": []
+			},
+			"gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+			"id": 3,
+			"options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+			"targets": [
+				{
+					"datasource": { "type": "prometheus", "uid": "prometheus" },
+					"expr": "sum(rate(jvm_gc_pause_seconds_sum{job=\"spring\"}[5m])) by (cause)",
+					"legendFormat": "{{cause}}",
+					"refId": "A"
+				}
+			],
+			"title": "GC pause time per second",
+			"type": "timeseries"
+		},
+		{
+			"datasource": { "type": "prometheus", "uid": "prometheus" },
+			"fieldConfig": {
+				"defaults": {
+					"color": { "mode": "palette-classic" },
+					"custom": { "axisLabel": "threads", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "showPoints": "never" },
+					"unit": "short"
+				},
+				"overrides": []
+			},
+			"gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+			"id": 4,
+			"options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+			"targets": [
+				{
+					"datasource": { "type": "prometheus", "uid": "prometheus" },
+					"expr": "jvm_threads_live_threads{job=\"spring\"}",
+					"legendFormat": "live threads",
+					"refId": "A"
+				},
+				{
+					"datasource": { "type": "prometheus", "uid": "prometheus" },
+					"expr": "jvm_threads_daemon_threads{job=\"spring\"}",
+					"legendFormat": "daemon threads",
+					"refId": "B"
+				}
+			],
+			"title": "JVM threads",
+			"type": "timeseries"
+		},
+		{
+			"datasource": { "type": "prometheus", "uid": "prometheus" },
+			"fieldConfig": {
+				"defaults": {
+					"color": { "mode": "palette-classic" },
+					"custom": { "axisLabel": "seconds", "drawStyle": "line", "fillOpacity": 0, "lineWidth": 1, "showPoints": "never" },
+					"unit": "s"
+				},
+				"overrides": []
+			},
+			"gridPos": { "h": 8, "w": 24, "x": 0, "y": 16 },
+			"id": 5,
+			"options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+			"targets": [
+				{
+					"datasource": { "type": "prometheus", "uid": "prometheus" },
+					"expr": "histogram_quantile(0.95, sum(rate(http_server_requests_seconds_bucket{job=\"spring\", uri!~\"/actuator.*\"}[5m])) by (le, uri))",
+					"legendFormat": "p95 {{uri}}",
+					"refId": "A"
+				}
+			],
+			"title": "HTTP p95 latency by endpoint",
+			"type": "timeseries"
+		},
+		{
+			"datasource": { "type": "prometheus", "uid": "prometheus" },
+			"fieldConfig": {
+				"defaults": {
+					"color": { "mode": "palette-classic" },
+					"custom": { "axisLabel": "connections", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "showPoints": "never" },
+					"unit": "short"
+				},
+				"overrides": []
+			},
+			"gridPos": { "h": 8, "w": 24, "x": 0, "y": 24 },
+			"id": 6,
+			"options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+			"targets": [
+				{
+					"datasource": { "type": "prometheus", "uid": "prometheus" },
+					"expr": "hikaricp_connections_active{job=\"spring\"}",
+					"legendFormat": "active",
+					"refId": "A"
+				},
+				{
+					"datasource": { "type": "prometheus", "uid": "prometheus" },
+					"expr": "hikaricp_connections_idle{job=\"spring\"}",
+					"legendFormat": "idle",
+					"refId": "B"
+				},
+				{
+					"datasource": { "type": "prometheus", "uid": "prometheus" },
+					"expr": "hikaricp_connections{job=\"spring\"}",
+					"legendFormat": "total",
+					"refId": "C"
+				},
+				{
+					"datasource": { "type": "prometheus", "uid": "prometheus" },
+					"expr": "hikaricp_connections_pending{job=\"spring\"}",
+					"legendFormat": "pending",
+					"refId": "D"
+				}
+			],
+			"title": "HikariCP database connection pool",
+			"type": "timeseries"
+		}
+	],
+	"preload": false,
+	"refresh": "30s",
+	"schemaVersion": 39,
+	"tags": ["alexandria", "spring"],
+	"templating": { "list": [] },
+	"time": { "from": "now-30m", "to": "now" },
+	"timepicker": {},
+	"timezone": "browser",
+	"title": "Alexandria Spring",
+	"uid": "alexandria-spring",
+	"version": 1,
+	"weekStart": ""
+}

--- a/infra/grafana/provisioning/dashboards/dashboards.yml
+++ b/infra/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: Alexandria
+    orgId: 1
+    folder: Alexandria
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/infra/grafana/provisioning/datasources/prometheus.yml
+++ b/infra/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    uid: prometheus
+    type: prometheus
+    access: proxy
+    # Prometheus runs behind the /prometheus route prefix, so Grafana queries
+    # have to include it as well.
+    url: http://prometheus:9090/prometheus
+    isDefault: true
+    editable: false

--- a/infra/prometheus/alert.rules.yml
+++ b/infra/prometheus/alert.rules.yml
@@ -1,0 +1,40 @@
+groups:
+  - name: alexandria
+    rules:
+      # Any scrape target that stops responding for a minute is considered down.
+      - alert: ServiceDown
+        expr: up == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "{{ $labels.job }} target is down"
+          description: "Prometheus has not been able to scrape {{ $labels.instance }} ({{ $labels.job }}) for over a minute."
+
+      # More than 5% of Spring HTTP responses are 5xx over the last 5 minutes.
+      - alert: SpringHighErrorRate
+        expr: |
+          sum(rate(http_server_requests_seconds_count{job="spring", status=~"5.."}[5m]))
+            /
+          sum(rate(http_server_requests_seconds_count{job="spring"}[5m]))
+            > 0.05
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Spring 5xx error rate above 5%"
+          description: "More than 5% of Spring requests have failed with a 5xx status over the last 5 minutes."
+
+      # GenAI 95th percentile request latency stays above 2s.
+      - alert: GenAiSlowResponses
+        expr: |
+          histogram_quantile(
+            0.95,
+            sum(rate(http_request_duration_seconds_bucket{job="genai"}[5m])) by (le)
+          ) > 2
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "GenAI p95 latency above 2s"
+          description: "The 95th percentile of GenAI request latency has been above 2 seconds for 5 minutes."

--- a/infra/prometheus/prometheus.yml
+++ b/infra/prometheus/prometheus.yml
@@ -1,0 +1,30 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+rule_files:
+  - /etc/prometheus/alert.rules.yml
+
+scrape_configs:
+  # Prometheus scrapes itself so we can alert if it ever stops collecting.
+  - job_name: prometheus
+    metrics_path: /prometheus/metrics
+    static_configs:
+      - targets: ["localhost:9090"]
+
+  # Spring Boot exposes Micrometer metrics via the Actuator Prometheus endpoint.
+  - job_name: spring
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ["spring:8080"]
+
+  # GenAI (FastAPI) exposes metrics via prometheus-fastapi-instrumentator.
+  - job_name: genai
+    metrics_path: /genai/metrics
+    static_configs:
+      - targets: ["genai:8000"]
+
+  # Traefik exposes proxy-level request metrics on the dedicated metrics entrypoint.
+  - job_name: traefik
+    static_configs:
+      - targets: ["traefik:8082"]


### PR DESCRIPTION
## What does this PR do?

Adds a Prometheus + Grafana monitoring stack to `docker-compose.yml`. Prometheus scrapes Spring (`/actuator/prometheus`), GenAI (`/genai/metrics`), Traefik, and itself; Grafana auto-provisions the datasource and three dashboards. Both are reachable through Traefik at `/prometheus` and `/grafana`.

Spring and GenAI already expose their metrics endpoints (#140, #141), so this is the piece that actually collects and visualizes them.

Closes #139, closes #142.

### To view locally

```bash
docker compose up -d
# generate a bit of traffic so the rate panels aren't flat
for i in $(seq 1 30); do curl -s http://localhost/hello >/dev/null; curl -s http://localhost/genai/health >/dev/null; sleep 1; done
```

Then open Grafana at http://localhost/grafana/ (login `admin` / `admin`). The three dashboards live in the "Alexandria" folder, or jump straight to them:

- Overview: http://localhost/grafana/d/alexandria-overview
- Spring: http://localhost/grafana/d/alexandria-spring
- GenAI: http://localhost/grafana/d/alexandria-genai

Prometheus (targets, raw queries): http://localhost/prometheus/

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [x] CI / infra

## Definition of Done

- [x] CI is green
- [x] If the API changed: `api/openapi.yaml` is updated and lint passes (no API change)
- [x] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [x] Tests added or updated for the changed behaviour (n/a, config only)
- [x] Docs updated where it matters (README, ADRs, comments)

## Notes for the reviewer

A few things I changed from the issue descriptions on purpose:

- I confirmed every metric name against the live endpoints instead of trusting the issue. GenAI's instrumentator reports `status` as `2xx`/`5xx` (not `200`/`500`) and uses `http_requests_total` / `http_request_duration_seconds`; Spring uses `http_server_requests_seconds_*`. The dashboards and alerts query the real series.
- Traefik had no metrics enabled, so I added a dedicated internal `metrics` entrypoint on `:8082` (not bound to the public `web` entrypoint) and scrape that, rather than the `traefik:8080` target the issue suggested.

Three alert rules are defined: `ServiceDown`, `SpringHighErrorRate`, `GenAiSlowResponses`.

Verified locally: full stack comes up healthy, all four scrape targets are up, `promtool check config` passes, and every dashboard panel returns live data when queried through Grafana.

@BjarneHa this only covers docker-compose. The Kubernetes side (#143) is still open and it's yours, could you pick it up? Worth deciding early whether the cluster already has the Prometheus operator / kube-prometheus-stack available or whether we ship our own Prometheus + Grafana in a `monitoring` namespace, since that changes whether we use ServiceMonitor CRDs or plain scrape config. The scrape targets, alert rules and dashboard JSON here should port over more or less as-is.

Grafana defaults to `admin` / `admin` locally, override with `GRAFANA_ADMIN_PASSWORD`.
