### PR TITLE
Task: Fix missing Spring Env Var in Helm Config Mapping

### DIFF
--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -77,7 +77,7 @@ kubectl -n alexandria get ingress
 
 # Kubernetes Troubleshooting
 
-**Spring or Keycloak fail postgres password authentication after a reinstall**
+### Spring or Keycloak fail postgres password authentication after a reinstall
 
 The postgres subchart creates a PersistentVolumeClaim that survives `helm uninstall`. On a subsequent install, postgres reuses the existing data directory (with the old password) and ignores the new `POSTGRES_PASSWORD` value, causing spring and keycloak to fail authentication.
 
@@ -90,4 +90,9 @@ helm install alexandria infra/k8s/alexandria \
   --namespace alexandria --create-namespace \
   --dependency-update \
   -f infra/k8s/alexandria/values-secrets.yaml
+```
+### Getting Pod Logs from Cluster Deployment
+To show logs from a remote cluster, you can run
+```bash
+kubectl -n alexandria logs <pod name>
 ```

--- a/infra/k8s/alexandria/templates/spring-configmap.yaml
+++ b/infra/k8s/alexandria/templates/spring-configmap.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "alexandria.labels" . | nindent 4 }}
     app: spring
 data:
+  SPRING_LOG_LEVEL: {{ .Values.spring.logLevel | quote }}
   POSTGRES_HOST: {{ .Values.spring.database.host | quote }}
   POSTGRES_PORT: {{ .Values.spring.database.port | quote }}
   POSTGRES_DB: {{ .Values.spring.database.name | quote }}

--- a/infra/k8s/alexandria/values.yaml
+++ b/infra/k8s/alexandria/values.yaml
@@ -11,6 +11,7 @@ image:
   tag: "latest"
 
 spring:
+  logLevel: "INFO"
   resources:
     requests:
       cpu: 250m

--- a/services/spring/app/src/main/resources/application.properties
+++ b/services/spring/app/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 spring.application.name=alexandria
-logging.level.root=${SPRING_LOG_LEVEL:INFO}
+logging.level.root=${SPRING_LOG_LEVEL}
 
 # API docs
 springdoc.api-docs.enabled=true

--- a/services/spring/app/src/main/resources/application.properties
+++ b/services/spring/app/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 spring.application.name=alexandria
-logging.level.root=${SPRING_LOG_LEVEL}
+logging.level.root=${SPRING_LOG_LEVEL:INFO}
 
 # API docs
 springdoc.api-docs.enabled=true
@@ -26,6 +26,7 @@ genai.base-url=${GENAI_BASE_URL}
 # Refer to https://grafana.com/docs/grafana-cloud/knowledge-graph/advanced-configuration/enable-prom-metrics-collection/application-frameworks/springboot/
 management.endpoint.prometheus.enabled=true
 management.endpoints.web.exposure.include=prometheus,health,info,metrics
+management.endpoint.health.probes.enabled=true
 management.metrics.distribution.percentiles-histogram.http.server.requests=true
 management.metrics.distribution.percentiles-histogram.http.client.requests=true
 


### PR DESCRIPTION
## What does this PR do?

<!-- Short description of the change. Reference any related issue: Closes #123 -->
This PR adresses the failing deployment to the STUD cluster. The issue was a missing Spring environment variable that wasn't set in the helm config mapping.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [X] CI / infra

## Definition of Done

- [ ] CI is green
- [ ] If the API changed: `api/openapi.yaml` is updated and lint passes
- [ ] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [ ] Tests added or updated for the changed behaviour
- [ ] Docs updated where it matters (README, ADRs, comments)

## Notes for the reviewer

<!-- Anything they should look at first, gotchas, screenshots, ... -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable Spring log level support in deployment settings, with a default of `INFO`.
  * Enabled Spring Boot health probe support for better service monitoring.

* **Documentation**
  * Improved Kubernetes troubleshooting guidance.
  * Added instructions for retrieving pod logs from a cluster deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->