### PR TITLE
fix: raise keycloak healthcheck start_period to 240s

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -162,7 +162,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-      start_period: 120s
+      start_period: 240s
 
   postgres-db:
     image: postgres:16-alpine


### PR DESCRIPTION
See #161 