### PR TITLE
CI: Harden workflows, extend dependabot, widen CodeQL matrix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+      semver-patch-days: 3
+      semver-minor-days: 7
     groups:
       gha-minor:
         update-types: [minor, patch]
@@ -14,6 +18,10 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+      semver-patch-days: 3
+      semver-minor-days: 7
     groups:
       spring-boot:
         patterns:
@@ -23,7 +31,50 @@ updates:
         update-types: [minor, patch]
 
   - package-ecosystem: docker
-    directory: "/services/spring"
+    directories:
+      - "/services/spring"
+      - "/services/genai"
+      - "/services/client"
     schedule:
       interval: weekly
     open-pull-requests-limit: 3
+    cooldown:
+      default-days: 7
+      semver-patch-days: 3
+      semver-minor-days: 7
+
+  - package-ecosystem: npm
+    directory: "/services/client"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+      semver-patch-days: 3
+      semver-minor-days: 7
+    groups:
+      npm-minor:
+        update-types: [minor, patch]
+
+  - package-ecosystem: uv
+    directory: "/services/genai"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+      semver-patch-days: 3
+      semver-minor-days: 7
+    groups:
+      uv-minor:
+        update-types: [minor, patch]
+
+  - package-ecosystem: terraform
+    directory: "/infra/azure/terraform"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    cooldown:
+      default-days: 7
+      semver-patch-days: 3
+      semver-minor-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       workflows: ${{ steps.filter.outputs.workflows }}
       docs: ${{ steps.filter.outputs.docs }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - id: filter
         uses: dorny/paths-filter@v4
         with:
@@ -91,7 +91,7 @@ jobs:
     if: needs.changes.outputs.api == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -117,7 +117,7 @@ jobs:
           - services/client/Dockerfile
           - services/genai/Dockerfile
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: hadolint/hadolint-action@v3.3.0
         with:
           dockerfile: ${{ matrix.dockerfile }}
@@ -135,7 +135,7 @@ jobs:
     if: needs.changes.outputs.workflows == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run actionlint
         # Pinned to the project's actionlint container so the version is reproducible.
         run: |
@@ -164,7 +164,7 @@ jobs:
       contents: read
       checks: write # for test report annotations
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         if: env.RUN_JOB == 'true'
 
       - name: Setup Java
@@ -216,7 +216,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -252,7 +252,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup uv
         uses: astral-sh/setup-uv@v7
@@ -310,7 +310,7 @@ jobs:
       packages: write # needed to push to GHCR on main
       security-events: write # for Trivy SARIF upload
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         if: env.RUN_JOB == 'true'
 
       - name: Setup Buildx
@@ -385,7 +385,7 @@ jobs:
       (needs.changes.outputs.spring == 'true' || needs.changes.outputs.client == 'true' || needs.changes.outputs.genai == 'true' || needs.changes.outputs.docker == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Bring Stack Up
         # --wait blocks until every service reports healthy (or the timeout
@@ -419,7 +419,7 @@ jobs:
       TEST_USER: ${{ vars.TEST_USER }}
       TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Bring Stack Up
         # --wait gates on healthchecks; Keycloak's reports ready only once the
@@ -537,7 +537,7 @@ jobs:
     needs: [build-image, ci-summary]
     environment: AZURE
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup SSH Key
         run: |
@@ -573,7 +573,7 @@ jobs:
     needs: [build-image, ci-summary]
     environment: STUD
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup Helm
         uses: azure/setup-helm@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,10 @@ jobs:
       docs: ${{ steps.filter.outputs.docs }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - id: filter
-        uses: dorny/paths-filter@v4
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         with:
           filters: |
             api:
@@ -92,6 +94,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -118,7 +122,9 @@ jobs:
           - services/genai/Dockerfile
     steps:
       - uses: actions/checkout@v7
-      - uses: hadolint/hadolint-action@v3.3.0
+        with:
+          persist-credentials: false
+      - uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
         with:
           dockerfile: ${{ matrix.dockerfile }}
           # The repo-wide config defines our shared rules / ignores.
@@ -136,11 +142,36 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Run actionlint
         # Pinned to the project's actionlint container so the version is reproducible.
         run: |
           bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
           ./actionlint -color
+
+  # ---------------------------------------------------------------------
+  # zizmor: static security analysis for the workflow files themselves.
+  # Runs alongside lint-workflows so a new workflow can't reintroduce a
+  # known class of issue.
+  # ---------------------------------------------------------------------
+  zizmor:
+    name: zizmor (Workflow Security Scan)
+    needs: changes
+    if: needs.changes.outputs.workflows == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # to clone the repo for scanning
+      actions: read  # to inspect workflow metadata
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        with:
+          advanced-security: false
 
   # ---------------------------------------------------------------------
   # Spring service: compile, test, package. Matrix-ready for when there
@@ -166,6 +197,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         if: env.RUN_JOB == 'true'
+        with:
+          persist-credentials: false
 
       - name: Setup Java
         if: env.RUN_JOB == 'true'
@@ -176,7 +209,7 @@ jobs:
 
       - name: Setup Gradle (with Build Cache)
         if: env.RUN_JOB == 'true'
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
         with:
           cache-read-only: ${{ github.event_name == 'pull_request' }}
 
@@ -217,6 +250,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -253,9 +288,11 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
           cache-dependency-glob: services/genai/uv.lock
@@ -312,15 +349,17 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         if: env.RUN_JOB == 'true'
+        with:
+          persist-credentials: false
 
       - name: Setup Buildx
         if: env.RUN_JOB == 'true'
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Extract Image Metadata
         if: env.RUN_JOB == 'true'
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.service.name }}
           tags: |
@@ -331,7 +370,7 @@ jobs:
 
       - name: Login to GHCR
         if: github.event_name == 'push' && env.RUN_JOB == 'true'
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -340,7 +379,7 @@ jobs:
       - name: Build (and Push on main)
         if: env.RUN_JOB == 'true'
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: ${{ matrix.service.context }}
           file: ${{ matrix.service.dockerfile }}
@@ -354,7 +393,7 @@ jobs:
 
       - name: Run Trivy Scan (Image)
         if: env.RUN_JOB == 'true'
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
           format: sarif
@@ -386,6 +425,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Bring Stack Up
         # --wait blocks until every service reports healthy (or the timeout
@@ -420,6 +461,8 @@ jobs:
       TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Bring Stack Up
         # --wait gates on healthchecks; Keycloak's reports ready only once the
@@ -507,6 +550,7 @@ jobs:
       - lint-openapi
       - lint-dockerfiles
       - lint-workflows
+      - zizmor
       - build-spring
       - build-client
       - build-genai
@@ -538,30 +582,39 @@ jobs:
     environment: AZURE
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Setup SSH Key
+        env:
+          AZURE_PRIVATE_KEY: ${{ secrets.AZURE_PRIVATE_KEY }}
         run: |
           install -m 700 -d ~/.ssh
-          echo "${{ secrets.AZURE_PRIVATE_KEY }}" > ~/.ssh/azure_key
+          printf '%s\n' "$AZURE_PRIVATE_KEY" > ~/.ssh/azure_key
           chmod 600 ~/.ssh/azure_key
-          ssh-keyscan -H "${{ env.AZURE_PUBLIC_IP }}" >> ~/.ssh/known_hosts
+          ssh-keyscan -H "$AZURE_PUBLIC_IP" >> ~/.ssh/known_hosts
 
       - name: Prepare Remote Directory
         run: |
-          ssh -i ~/.ssh/azure_key "${{ env.AZURE_USER }}@${{ env.AZURE_PUBLIC_IP }}" \
+          ssh -i ~/.ssh/azure_key "$AZURE_USER@$AZURE_PUBLIC_IP" \
             "rm -rf ~/deploy/infra/prometheus ~/deploy/infra/grafana && mkdir -p ~/deploy/infra/oidc ~/deploy/infra/prometheus ~/deploy/infra/grafana"
 
       - name: Copy Compose and Config
         run: |
-          scp -i ~/.ssh/azure_key docker-compose.yml "${{ env.AZURE_USER }}@${{ env.AZURE_PUBLIC_IP }}:~/deploy/docker-compose.yml"
-          scp -i ~/.ssh/azure_key infra/oidc/realm.json "${{ env.AZURE_USER }}@${{ env.AZURE_PUBLIC_IP }}:~/deploy/infra/oidc/realm.json"
-          scp -r -i ~/.ssh/azure_key infra/prometheus/. "${{ env.AZURE_USER }}@${{ env.AZURE_PUBLIC_IP }}:~/deploy/infra/prometheus/"
-          scp -r -i ~/.ssh/azure_key infra/grafana/. "${{ env.AZURE_USER }}@${{ env.AZURE_PUBLIC_IP }}:~/deploy/infra/grafana/"
+          scp -i ~/.ssh/azure_key docker-compose.yml "$AZURE_USER@$AZURE_PUBLIC_IP:~/deploy/docker-compose.yml"
+          scp -i ~/.ssh/azure_key infra/oidc/realm.json "$AZURE_USER@$AZURE_PUBLIC_IP:~/deploy/infra/oidc/realm.json"
+          scp -r -i ~/.ssh/azure_key infra/prometheus/. "$AZURE_USER@$AZURE_PUBLIC_IP:~/deploy/infra/prometheus/"
+          scp -r -i ~/.ssh/azure_key infra/grafana/. "$AZURE_USER@$AZURE_PUBLIC_IP:~/deploy/infra/grafana/"
 
       - name: Deploy
+        # GITHUB_TOKEN and github.actor are passed through env so an
+        # attacker-controlled username can't escape into the remote shell.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTOR: ${{ github.actor }}
         run: |
-          ssh -i ~/.ssh/azure_key "${{ env.AZURE_USER }}@${{ env.AZURE_PUBLIC_IP }}" \
-            "cd ~/deploy && echo '${{ secrets.GITHUB_TOKEN }}' | docker login ${{ env.REGISTRY }} -u '${{ github.actor }}' --password-stdin && docker compose pull && docker compose up -d"
+          ssh -i ~/.ssh/azure_key "$AZURE_USER@$AZURE_PUBLIC_IP" \
+            "cd ~/deploy && printf '%s\n' \"$GH_TOKEN\" | docker login \"$REGISTRY\" -u \"$ACTOR\" --password-stdin && docker compose pull && docker compose up -d"
 
   # ---------------------------------------------------------------------
   # Deploy to stud cluster (Rancher/k8s)
@@ -574,21 +627,25 @@ jobs:
     environment: STUD
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Setup Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5
         with:
           version: v3.18.4
 
       - name: Setup kubectl
-        uses: azure/setup-kubectl@v5
+        uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5
         with:
           version: v1.32.4
 
       - name: Configure kubeconfig
+        env:
+          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
         run: |
           mkdir -p ~/.kube
-          echo "${{ secrets.KUBE_CONFIG }}" > ~/.kube/config
+          printf '%s\n' "$KUBE_CONFIG" > ~/.kube/config
           chmod 600 ~/.kube/config
 
       - name: Update Helm Dependencies
@@ -596,16 +653,22 @@ jobs:
         run: helm dependency update
 
       - name: Deploy with Helm
+        # Secrets are passed through env so they don't hit shell expansion.
+        env:
+          IMAGE_TAG: ${{ needs.build-image.outputs.image-tag }}
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+          KC_BOOTSTRAP_ADMIN_USERNAME: ${{ secrets.KC_BOOTSTRAP_ADMIN_USERNAME }}
+          KC_BOOTSTRAP_ADMIN_PASSWORD: ${{ secrets.KC_BOOTSTRAP_ADMIN_PASSWORD }}
         working-directory: infra/k8s/alexandria
         run: |
           helm upgrade --install alexandria . \
             --namespace alexandria \
-            --set "image.tag=${{ needs.build-image.outputs.image-tag }}" \
-            --set "spring.database.password=${{ secrets.POSTGRES_PASSWORD }}" \
-            --set "keycloak.adminUser=${{ secrets.KC_BOOTSTRAP_ADMIN_USERNAME }}" \
-            --set "keycloak.adminPassword=${{ secrets.KC_BOOTSTRAP_ADMIN_PASSWORD }}" \
-            --set "keycloak.database.password=${{ secrets.POSTGRES_PASSWORD }}" \
-            --set "postgres-db.auth.password=${{ secrets.POSTGRES_PASSWORD }}" \
+            --set "image.tag=$IMAGE_TAG" \
+            --set "spring.database.password=$POSTGRES_PASSWORD" \
+            --set "keycloak.adminUser=$KC_BOOTSTRAP_ADMIN_USERNAME" \
+            --set "keycloak.adminPassword=$KC_BOOTSTRAP_ADMIN_PASSWORD" \
+            --set "keycloak.database.password=$POSTGRES_PASSWORD" \
+            --set "postgres-db.auth.password=$POSTGRES_PASSWORD" \
             --wait \
             --timeout 5m
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,7 +38,7 @@ jobs:
       matrix:
         language: [java-kotlin]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup Java
         uses: actions/setup-java@v5

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,11 +9,15 @@ on:
     branches: [main]
     paths:
       - 'services/spring/**'
+      - 'services/genai/**'
+      - 'services/client/**'
       - '.github/workflows/codeql.yml'
   push:
     branches: [main]
     paths:
       - 'services/spring/**'
+      - 'services/genai/**'
+      - 'services/client/**'
   schedule:
     - cron: '17 4 * * 1'
 
@@ -26,21 +30,32 @@ permissions:
 
 jobs:
   analyze:
-    name: Analyze ${{ matrix.language == 'java-kotlin' && 'Java/Kotlin' }}
+    name: Analyze ${{ matrix.display }}
     runs-on: ubuntu-latest
     permissions:
-      security-events: write
-      packages: read
-      actions: read
-      contents: read
+      security-events: write # upload SARIF findings to the Security tab
+      packages: read         # read GHCR packages during Java autobuild
+      actions: read           # required to read workflow metadata
+      contents: read          # checkout of the repo under test
     strategy:
       fail-fast: false
       matrix:
-        language: [java-kotlin]
+        include:
+          - language: java-kotlin
+            display: Java/Kotlin
+          - language: python
+            display: Python
+          - language: javascript-typescript
+            display: JavaScript/TypeScript
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Setup Java
+        # Only the Java/Kotlin path needs Gradle. Python and JS/TS use
+        # CodeQL's no-build analysis, so the autobuild step alone is enough.
+        if: matrix.language == 'java-kotlin'
         uses: actions/setup-java@v5
         with:
           java-version: '21'
@@ -53,6 +68,7 @@ jobs:
           queries: security-and-quality
 
       - name: Build (Manual Mode for Reliability)
+        if: matrix.language == 'java-kotlin'
         working-directory: services/spring/app
         run: ./gradlew --no-daemon assemble
 

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,13 @@
+# zizmor audit configuration.
+# Docs: https://docs.zizmor.sh/configuration/
+#
+# Pinning policy: third-party actions are SHA-pinned (we want zizmor to fail
+# if a new third-party use is tag-only). First-party actions/ actions and
+# the CodeQL action are kept on tag refs.
+
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        actions/*: ref-pin
+        github/codeql-action/*: ref-pin


### PR DESCRIPTION
## What does this PR do?

Closes #173, #176, #179.

- #173: harden workflows per zizmor. Move `${{ }}` expansions out of `run:` blocks into step `env:`, add `persist-credentials: false` to every `actions/checkout`, SHA-pin third-party actions, add a `zizmor` job as a regression guard.
- #176: extend `dependabot.yml` to npm, uv, docker (genai + client), and terraform. Add `cooldown` (`default-days: 7`, patch 3, minor 7) to every ecosystem.
- #179: add `python` and `javascript-typescript` to the CodeQL matrix, guard the Gradle build to `java-kotlin`, widen `paths:` triggers to genai and client.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [x] CI / infra

## Definition of Done

- [x] CI is green
- [ ] If the API changed: `api/openapi.yaml` is updated and lint passes
- [ ] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [ ] Tests added or updated for the changed behaviour
- [ ] Docs updated where it matters (README, ADRs, comments)

## Notes for the reviewer

- Verified locally: `actionlint` clean, `zizmor` (default persona) 0 findings, `dependabot.yml` valid per schemastore dependabot-2.0 schema.
- First-party actions stay on tag refs by policy; see `.github/zizmor.yml`.
- Also adds typos to `.pre-commit-config.yml` (Kudos @ladu-tu #191)
