### PR TITLE
Add resource limits to SeaweedFS bucket hooks

### DIFF
--- a/infra/k8s/alexandria/values.yaml
+++ b/infra/k8s/alexandria/values.yaml
@@ -201,6 +201,14 @@ seaweedfs:
     createBuckets:
       - name: "alexandria-storage"
         anonymousRead: false
+    createBucketsHook:
+      resources:
+        requests:
+          cpu: 50m
+          memory: 64Mi
+        limits:
+          cpu: 100m
+          memory: 128Mi
     resources:
       requests:
         cpu: 50m


### PR DESCRIPTION
## What does this PR do?

Our rancher instance requires all pods to have resource limits assigned to them. Without these, the deployment fails.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [X] CI / infra

## Definition of Done

- [x] CI is green
- [ ] If the API changed: `api/openapi.yaml` is updated and lint passes
- [ ] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [ ] Tests added or updated for the changed behaviour
- [ ] Docs updated where it matters (README, ADRs, comments)

## Notes for the reviewer

<!-- Anything they should look at first, gotchas, screenshots, ... -->
