### PR TITLE
Feat: Weaviate-backed RAG pipeline for GenAI (#180)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,10 +49,14 @@
 # CHUNK_SIZE=1000
 # CHUNK_OVERLAP=200
 
+# Number of chunks retrieved per question in /genai/ask
+# RAG_TOP_K=5
+
 # Weaviate (RAG vector database) URL. Only the genai service talks to it.
 # In docker-compose this is the in-network address; in k8s the genai
 # configmap wires the in-cluster service name automatically.
 # WEAVIATE_URL=http://weaviate:8080
+# WEAVIATE_GRPC_PORT=50051
 
 
 # ----------------------------------------------------------------------------------

--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,11 @@
 # OpenAI: use your sk-... key
 # LLM_API_KEY="lg-your-api-key"
 
+# Weaviate (RAG vector database) URL. Only the genai service talks to it.
+# In docker-compose this is the in-network address; in k8s the genai
+# configmap wires the in-cluster service name automatically.
+# WEAVIATE_URL=http://weaviate:8080
+
 
 # ----------------------------------------------------------------------------------
 # OpenID Connect

--- a/.env.example
+++ b/.env.example
@@ -40,10 +40,15 @@
 # LLM_API_KEY="lg-your-api-key"
 
 # Embedding provider for the RAG pipeline: "logos" (default), "openai", or
-# "ollama". The logos/openai providers reuse LLM_BASE_URL and LLM_API_KEY since
-# embeddings run on the same gateway as the chat model; ollama uses OLLAMA_BASE_URL.
+# "ollama". The logos/openai providers default to LLM_BASE_URL and LLM_API_KEY
+# so a single-provider setup needs no extra config; ollama uses OLLAMA_BASE_URL.
 # EMBEDDING_PROVIDER=logos
 # EMBEDDING_MODEL=Qwen/Qwen3-Embedding-8B
+
+# Override these only to run embeddings on a different endpoint/key than the chat
+# model (e.g. chat on Logos, embeddings on OpenAI). Fall back to LLM_* when unset.
+# EMBEDDING_BASE_URL=https://api.openai.com/v1
+# EMBEDDING_API_KEY="sk-your-embedding-key"
 
 # Chunking for indexing (characters per chunk and overlap between chunks)
 # CHUNK_SIZE=1000

--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,16 @@
 # OpenAI: use your sk-... key
 # LLM_API_KEY="lg-your-api-key"
 
+# Embedding provider for the RAG pipeline: "logos" (default), "openai", or
+# "ollama". The logos/openai providers reuse LLM_BASE_URL and LLM_API_KEY since
+# embeddings run on the same gateway as the chat model; ollama uses OLLAMA_BASE_URL.
+# EMBEDDING_PROVIDER=logos
+# EMBEDDING_MODEL=Qwen/Qwen3-Embedding-8B
+
+# Chunking for indexing (characters per chunk and overlap between chunks)
+# CHUNK_SIZE=1000
+# CHUNK_OVERLAP=200
+
 # Weaviate (RAG vector database) URL. Only the genai service talks to it.
 # In docker-compose this is the in-network address; in k8s the genai
 # configmap wires the in-cluster service name automatically.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -5,7 +5,7 @@ info:
   license:
     name: MIT
     identifier: MIT
-  version: 1.4.0
+  version: 1.5.0
 servers:
   - url: /
     description: Current server

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -404,6 +404,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/GenAiExtractResponse'
           description: Successful Response
+        '404':
+          description: Object not found
+        '415':
+          description: Object is not a supported file type
         '422':
           content:
             application/json:
@@ -472,6 +476,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/GenAiIndexResponse'
           description: Successful Response
+        '404':
+          description: Object not found
+        '415':
+          description: Object is not a supported file type
         '422':
           content:
             application/json:
@@ -537,6 +545,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/GenAiSummarizeResponse'
           description: Successful Response
+        '404':
+          description: Object not found
+        '415':
+          description: Object is not a supported file type
         '422':
           content:
             application/json:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -482,6 +482,44 @@ paths:
       summary: Index
       tags:
         - ai
+  /genai/index/{object_key}:
+    delete:
+      description: >-
+        Remove all indexed chunks for the document at the given object key.
+
+
+        Idempotent: deleting a document that was never indexed removes nothing
+        and
+
+        still returns 200. The :path converter keeps object keys that contain
+        slashes
+
+        intact.
+      operationId: delete_index_genai_index__object_key__delete
+      parameters:
+        - in: path
+          name: object_key
+          required: true
+          schema:
+            title: Object Key
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenAiDeleteIndexResponse'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      security: []
+      summary: Delete Index
+      tags:
+        - ai
   /genai/summarize:
     post:
       description: Summarize the document stored under the given object key.
@@ -706,6 +744,19 @@ components:
         - sourceObjectKeys
         - modelUsed
       title: GenAiAskResponse
+      type: object
+    GenAiDeleteIndexResponse:
+      properties:
+        chunksDeleted:
+          title: Chunksdeleted
+          type: integer
+        objectKey:
+          title: Objectkey
+          type: string
+      required:
+        - objectKey
+        - chunksDeleted
+      title: GenAiDeleteIndexResponse
       type: object
     GenAiExtractRequest:
       properties:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -353,14 +353,14 @@ paths:
   /genai/ask:
     post:
       description: >-
-        Answer a question grounded in the documents stored under the given
-        object keys.
+        Answer a question from chunks retrieved for the given documents.
 
 
-        Each object key is fetched from storage; keys that cannot be read are
-        skipped so a
+        The question is embedded and matched against the indexed chunks scoped
+        to the
 
-        single missing or unreadable document does not fail the whole request.
+        requested object keys; the answer cites the documents its chunks came
+        from.
       operationId: ask_genai_ask_post
       requestBody:
         content:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -447,6 +447,41 @@ paths:
       summary: Hello
       tags:
         - hello
+  /genai/index:
+    post:
+      description: >-
+        Chunk, embed, and index the document at the given object key into
+        Weaviate.
+
+
+        Re-indexing the same key replaces its existing chunks, so the call is
+        safe to
+
+        repeat (e.g. when Spring re-processes a document).
+      operationId: index_genai_index_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GenAiIndexRequest'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenAiIndexResponse'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      security: []
+      summary: Index
+      tags:
+        - ai
   /genai/summarize:
     post:
       description: Summarize the document stored under the given object key.
@@ -712,6 +747,32 @@ components:
         - type
         - confidence
       title: GenAiExtractedEntity
+      type: object
+    GenAiIndexRequest:
+      properties:
+        objectKey:
+          title: Objectkey
+          type: string
+      required:
+        - objectKey
+      title: GenAiIndexRequest
+      type: object
+    GenAiIndexResponse:
+      properties:
+        chunksIndexed:
+          title: Chunksindexed
+          type: integer
+        embeddingModel:
+          title: Embeddingmodel
+          type: string
+        objectKey:
+          title: Objectkey
+          type: string
+      required:
+        - objectKey
+        - chunksIndexed
+        - embeddingModel
+      title: GenAiIndexResponse
       type: object
     GenAiSummarizeRequest:
       properties:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -249,10 +249,7 @@ services:
       start_period: 10s
       timeout: 30s
 
-  # Vector database for the RAG pipeline. In-network only -- no Traefik route
-  # and no published ports. Only the genai service talks to it over the
-  # alexandria network. ENABLE_MODULES is empty because embeddings come from
-  # the genai service (see #182), not a Weaviate-side vectorizer.
+  # Vector store for RAG. In-network only, no published ports.
   weaviate:
     image: semitechnologies/weaviate:1.38.2
     container_name: weaviate
@@ -283,8 +280,6 @@ services:
       start_period: 30s
 
   # Throwaway Weaviate for the genai integration tests (test profile only).
-  # In-network, no published ports, ephemeral storage -- it holds nothing and is
-  # discarded with the test run, so the suite never touches real data.
   weaviate-test:
     image: semitechnologies/weaviate:1.38.2
     profiles:
@@ -305,10 +300,7 @@ services:
       retries: 12
       start_period: 20s
 
-  # Runs the genai test suite in a container against weaviate-test. Uses the uv
-  # image with the dev dependency group (the runtime image ships neither uv nor
-  # pytest) and mounts the source, so no Dockerfile change is needed. Run with:
-  #   docker compose run --rm genai-test
+  # Runs the genai test suite against weaviate-test (test profile only, see the genai README).
   genai-test:
     image: ghcr.io/astral-sh/uv:python3.14-alpine
     profiles:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,12 +114,14 @@ services:
       EMBEDDING_MODEL: ${EMBEDDING_MODEL:-Qwen/Qwen3-Embedding-8B}
       CHUNK_SIZE: ${CHUNK_SIZE:-1000}
       CHUNK_OVERLAP: ${CHUNK_OVERLAP:-200}
+      RAG_TOP_K: ${RAG_TOP_K:-5}
       S3_ENDPOINT: "http://s3-storage:8333"
       S3_REGION: ${S3_REGION:-eu-central-1}
       S3_ACCESS_KEY: ${S3_ACCESS_KEY:-admin}
       S3_SECRET_KEY: ${S3_SECRET_KEY:-locals3password}
       S3_BUCKET: ${S3_BUCKET:-alexandria-storage}
       WEAVIATE_URL: ${WEAVIATE_URL:-http://weaviate:8080}
+      WEAVIATE_GRPC_PORT: ${WEAVIATE_GRPC_PORT:-50051}
     restart: unless-stopped
     networks:
       - alexandria

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,6 +110,10 @@ services:
       LLM_BASE_URL: ${LLM_BASE_URL:-https://logos.aet.cit.tum.de/v1}
       LLM_MODEL: ${LLM_MODEL:-openai/gpt-oss-120b}
       LLM_API_KEY: ${LLM_API_KEY:-lg-your-api-key}
+      EMBEDDING_PROVIDER: ${EMBEDDING_PROVIDER:-logos}
+      EMBEDDING_MODEL: ${EMBEDDING_MODEL:-Qwen/Qwen3-Embedding-8B}
+      CHUNK_SIZE: ${CHUNK_SIZE:-1000}
+      CHUNK_OVERLAP: ${CHUNK_OVERLAP:-200}
       S3_ENDPOINT: "http://s3-storage:8333"
       S3_REGION: ${S3_REGION:-eu-central-1}
       S3_ACCESS_KEY: ${S3_ACCESS_KEY:-admin}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -280,6 +280,52 @@ services:
       retries: 5
       start_period: 30s
 
+  # Throwaway Weaviate for the genai integration tests (test profile only).
+  # In-network, no published ports, ephemeral storage -- it holds nothing and is
+  # discarded with the test run, so the suite never touches real data.
+  weaviate-test:
+    image: semitechnologies/weaviate:1.38.2
+    profiles:
+      - test
+    environment:
+      QUERY_DEFAULTS_LIMIT: 25
+      AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: "true"
+      PERSISTENCE_DATA_PATH: /var/lib/weaviate
+      ENABLE_MODULES: ""
+      DISABLE_TELEMETRY: "true"
+      CLUSTER_HOSTNAME: "node1"
+    networks:
+      - alexandria
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://localhost:8080/v1/.well-known/ready"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 20s
+
+  # Runs the genai test suite in a container against weaviate-test. Uses the uv
+  # image with the dev dependency group (the runtime image ships neither uv nor
+  # pytest) and mounts the source, so no Dockerfile change is needed. Run with:
+  #   docker compose run --rm genai-test
+  genai-test:
+    image: ghcr.io/astral-sh/uv:python3.14-alpine
+    profiles:
+      - test
+    working_dir: /app
+    environment:
+      WEAVIATE_URL: http://weaviate-test:8080
+      WEAVIATE_GRPC_PORT: "50051"
+      UV_CACHE_DIR: /tmp/uv-cache
+    volumes:
+      - ./services/genai:/app
+      - /app/.venv
+    networks:
+      - alexandria
+    depends_on:
+      weaviate-test:
+        condition: service_healthy
+    command: ["sh", "-c", "uv sync --frozen && uv run pytest"]
+
   traefik:
     image: traefik:v3.7
     container_name: traefik

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,6 +115,7 @@ services:
       S3_ACCESS_KEY: ${S3_ACCESS_KEY:-admin}
       S3_SECRET_KEY: ${S3_SECRET_KEY:-locals3password}
       S3_BUCKET: ${S3_BUCKET:-alexandria-storage}
+      WEAVIATE_URL: ${WEAVIATE_URL:-http://weaviate:8080}
     restart: unless-stopped
     networks:
       - alexandria
@@ -138,6 +139,8 @@ services:
       start_period: 5s
     depends_on:
       s3-storage:
+        condition: service_healthy
+      weaviate:
         condition: service_healthy
 
   keycloak:
@@ -211,7 +214,7 @@ services:
   s3-storage:
     image: chrislusf/seaweedfs:4.36
     container_name: s3-storage
-    # start master, volume and S3 gateway in a signle container.
+    # start master, volume and S3 gateway in a single container.
     # -metricsPort exposes a Prometheus pull endpoint on :9091/metrics for the s3-storage scrape job.
     command: "server -s3 -metricsPort=9091"
     environment:
@@ -239,6 +242,39 @@ services:
       interval: 1s
       start_period: 10s
       timeout: 30s
+
+  # Vector database for the RAG pipeline. In-network only -- no Traefik route
+  # and no published ports. Only the genai service talks to it over the
+  # alexandria network. ENABLE_MODULES is empty because embeddings come from
+  # the genai service (see #182), not a Weaviate-side vectorizer.
+  weaviate:
+    image: semitechnologies/weaviate:1.38.2
+    container_name: weaviate
+    environment:
+      QUERY_DEFAULTS_LIMIT: 25
+      AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: "true"
+      PERSISTENCE_DATA_PATH: /var/lib/weaviate
+      ENABLE_MODULES: ""
+      DISABLE_TELEMETRY: "true"
+      CLUSTER_HOSTNAME: "node1"
+    restart: unless-stopped
+    networks:
+      - alexandria
+    volumes:
+      - weaviate_data:/var/lib/weaviate
+    deploy:
+      resources:
+        limits:
+          cpus: "0.50"
+          memory: 512M
+    healthcheck:
+      # /.well-known/ready returns 200 with an empty body, so check the status
+      # code via wget's exit code rather than grepping the (empty) response.
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://localhost:8080/v1/.well-known/ready"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 30s
 
   traefik:
     image: traefik:v3.7
@@ -374,3 +410,4 @@ volumes:
   s3data:
   prometheus_data:
   grafana_data:
+  weaviate_data:

--- a/docs/Problem_Statement.md
+++ b/docs/Problem_Statement.md
@@ -21,7 +21,7 @@ The GenAI service is central to what Alexandria does. Every document that gets u
 2. Entity extraction: The GenAI identifies and tags key entities like dates, names, organizations, and main topics. These tags are used in the search and indexing system to categorize documents without manual tagging.
 3. Question answering (RAG): Users can ask natural-language questions about their documents. Using retrieval-augmented generation with a vector database (Weaviate), the system retrieves relevant document chunks and generates answers with references back to the source material.
 
-Alexandria supports both cloud-based models (OpenAI API) and local models (GPT4All / LLaMA) so it can run in environments where sending data to external APIs is not acceptable.
+Alexandria supports both cloud-based models (the TUM Logos gateway or the OpenAI API) and local models (via Ollama) so it can run in environments where sending data to external APIs is not acceptable. The same applies to the embedding model used for retrieval, which is provider-configurable in the same way.
 
 ## Scenarios
 

--- a/docs/System_Overview.md
+++ b/docs/System_Overview.md
@@ -44,14 +44,17 @@ Team member responsible for this subsystem: Bjarne Hansen
 
 ### GenAI Service: Python
 
-The GenAI service is an independent Python microservice that handles all AI-related processing:
-- Provides an endpoint that accepts document contents and returns a concise summary
-- Provides an endpoint that accepts document contents and extracts structured entities (dates, names etc.)
-- Provides an endpoint that accepts user questions in natural language and returns an answer based on data in the knowledge base. Also provides backlinks to source documents.
+The GenAI service is an independent Python microservice that handles all AI-related processing. It downloads the referenced document from object storage and extracts its text (plain UTF-8 or PDF) before processing.
 
-The GenAI service supports both cloud-based models (OpenAI API) and local models (GPT4All, LLaMA) via configuration. The active model provider is selected through environment variables so switching between cloud and local requires no code changes.
+- Summarize: returns a concise summary of the document at a given object key.
+- Extract: extracts structured entities (dates, names, organizations, topics).
+- Index: chunks the document, embeds each chunk, and stores the chunks in Weaviate. Re-indexing the same document replaces its chunks, so the call is idempotent.
+- Delete: removes a document's chunks from Weaviate so the index stays in sync when a document is deleted.
+- Ask: answers a natural-language question with retrieval-augmented generation and cites the source documents the answer came from.
 
-For the RAG pipeline, document chunks are stored in Weaviate (vector database). When a user asks a question, relevant chunks are retrieved and then passed as context to the LLM for answer generation.
+Both the chat model and the embedding model are provider-configurable through environment variables, so switching between the TUM Logos gateway, OpenAI, and a local Ollama requires no code changes. Embeddings default to `Qwen/Qwen3-Embedding-8B` via Logos.
+
+For the RAG pipeline, document text is chunked, embedded, and indexed in Weaviate when a document is added. On a question, the GenAI service embeds the question, retrieves the most similar chunks scoped to the user's documents, and passes those chunks to the LLM as context. The answer links back to the documents whose chunks fed it.
 
 Team member responsible for this subsystem: Dominic Prinz
 
@@ -66,7 +69,7 @@ Team member responsible for this subsystem: Niklas Ladurner
 
 ### Vector Database: Weaviate
 
-The Weaviate database stores document chunk embeddings for semantic search. Runs as a separate container, accessed by the GenAI service over HTTP.
+Weaviate stores document chunks for semantic retrieval: the chunk text, an externally supplied embedding vector, and source metadata (object key and chunk index). It runs as a separate in-network container, reached only by the GenAI service. Vectors are produced by the GenAI service rather than a Weaviate vectorizer module, so the collection uses self-provided vectors and is not tied to a specific embedding model. Because Weaviate locks the collection to the first vector's dimension, switching to an embedding model of a different size means re-indexing.
 
 Team member responsible for this subsystem: Dominic Prinz
 

--- a/infra/k8s/alexandria/templates/genai-configmap.yaml
+++ b/infra/k8s/alexandria/templates/genai-configmap.yaml
@@ -9,3 +9,4 @@ data:
   S3_ENDPOINT: {{ .Values.s3.endpoint | default (include "alexandria.s3Endpoint" .) | quote }}
   S3_REGION: {{ .Values.s3.region | quote }}
   S3_BUCKET: {{ .Values.s3.bucket | quote }}
+  WEAVIATE_URL: {{ .Values.weaviate.url | default (printf "http://%s-weaviate:8080" (include "alexandria.fullname" .)) | quote }}

--- a/infra/k8s/alexandria/templates/genai-configmap.yaml
+++ b/infra/k8s/alexandria/templates/genai-configmap.yaml
@@ -10,3 +10,4 @@ data:
   S3_REGION: {{ .Values.s3.region | quote }}
   S3_BUCKET: {{ .Values.s3.bucket | quote }}
   WEAVIATE_URL: {{ .Values.weaviate.url | default (printf "http://%s-weaviate:8080" (include "alexandria.fullname" .)) | quote }}
+  WEAVIATE_GRPC_PORT: {{ .Values.weaviate.grpcPort | default 50051 | quote }}

--- a/infra/k8s/alexandria/templates/weaviate-deployment.yaml
+++ b/infra/k8s/alexandria/templates/weaviate-deployment.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "alexandria.fullname" . }}-weaviate
+  labels:
+    {{- include "alexandria.labels" . | nindent 4 }}
+    app: weaviate
+    app.kubernetes.io/component: vector-database
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "alexandria.selectorLabels" . | nindent 6 }}
+      app: weaviate
+  template:
+    metadata:
+      labels:
+        {{- include "alexandria.selectorLabels" . | nindent 8 }}
+        app: weaviate
+        app.kubernetes.io/component: vector-database
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: weaviate
+          image: {{ .Values.weaviate.image.repository }}:{{ .Values.weaviate.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 50051
+              protocol: TCP
+          env:
+            # ENABLE_MODULES is empty because embeddings come from the genai
+            # service (see #182), not a Weaviate-side vectorizer. Anonymous
+            # access is fine for the in-network deployment; if the cluster
+            # exposes this further, swap to API-key auth via a Secret.
+            - name: QUERY_DEFAULTS_LIMIT
+              value: "25"
+            - name: AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED
+              value: "true"
+            - name: PERSISTENCE_DATA_PATH
+              value: /var/lib/weaviate
+            - name: ENABLE_MODULES
+              value: ""
+            - name: DISABLE_TELEMETRY
+              value: "true"
+            - name: CLUSTER_HOSTNAME
+              value: {{ include "alexandria.fullname" . }}-weaviate
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/weaviate
+          resources:
+            {{- toYaml .Values.weaviate.resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /v1/.well-known/live
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /v1/.well-known/ready
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "alexandria.fullname" . }}-weaviate

--- a/infra/k8s/alexandria/templates/weaviate-deployment.yaml
+++ b/infra/k8s/alexandria/templates/weaviate-deployment.yaml
@@ -7,7 +7,12 @@ metadata:
     app: weaviate
     app.kubernetes.io/component: vector-database
 spec:
-  replicas: {{ .Values.replicaCount }}
+  # Single replica against one ReadWriteOnce PVC. Recreate (not the default
+  # RollingUpdate) so the old pod releases the volume before the new one starts,
+  # otherwise an update deadlocks on the volume attachment.
+  replicas: {{ .Values.weaviate.replicaCount | default 1 }}
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "alexandria.selectorLabels" . | nindent 6 }}

--- a/infra/k8s/alexandria/templates/weaviate-pvc.yaml
+++ b/infra/k8s/alexandria/templates/weaviate-pvc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "alexandria.fullname" . }}-weaviate
+  labels:
+    {{- include "alexandria.labels" . | nindent 4 }}
+    app: weaviate
+    app.kubernetes.io/component: vector-database
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.weaviate.persistence.size | default "2Gi" }}

--- a/infra/k8s/alexandria/templates/weaviate-service.yaml
+++ b/infra/k8s/alexandria/templates/weaviate-service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "alexandria.fullname" . }}-weaviate
+  labels:
+    {{- include "alexandria.labels" . | nindent 4 }}
+    app: weaviate
+    app.kubernetes.io/component: vector-database
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "alexandria.selectorLabels" . | nindent 4 }}
+    app: weaviate
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+      protocol: TCP
+    - name: grpc
+      port: 50051
+      targetPort: grpc
+      protocol: TCP

--- a/infra/k8s/alexandria/values.yaml
+++ b/infra/k8s/alexandria/values.yaml
@@ -53,6 +53,8 @@ genai:
 
 weaviate:
   url: ""
+  grpcPort: 50051
+  replicaCount: 1
   image:
     repository: semitechnologies/weaviate
     tag: 1.38.2

--- a/infra/k8s/alexandria/values.yaml
+++ b/infra/k8s/alexandria/values.yaml
@@ -51,6 +51,21 @@ genai:
       cpu: 500m
       memory: 512Mi
 
+weaviate:
+  url: ""
+  image:
+    repository: semitechnologies/weaviate
+    tag: 1.38.2
+  persistence:
+    size: 2Gi
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
 ingress:
   enabled: true
   className: nginx

--- a/services/genai/README.md
+++ b/services/genai/README.md
@@ -6,16 +6,20 @@ The processing endpoints take object keys, not raw text. The service downloads t
 
 ## Endpoints
 
-| Method | Path               | Description                                                 |
-| ------ | ------------------ | ----------------------------------------------------------- |
-| GET    | `/genai/health`    | Liveness/readiness probe                                    |
-| GET    | `/genai/hello`     | Sanity check, returns a plain string                        |
-| POST   | `/genai/summarize` | Summarize the document at `objectKey`                       |
-| POST   | `/genai/extract`   | Extract named entities from the document at `objectKey`     |
-| POST   | `/genai/ask`       | Answer a question grounded in the documents at `objectKeys` |
-| GET    | `/genai/metrics`   | Prometheus metrics (in-network scraping only)               |
+| Method | Path                       | Description                                                  |
+| ------ | -------------------------- | ------------------------------------------------------------ |
+| GET    | `/genai/health`            | Liveness/readiness probe                                     |
+| GET    | `/genai/hello`             | Sanity check, returns a plain string                         |
+| POST   | `/genai/summarize`         | Summarize the document at `objectKey`                        |
+| POST   | `/genai/extract`           | Extract named entities from the document at `objectKey`      |
+| POST   | `/genai/index`             | Chunk, embed, and index the document at `objectKey`          |
+| DELETE | `/genai/index/{objectKey}` | Remove a document's chunks from the index                    |
+| POST   | `/genai/ask`               | Answer a question from indexed chunks of the given documents |
+| GET    | `/genai/metrics`           | Prometheus metrics (in-network scraping only)                |
 
-`summarize` and `extract` take `{"objectKey": "..."}`; `ask` takes `{"question": "...", "objectKeys": [...]}` and returns `sourceObjectKeys`. A key that is missing returns 404 (415 if the object is neither UTF-8 text nor a PDF). For `ask`, unreadable keys are skipped so one bad document does not fail the whole request.
+`summarize`, `extract`, and `index` take `{"objectKey": "..."}`. A key that is missing returns 404 (415 if the object is neither UTF-8 text nor a PDF, 422 if it has no extractable text).
+
+`ask` takes `{"question": "...", "objectKeys": [...]}` and answers with retrieval-augmented generation: the question is embedded, matched against the indexed chunks of the listed documents, and the top matches are passed to the LLM. The response returns `sourceObjectKeys`, the documents whose chunks actually fed the answer. When nothing relevant is found (or no documents are in scope), it says so instead of guessing.
 
 FastAPI also exposes `/openapi.json` and `/docs` (Swagger UI) out of the box.
 
@@ -37,14 +41,23 @@ The service is configured entirely via environment variables. Copy `.env.example
 
 Document text is split into overlapping chunks and embedded into vectors for the RAG pipeline (see `app/embeddings.py`). The embedding provider is selected the same way as the LLM, and the logos/openai providers reuse `LLM_BASE_URL` and `LLM_API_KEY` since embeddings run on the same gateway as the chat model.
 
-| Variable             | Default                   | Description                                           |
-| -------------------- | ------------------------- | ----------------------------------------------------- |
-| `EMBEDDING_PROVIDER` | `logos`                   | `logos`, `openai`, or `ollama`                        |
-| `EMBEDDING_MODEL`    | `Qwen/Qwen3-Embedding-8B` | Embedding model id (provider-specific default)        |
-| `CHUNK_SIZE`         | `1000`                    | Characters per chunk                                  |
-| `CHUNK_OVERLAP`      | `200`                     | Character overlap between consecutive chunks          |
+| Variable             | Default                   | Description                                    |
+| -------------------- | ------------------------- | ---------------------------------------------- |
+| `EMBEDDING_PROVIDER` | `logos`                   | `logos`, `openai`, or `ollama`                 |
+| `EMBEDDING_MODEL`    | `Qwen/Qwen3-Embedding-8B` | Embedding model id (provider-specific default) |
+| `CHUNK_SIZE`         | `1000`                    | Characters per chunk                           |
+| `CHUNK_OVERLAP`      | `200`                     | Character overlap between consecutive chunks   |
+| `WEAVIATE_URL`       | `http://weaviate:8080`    | Weaviate HTTP endpoint                         |
+| `WEAVIATE_GRPC_PORT` | `50051`                   | Weaviate gRPC port (batch/query)               |
+| `RAG_TOP_K`          | `5`                       | Chunks retrieved per question in `/genai/ask`  |
 
-OpenAI defaults to `text-embedding-3-small`, Ollama to `nomic-embed-text`. Each provider/model emits a different vector size, so the Weaviate collection stores whatever the configured embedder produces rather than pinning a fixed dimension.
+OpenAI defaults to `text-embedding-3-small`, Ollama to `nomic-embed-text`. Each provider/model emits a different vector size, and the Weaviate collection stores whatever the configured embedder produces rather than pinning a fixed dimension. Weaviate locks the collection to the first vector's width, so switching embedding providers to one with a different dimension means dropping and re-indexing the collection.
+
+### How indexing and Q&A work
+
+`POST /genai/index` pulls the document text from object storage, splits it into chunks, embeds each chunk, and stores them in Weaviate keyed by object key and chunk index. Re-indexing the same key replaces its chunks, so the call is idempotent.
+
+`POST /genai/ask` embeds the question, retrieves the `RAG_TOP_K` nearest chunks scoped to the requested `objectKeys`, and asks the LLM to answer from those excerpts. The retrieval is scoped per request, so a user only ever sees answers grounded in the documents they pass in.
 
 ### Logos (default -- TUM course API)
 

--- a/services/genai/README.md
+++ b/services/genai/README.md
@@ -39,17 +39,19 @@ The service is configured entirely via environment variables. Copy `.env.example
 
 ## Embeddings and chunking (RAG)
 
-Document text is split into overlapping chunks and embedded into vectors for the RAG pipeline (see `app/embeddings.py`). The embedding provider is selected the same way as the LLM, and the logos/openai providers reuse `LLM_BASE_URL` and `LLM_API_KEY` since embeddings run on the same gateway as the chat model.
+Document text is split into overlapping chunks and embedded into vectors for the RAG pipeline (see `app/embeddings.py`). The embedding provider is selected the same way as the LLM. By default the logos/openai providers reuse `LLM_BASE_URL` and `LLM_API_KEY` (so a single-provider setup needs no extra config), but you can point embeddings at a different endpoint/key via `EMBEDDING_BASE_URL` / `EMBEDDING_API_KEY`, e.g. to run chat on Logos and embeddings on OpenAI.
 
-| Variable             | Default                   | Description                                    |
-| -------------------- | ------------------------- | ---------------------------------------------- |
-| `EMBEDDING_PROVIDER` | `logos`                   | `logos`, `openai`, or `ollama`                 |
-| `EMBEDDING_MODEL`    | `Qwen/Qwen3-Embedding-8B` | Embedding model id (provider-specific default) |
-| `CHUNK_SIZE`         | `1000`                    | Characters per chunk                           |
-| `CHUNK_OVERLAP`      | `200`                     | Character overlap between consecutive chunks   |
-| `WEAVIATE_URL`       | `http://weaviate:8080`    | Weaviate HTTP endpoint                         |
-| `WEAVIATE_GRPC_PORT` | `50051`                   | Weaviate gRPC port (batch/query)               |
-| `RAG_TOP_K`          | `5`                       | Chunks retrieved per question in `/genai/ask`  |
+| Variable             | Default                          | Description                                    |
+| -------------------- | -------------------------------- | ---------------------------------------------- |
+| `EMBEDDING_PROVIDER` | `logos`                          | `logos`, `openai`, or `ollama`                 |
+| `EMBEDDING_MODEL`    | `Qwen/Qwen3-Embedding-8B`        | Embedding model id (provider-specific default) |
+| `EMBEDDING_BASE_URL` | _(falls back to `LLM_BASE_URL`)_ | Override the embedding endpoint                |
+| `EMBEDDING_API_KEY`  | _(falls back to `LLM_API_KEY`)_  | Override the embedding API key                 |
+| `CHUNK_SIZE`         | `1000`                           | Characters per chunk                           |
+| `CHUNK_OVERLAP`      | `200`                            | Character overlap between consecutive chunks   |
+| `WEAVIATE_URL`       | `http://weaviate:8080`           | Weaviate HTTP endpoint                         |
+| `WEAVIATE_GRPC_PORT` | `50051`                          | Weaviate gRPC port (batch/query)               |
+| `RAG_TOP_K`          | `5`                              | Chunks retrieved per question in `/genai/ask`  |
 
 OpenAI defaults to `text-embedding-3-small`, Ollama to `nomic-embed-text`. Each provider/model emits a different vector size, and the Weaviate collection stores whatever the configured embedder produces rather than pinning a fixed dimension. Weaviate locks the collection to the first vector's width, so switching embedding providers to one with a different dimension means dropping and re-indexing the collection.
 

--- a/services/genai/README.md
+++ b/services/genai/README.md
@@ -91,13 +91,13 @@ Then: `curl http://localhost:8000/genai/health`.
 
 ## Tests
 
-Most tests mock the LLM and embedder, so they need no API key or network:
+No test needs a real API key. Unit tests mock the LLM and embedder:
 
 ```bash
 uv run pytest -v
 ```
 
-The Weaviate integration tests skip when no Weaviate is reachable. To run the full suite including them, use the compose test profile, which starts a throwaway Weaviate (in-network only, ephemeral) and runs the suite in a container against it:
+The Weaviate integration tests (`tests/test_vectorstore.py`) use synthetic vectors, not a real embedder, but they do need a reachable Weaviate; they skip automatically when there isn't one. To run the full suite including them, use the compose test profile, which starts a throwaway Weaviate (in-network only, ephemeral) and runs the suite in a container against it:
 
 ```bash
 docker compose run --rm genai-test

--- a/services/genai/README.md
+++ b/services/genai/README.md
@@ -76,10 +76,16 @@ Then: `curl http://localhost:8000/genai/health`.
 
 ## Tests
 
-Tests mock the LLM so no API key or network access is required.
+Most tests mock the LLM and embedder, so they need no API key or network:
 
 ```bash
 uv run pytest -v
+```
+
+The Weaviate integration tests skip when no Weaviate is reachable. To run the full suite including them, use the compose test profile, which starts a throwaway Weaviate (in-network only, ephemeral) and runs the suite in a container against it:
+
+```bash
+docker compose run --rm genai-test
 ```
 
 ## Docker

--- a/services/genai/README.md
+++ b/services/genai/README.md
@@ -55,7 +55,7 @@ OpenAI defaults to `text-embedding-3-small`, Ollama to `nomic-embed-text`. Each 
 
 ### How indexing and Q&A work
 
-`POST /genai/index` pulls the document text from object storage, splits it into chunks, embeds each chunk, and stores them in Weaviate keyed by object key and chunk index. Re-indexing the same key replaces its chunks, so the call is idempotent.
+`POST /genai/index` pulls the document text from object storage, splits it into chunks, embeds each chunk, and stores them in Weaviate keyed by object key and chunk index. Re-indexing the same key replaces its chunks, so the call is idempotent. `DELETE /genai/index/{objectKey}` removes a document's chunks so the index stays in sync when a document is deleted; deleting an unindexed document is a no-op.
 
 `POST /genai/ask` embeds the question, retrieves the `RAG_TOP_K` nearest chunks scoped to the requested `objectKeys`, and asks the LLM to answer from those excerpts. The retrieval is scoped per request, so a user only ever sees answers grounded in the documents they pass in.
 

--- a/services/genai/README.md
+++ b/services/genai/README.md
@@ -33,6 +33,19 @@ The service is configured entirely via environment variables. Copy `.env.example
 | `LLM_API_KEY`     | _(required for logos/openai)_     | API key (`lg-...` for Logos, `sk-...` for OAI) |
 | `OLLAMA_BASE_URL` | `http://localhost:11434`          | Ollama server URL (provider=ollama only)       |
 
+## Embeddings and chunking (RAG)
+
+Document text is split into overlapping chunks and embedded into vectors for the RAG pipeline (see `app/embeddings.py`). The embedding provider is selected the same way as the LLM, and the logos/openai providers reuse `LLM_BASE_URL` and `LLM_API_KEY` since embeddings run on the same gateway as the chat model.
+
+| Variable             | Default                   | Description                                           |
+| -------------------- | ------------------------- | ----------------------------------------------------- |
+| `EMBEDDING_PROVIDER` | `logos`                   | `logos`, `openai`, or `ollama`                        |
+| `EMBEDDING_MODEL`    | `Qwen/Qwen3-Embedding-8B` | Embedding model id (provider-specific default)        |
+| `CHUNK_SIZE`         | `1000`                    | Characters per chunk                                  |
+| `CHUNK_OVERLAP`      | `200`                     | Character overlap between consecutive chunks          |
+
+OpenAI defaults to `text-embedding-3-small`, Ollama to `nomic-embed-text`. Each provider/model emits a different vector size, so the Weaviate collection stores whatever the configured embedder produces rather than pinning a fixed dimension.
+
 ### Logos (default -- TUM course API)
 
 The course organizers provide [Logos](https://logos.aet.cit.tum.de), an OpenAI-compatible API gateway serving f.e. `openai/gpt-oss-120b`.

--- a/services/genai/app/embeddings.py
+++ b/services/genai/app/embeddings.py
@@ -30,6 +30,8 @@ from dataclasses import dataclass
 from langchain_core.embeddings import Embeddings
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 
+from app.env import int_env
+
 _LOGOS_BASE_URL = "https://logos.aet.cit.tum.de/v1"
 _OPENAI_BASE_URL = "https://api.openai.com/v1"
 
@@ -50,11 +52,6 @@ class Chunk:
     text: str
 
 
-def _int_env(name: str, default: int) -> int:
-    raw = os.getenv(name)
-    return int(raw) if raw else default
-
-
 def chunk_text(text: str, object_key: str) -> list[Chunk]:
     """Split a document's text into overlapping chunks tagged with their source.
 
@@ -65,8 +62,8 @@ def chunk_text(text: str, object_key: str) -> list[Chunk]:
         return []
 
     splitter = RecursiveCharacterTextSplitter(
-        chunk_size=_int_env("CHUNK_SIZE", _DEFAULT_CHUNK_SIZE),
-        chunk_overlap=_int_env("CHUNK_OVERLAP", _DEFAULT_CHUNK_OVERLAP),
+        chunk_size=int_env("CHUNK_SIZE", _DEFAULT_CHUNK_SIZE, minimum=1),
+        chunk_overlap=int_env("CHUNK_OVERLAP", _DEFAULT_CHUNK_OVERLAP, minimum=0),
     )
     pieces = splitter.split_text(text)
     return [Chunk(object_key=object_key, chunk_index=i, text=piece) for i, piece in enumerate(pieces)]
@@ -80,18 +77,24 @@ def get_embeddings() -> Embeddings:
         from langchain_openai import OpenAIEmbeddings
 
         if provider == "logos":
-            base_url = os.getenv("LLM_BASE_URL", _LOGOS_BASE_URL)
+            default_base_url = _LOGOS_BASE_URL
             model = os.getenv("EMBEDDING_MODEL", _DEFAULT_LOGOS_MODEL)
         else:
-            base_url = os.getenv("LLM_BASE_URL", _OPENAI_BASE_URL)
+            default_base_url = _OPENAI_BASE_URL
             model = os.getenv("EMBEDDING_MODEL", _DEFAULT_OPENAI_MODEL)
+
+        # Embeddings can run on a different endpoint than the chat model. Prefer
+        # the embedding-specific vars, fall back to the chat client's, then the
+        # provider default, so existing single-provider setups keep working.
+        base_url = os.getenv("EMBEDDING_BASE_URL") or os.getenv("LLM_BASE_URL", default_base_url)
+        api_key = os.getenv("EMBEDDING_API_KEY") or os.getenv("LLM_API_KEY", "")
 
         # check_embedding_ctx_length forces a tiktoken tokenization pass that
         # assumes an OpenAI model. The Logos-hosted Qwen model isn't one, so we
         # disable it and rely on our own chunking to keep inputs within range.
         return OpenAIEmbeddings(
             base_url=base_url,
-            api_key=os.getenv("LLM_API_KEY", ""),
+            api_key=api_key,
             model=model,
             check_embedding_ctx_length=False,
         )

--- a/services/genai/app/embeddings.py
+++ b/services/genai/app/embeddings.py
@@ -2,9 +2,9 @@
 
 Splits extracted document text into overlapping chunks and turns each chunk
 into an embedding vector via a provider-configurable client, mirroring the
-provider selection in app/llm.py. Indexing (#183) and retrieval (#184) both
-build on this module; it works on plain text and knows nothing about object
-storage or Weaviate.
+provider selection in app/llm.py. Indexing and retrieval both build on this
+module; it works on plain text and knows nothing about object storage or
+Weaviate.
 
 Chunking:
   CHUNK_SIZE      characters per chunk (default 1000)
@@ -14,14 +14,16 @@ Embeddings:
   EMBEDDING_PROVIDER  "logos" (default) | "openai" | "ollama"
   EMBEDDING_MODEL     model id (provider-specific default)
 
-The logos/openai providers reuse the LLM gateway credentials (LLM_BASE_URL,
-LLM_API_KEY) because embeddings run on the same OpenAI-compatible endpoint as
-the chat model; ollama reuses OLLAMA_BASE_URL.
+The logos/openai providers default to the LLM gateway credentials
+(LLM_BASE_URL, LLM_API_KEY) because embeddings usually run on the same
+OpenAI-compatible endpoint as the chat model; EMBEDDING_BASE_URL /
+EMBEDDING_API_KEY override that when embeddings should run elsewhere. Ollama
+reuses OLLAMA_BASE_URL.
 
 Vector dimensions differ per provider/model (Qwen3-Embedding-8B, OpenAI's
 text-embedding-3-small and the Ollama models all emit different sizes), so the
-Weaviate collection in #183 must not pin a fixed dimension -- it stores
-whatever the configured embedder produces.
+Weaviate collection must not pin a fixed dimension -- it stores whatever the
+configured embedder produces.
 """
 
 import os

--- a/services/genai/app/embeddings.py
+++ b/services/genai/app/embeddings.py
@@ -1,0 +1,130 @@
+"""Chunking and embedding for the RAG pipeline.
+
+Splits extracted document text into overlapping chunks and turns each chunk
+into an embedding vector via a provider-configurable client, mirroring the
+provider selection in app/llm.py. Indexing (#183) and retrieval (#184) both
+build on this module; it works on plain text and knows nothing about object
+storage or Weaviate.
+
+Chunking:
+  CHUNK_SIZE      characters per chunk (default 1000)
+  CHUNK_OVERLAP   character overlap between chunks (default 200)
+
+Embeddings:
+  EMBEDDING_PROVIDER  "logos" (default) | "openai" | "ollama"
+  EMBEDDING_MODEL     model id (provider-specific default)
+
+The logos/openai providers reuse the LLM gateway credentials (LLM_BASE_URL,
+LLM_API_KEY) because embeddings run on the same OpenAI-compatible endpoint as
+the chat model; ollama reuses OLLAMA_BASE_URL.
+
+Vector dimensions differ per provider/model (Qwen3-Embedding-8B, OpenAI's
+text-embedding-3-small and the Ollama models all emit different sizes), so the
+Weaviate collection in #183 must not pin a fixed dimension -- it stores
+whatever the configured embedder produces.
+"""
+
+import os
+from dataclasses import dataclass
+
+from langchain_core.embeddings import Embeddings
+from langchain_text_splitters import RecursiveCharacterTextSplitter
+
+_LOGOS_BASE_URL = "https://logos.aet.cit.tum.de/v1"
+_OPENAI_BASE_URL = "https://api.openai.com/v1"
+
+_DEFAULT_LOGOS_MODEL = "Qwen/Qwen3-Embedding-8B"
+_DEFAULT_OPENAI_MODEL = "text-embedding-3-small"
+_DEFAULT_OLLAMA_MODEL = "nomic-embed-text"
+
+_DEFAULT_CHUNK_SIZE = 1000
+_DEFAULT_CHUNK_OVERLAP = 200
+
+
+@dataclass(frozen=True)
+class Chunk:
+    """A slice of a document, with enough metadata to link back to its source."""
+
+    object_key: str
+    chunk_index: int
+    text: str
+
+
+def _int_env(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    return int(raw) if raw else default
+
+
+def chunk_text(text: str, object_key: str) -> list[Chunk]:
+    """Split a document's text into overlapping chunks tagged with their source.
+
+    Chunk size and overlap come from CHUNK_SIZE / CHUNK_OVERLAP. Returns an empty
+    list for blank input so callers can treat "nothing to index" uniformly.
+    """
+    if not text.strip():
+        return []
+
+    splitter = RecursiveCharacterTextSplitter(
+        chunk_size=_int_env("CHUNK_SIZE", _DEFAULT_CHUNK_SIZE),
+        chunk_overlap=_int_env("CHUNK_OVERLAP", _DEFAULT_CHUNK_OVERLAP),
+    )
+    pieces = splitter.split_text(text)
+    return [Chunk(object_key=object_key, chunk_index=i, text=piece) for i, piece in enumerate(pieces)]
+
+
+def get_embeddings() -> Embeddings:
+    """Return a configured embedding client based on environment variables."""
+    provider = os.getenv("EMBEDDING_PROVIDER", "logos").lower()
+
+    if provider in ("logos", "openai"):
+        from langchain_openai import OpenAIEmbeddings
+
+        if provider == "logos":
+            base_url = os.getenv("LLM_BASE_URL", _LOGOS_BASE_URL)
+            model = os.getenv("EMBEDDING_MODEL", _DEFAULT_LOGOS_MODEL)
+        else:
+            base_url = os.getenv("LLM_BASE_URL", _OPENAI_BASE_URL)
+            model = os.getenv("EMBEDDING_MODEL", _DEFAULT_OPENAI_MODEL)
+
+        # check_embedding_ctx_length forces a tiktoken tokenization pass that
+        # assumes an OpenAI model. The Logos-hosted Qwen model isn't one, so we
+        # disable it and rely on our own chunking to keep inputs within range.
+        return OpenAIEmbeddings(
+            base_url=base_url,
+            api_key=os.getenv("LLM_API_KEY", ""),
+            model=model,
+            check_embedding_ctx_length=False,
+        )
+
+    if provider == "ollama":
+        from langchain_ollama import OllamaEmbeddings
+
+        base_url = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
+        model = os.getenv("EMBEDDING_MODEL", _DEFAULT_OLLAMA_MODEL)
+        return OllamaEmbeddings(base_url=base_url, model=model)
+
+    raise ValueError(f"Unknown EMBEDDING_PROVIDER '{provider}'. Use 'logos', 'openai', or 'ollama'.")
+
+
+def get_embedding_model_name() -> str:
+    """Return the configured embedding model id for use in API responses."""
+    provider = os.getenv("EMBEDDING_PROVIDER", "logos").lower()
+    if provider == "logos":
+        return os.getenv("EMBEDDING_MODEL", _DEFAULT_LOGOS_MODEL)
+    if provider == "openai":
+        return os.getenv("EMBEDDING_MODEL", _DEFAULT_OPENAI_MODEL)
+    if provider == "ollama":
+        return os.getenv("EMBEDDING_MODEL", _DEFAULT_OLLAMA_MODEL)
+    return "unknown"
+
+
+def embed_chunks(chunks: list[Chunk]) -> list[list[float]]:
+    """Embed a list of chunks, returning one vector per chunk in the same order."""
+    if not chunks:
+        return []
+    return get_embeddings().embed_documents([chunk.text for chunk in chunks])
+
+
+def embed_query(text: str) -> list[float]:
+    """Embed a single query string into one vector."""
+    return get_embeddings().embed_query(text)

--- a/services/genai/app/env.py
+++ b/services/genai/app/env.py
@@ -1,0 +1,22 @@
+"""Environment helpers shared across the service."""
+
+import os
+
+
+def int_env(name: str, default: int, *, minimum: int) -> int:
+    """Read an integer environment variable, failing loudly on bad input.
+
+    Returns the default when the variable is unset or empty. Raises RuntimeError
+    when the value isn't an integer or falls below ``minimum`` so a typo surfaces
+    at startup rather than as a confusing failure deep in a request.
+    """
+    raw = os.getenv(name)
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise RuntimeError(f"{name} must be an integer, got {raw!r}") from exc
+    if value < minimum:
+        raise RuntimeError(f"{name} must be >= {minimum}, got {value}")
+    return value

--- a/services/genai/app/main.py
+++ b/services/genai/app/main.py
@@ -150,22 +150,15 @@ def extract(request: GenAiExtractRequest) -> GenAiExtractResponse:
 
 @app.post("/genai/ask", tags=["ai"], response_model=GenAiAskResponse, openapi_extra={"security": []})
 def ask(request: GenAiAskRequest) -> GenAiAskResponse:
-    """Answer a question grounded in the documents stored under the given object keys.
+    """Answer a question from chunks retrieved for the given documents.
 
-    Each object key is fetched from storage; keys that cannot be read are skipped so a
-    single missing or unreadable document does not fail the whole request.
+    The question is embedded and matched against the indexed chunks scoped to the
+    requested object keys; the answer cites the documents its chunks came from.
     """
     if not request.question.strip():
         raise HTTPException(status_code=422, detail="question must not be empty")
 
-    documents: list[dict[str, str]] = []
-    for object_key in request.objectKeys:
-        try:
-            documents.append({"id": object_key, "content": fetch_text(object_key)})
-        except ObjectNotFoundError, UnsupportedFileError:
-            continue
-
-    answer, source_keys, model = answer_question(request.question, request.objectKeys, documents or None)
+    answer, source_keys, model = answer_question(request.question, request.objectKeys)
     return GenAiAskResponse(answer=answer, sourceObjectKeys=source_keys, modelUsed=model)
 
 

--- a/services/genai/app/main.py
+++ b/services/genai/app/main.py
@@ -1,15 +1,26 @@
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import PlainTextResponse
 from prometheus_fastapi_instrumentator import Instrumentator
 from pydantic import BaseModel
 
+from app.embeddings import chunk_text, embed_chunks, get_embedding_model_name
 from app.extract import extract_entities
 from app.qa import answer_question
 from app.storage import ObjectNotFoundError, UnsupportedFileError, fetch_text
 from app.summarize import summarize
+from app.vectorstore import close_client, index_chunks
 
 SERVICE_NAME = "alexandria-genai"
 SERVICE_VERSION = "1.4.0"
+
+
+@asynccontextmanager
+async def lifespan(_: FastAPI):
+    yield
+    close_client()
+
 
 app = FastAPI(
     title="Alexandria GenAI",
@@ -21,6 +32,7 @@ app = FastAPI(
         {"name": "ai", "description": "AI-powered document processing"},
     ],
     servers=[{"url": "/"}],
+    lifespan=lifespan,
 )
 
 # should_group_untemplated rolls unmatched URLs (404s, port scans) into one
@@ -70,6 +82,16 @@ class GenAiAskResponse(BaseModel):
     answer: str
     sourceObjectKeys: list[str]
     modelUsed: str
+
+
+class GenAiIndexRequest(BaseModel):
+    objectKey: str
+
+
+class GenAiIndexResponse(BaseModel):
+    objectKey: str
+    chunksIndexed: int
+    embeddingModel: str
 
 
 # --- helpers ---
@@ -145,3 +167,21 @@ def ask(request: GenAiAskRequest) -> GenAiAskResponse:
 
     answer, source_keys, model = answer_question(request.question, request.objectKeys, documents or None)
     return GenAiAskResponse(answer=answer, sourceObjectKeys=source_keys, modelUsed=model)
+
+
+@app.post("/genai/index", tags=["ai"], response_model=GenAiIndexResponse, openapi_extra={"security": []})
+def index(request: GenAiIndexRequest) -> GenAiIndexResponse:
+    """Chunk, embed, and index the document at the given object key into Weaviate.
+
+    Re-indexing the same key replaces its existing chunks, so the call is safe to
+    repeat (e.g. when Spring re-processes a document).
+    """
+    content = _load_document(request.objectKey)
+    chunks = chunk_text(content, request.objectKey)
+    vectors = embed_chunks(chunks)
+    count = index_chunks(request.objectKey, chunks, vectors)
+    return GenAiIndexResponse(
+        objectKey=request.objectKey,
+        chunksIndexed=count,
+        embeddingModel=get_embedding_model_name(),
+    )

--- a/services/genai/app/main.py
+++ b/services/genai/app/main.py
@@ -115,6 +115,14 @@ def _load_document(object_key: str) -> str:
     return text
 
 
+# Error responses _load_document can return, declared so they show up in the
+# OpenAPI spec for every endpoint that loads a document.
+_DOCUMENT_ERROR_RESPONSES = {
+    404: {"description": "Object not found"},
+    415: {"description": "Object is not a supported file type"},
+}
+
+
 # --- endpoints ---
 
 
@@ -134,7 +142,7 @@ def hello() -> str:
     return "Hello from Alexandria GenAI!"
 
 
-@app.post("/genai/summarize", tags=["ai"], response_model=GenAiSummarizeResponse, openapi_extra={"security": []})
+@app.post("/genai/summarize", tags=["ai"], response_model=GenAiSummarizeResponse, responses=_DOCUMENT_ERROR_RESPONSES, openapi_extra={"security": []})
 def summarize_document(request: GenAiSummarizeRequest) -> GenAiSummarizeResponse:
     """Summarize the document stored under the given object key."""
     content = _load_document(request.objectKey)
@@ -142,7 +150,7 @@ def summarize_document(request: GenAiSummarizeRequest) -> GenAiSummarizeResponse
     return GenAiSummarizeResponse(summary=summary, modelUsed=model)
 
 
-@app.post("/genai/extract", tags=["ai"], response_model=GenAiExtractResponse, openapi_extra={"security": []})
+@app.post("/genai/extract", tags=["ai"], response_model=GenAiExtractResponse, responses=_DOCUMENT_ERROR_RESPONSES, openapi_extra={"security": []})
 def extract(request: GenAiExtractRequest) -> GenAiExtractResponse:
     """Extract named entities from the document stored under the given object key."""
     content = _load_document(request.objectKey)
@@ -167,7 +175,7 @@ def ask(request: GenAiAskRequest) -> GenAiAskResponse:
     return GenAiAskResponse(answer=answer, sourceObjectKeys=source_keys, modelUsed=model)
 
 
-@app.post("/genai/index", tags=["ai"], response_model=GenAiIndexResponse, openapi_extra={"security": []})
+@app.post("/genai/index", tags=["ai"], response_model=GenAiIndexResponse, responses=_DOCUMENT_ERROR_RESPONSES, openapi_extra={"security": []})
 def index(request: GenAiIndexRequest) -> GenAiIndexResponse:
     """Chunk, embed, and index the document at the given object key into Weaviate.
 

--- a/services/genai/app/main.py
+++ b/services/genai/app/main.py
@@ -10,7 +10,7 @@ from app.extract import extract_entities
 from app.qa import answer_question
 from app.storage import ObjectNotFoundError, UnsupportedFileError, fetch_text
 from app.summarize import summarize
-from app.vectorstore import close_client, index_chunks
+from app.vectorstore import close_client, delete_document, index_chunks
 
 SERVICE_NAME = "alexandria-genai"
 SERVICE_VERSION = "1.4.0"
@@ -92,6 +92,11 @@ class GenAiIndexResponse(BaseModel):
     objectKey: str
     chunksIndexed: int
     embeddingModel: str
+
+
+class GenAiDeleteIndexResponse(BaseModel):
+    objectKey: str
+    chunksDeleted: int
 
 
 # --- helpers ---
@@ -178,3 +183,15 @@ def index(request: GenAiIndexRequest) -> GenAiIndexResponse:
         chunksIndexed=count,
         embeddingModel=get_embedding_model_name(),
     )
+
+
+@app.delete("/genai/index/{object_key:path}", tags=["ai"], response_model=GenAiDeleteIndexResponse, openapi_extra={"security": []})
+def delete_index(object_key: str) -> GenAiDeleteIndexResponse:
+    """Remove all indexed chunks for the document at the given object key.
+
+    Idempotent: deleting a document that was never indexed removes nothing and
+    still returns 200. The :path converter keeps object keys that contain slashes
+    intact.
+    """
+    removed = delete_document(object_key)
+    return GenAiDeleteIndexResponse(objectKey=object_key, chunksDeleted=removed)

--- a/services/genai/app/main.py
+++ b/services/genai/app/main.py
@@ -13,7 +13,7 @@ from app.summarize import summarize
 from app.vectorstore import close_client, delete_document, index_chunks
 
 SERVICE_NAME = "alexandria-genai"
-SERVICE_VERSION = "1.4.0"
+SERVICE_VERSION = "1.5.0"
 
 
 @asynccontextmanager

--- a/services/genai/app/qa.py
+++ b/services/genai/app/qa.py
@@ -1,68 +1,82 @@
-"""Question answering over documents using LangChain."""
+"""Retrieval-augmented question answering over indexed document chunks.
+
+Embeds the question, retrieves the most similar chunks from Weaviate scoped to
+the requested documents, and asks the LLM to answer from those chunks. Sources
+are the documents whose chunks actually fed the answer (chunk-level attribution),
+not the whole set the caller passed in.
+
+  RAG_TOP_K   number of chunks to retrieve (default 5)
+"""
+
+import os
 
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import ChatPromptTemplate
 
+from app.embeddings import embed_query
 from app.llm import get_llm, get_model_name
+from app.vectorstore import search
 
-_PROMPT_WITH_CONTEXT = ChatPromptTemplate.from_messages(
+_DEFAULT_TOP_K = 5
+
+_NO_CONTEXT_MESSAGE = "I couldn't find anything relevant in the selected documents to answer that question."
+
+_PROMPT = ChatPromptTemplate.from_messages(
     [
         (
             "system",
             "You are a helpful assistant that answers questions strictly based on the provided document excerpts. "
-            "If the answer cannot be found in the documents, say so clearly. "
-            "When relevant, mention which documents support your answer.",
+            "Each excerpt is labelled with its source. If the answer cannot be found in the excerpts, say so clearly. "
+            "Cite the sources that support your answer.",
         ),
         (
             "human",
-            "Documents:\n{context}\n\nQuestion: {question}",
+            "Excerpts:\n{context}\n\nQuestion: {question}",
         ),
     ]
 )
 
-_PROMPT_NO_CONTEXT = ChatPromptTemplate.from_messages(
-    [
-        (
-            "system",
-            "You are a helpful assistant. Answer the question as best you can. "
-            "Note: no document content was provided, so this answer is based on general knowledge only.",
-        ),
-        ("human", "{question}"),
-    ]
-)
+
+def _top_k() -> int:
+    raw = os.getenv("RAG_TOP_K")
+    return int(raw) if raw else _DEFAULT_TOP_K
 
 
-def answer_question(
-    question: str,
-    object_keys: list[str],
-    documents: list[dict] | None = None,
-) -> tuple[str, list[str], str]:
-    """Answer a question, optionally grounded in document content.
+def _unique_sources(chunks: list[dict]) -> list[str]:
+    """Source object keys in retrieval order, deduplicated."""
+    seen: set[str] = set()
+    sources: list[str] = []
+    for chunk in chunks:
+        key = chunk["object_key"]
+        if key not in seen:
+            seen.add(key)
+            sources.append(key)
+    return sources
+
+
+def answer_question(question: str, object_keys: list[str]) -> tuple[str, list[str], str]:
+    """Answer a question from chunks retrieved for the given documents.
 
     Args:
         question: The user's question.
-        object_keys: Object keys of documents in scope (used as source attribution).
-        documents: Optional list of {"id": <object key>, "content": ...} dicts.
-                   When provided, answers are grounded in the document text and only
-                   the keys that were actually readable are returned as sources.
+        object_keys: Object keys of the documents to search within. Retrieval is
+                     scoped to these, so an empty list means "nothing to search".
 
     Returns:
-        (answer, source_object_keys, model_name)
+        (answer, source_object_keys, model_name). source_object_keys are the
+        documents whose chunks fed the answer; empty when nothing was retrieved.
     """
-    llm = get_llm()
+    model = get_model_name()
 
-    if documents:
-        context_parts = []
-        for doc in documents:
-            context_parts.append(f"[Document {doc['id']}]\n{doc['content']}")
-        context = "\n\n---\n\n".join(context_parts)
+    if not object_keys:
+        return _NO_CONTEXT_MESSAGE, [], model
 
-        chain = _PROMPT_WITH_CONTEXT | llm | StrOutputParser()
-        answer = chain.invoke({"context": context, "question": question})
-        source_keys = [doc["id"] for doc in documents]
-    else:
-        chain = _PROMPT_NO_CONTEXT | llm | StrOutputParser()
-        answer = chain.invoke({"question": question})
-        source_keys = object_keys
+    retrieved = search(embed_query(question), object_keys, _top_k())
+    if not retrieved:
+        return _NO_CONTEXT_MESSAGE, [], model
 
-    return answer.strip(), source_keys, get_model_name()
+    context = "\n\n---\n\n".join(f"[Source: {chunk['object_key']}]\n{chunk['text']}" for chunk in retrieved)
+    chain = _PROMPT | get_llm() | StrOutputParser()
+    answer = chain.invoke({"context": context, "question": question})
+
+    return answer.strip(), _unique_sources(retrieved), model

--- a/services/genai/app/qa.py
+++ b/services/genai/app/qa.py
@@ -8,12 +8,11 @@ not the whole set the caller passed in.
   RAG_TOP_K   number of chunks to retrieve (default 5)
 """
 
-import os
-
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import ChatPromptTemplate
 
 from app.embeddings import embed_query
+from app.env import int_env
 from app.llm import get_llm, get_model_name
 from app.vectorstore import search
 
@@ -38,8 +37,7 @@ _PROMPT = ChatPromptTemplate.from_messages(
 
 
 def _top_k() -> int:
-    raw = os.getenv("RAG_TOP_K")
-    return int(raw) if raw else _DEFAULT_TOP_K
+    return int_env("RAG_TOP_K", _DEFAULT_TOP_K, minimum=1)
 
 
 def _unique_sources(chunks: list[dict]) -> list[str]:

--- a/services/genai/app/vectorstore.py
+++ b/services/genai/app/vectorstore.py
@@ -1,0 +1,142 @@
+"""Weaviate vector store for the RAG pipeline.
+
+Stores document chunks (text + externally supplied embedding vector + source
+metadata) in a single collection, and supports indexing, retrieval, and
+deletion scoped to a document.
+
+Connection:
+  WEAVIATE_URL        HTTP endpoint (default http://weaviate:8080)
+  WEAVIATE_GRPC_PORT  gRPC port (default 50051)
+
+The collection uses self-provided vectors (no Weaviate-side vectorizer): the
+genai service supplies one vector per chunk. No fixed dimension is configured,
+so any embedding provider's output size works (see app/embeddings.py).
+"""
+
+import os
+from functools import lru_cache
+from urllib.parse import urlparse
+
+import weaviate
+from weaviate.classes.config import Configure, DataType, Property
+from weaviate.classes.data import DataObject
+from weaviate.classes.query import Filter, MetadataQuery
+from weaviate.util import generate_uuid5
+
+from app.embeddings import Chunk
+
+COLLECTION_NAME = "DocumentChunk"
+
+_DEFAULT_URL = "http://weaviate:8080"
+_DEFAULT_GRPC_PORT = 50051
+
+
+def _connection_params() -> dict:
+    parsed = urlparse(os.getenv("WEAVIATE_URL", _DEFAULT_URL))
+    secure = parsed.scheme == "https"
+    host = parsed.hostname or "weaviate"
+    http_port = parsed.port or (443 if secure else 80)
+    grpc_port = int(os.getenv("WEAVIATE_GRPC_PORT", str(_DEFAULT_GRPC_PORT)))
+    return {
+        "http_host": host,
+        "http_port": http_port,
+        "http_secure": secure,
+        "grpc_host": host,
+        "grpc_port": grpc_port,
+        "grpc_secure": secure,
+    }
+
+
+@lru_cache(maxsize=1)
+def _client() -> weaviate.WeaviateClient:
+    client = weaviate.connect_to_custom(**_connection_params())
+    _ensure_collection(client)
+    return client
+
+
+def _ensure_collection(client: weaviate.WeaviateClient) -> None:
+    """Create the chunk collection on first use if it doesn't exist yet."""
+    if client.collections.exists(COLLECTION_NAME):
+        return
+    client.collections.create(
+        name=COLLECTION_NAME,
+        vector_config=Configure.Vectors.self_provided(),
+        properties=[
+            Property(name="text", data_type=DataType.TEXT),
+            Property(name="object_key", data_type=DataType.TEXT),
+            Property(name="chunk_index", data_type=DataType.INT),
+        ],
+    )
+
+
+def _chunk_uuid(object_key: str, chunk_index: int) -> str:
+    """Deterministic per-chunk id so a re-insert overwrites instead of duplicating."""
+    return generate_uuid5(f"{object_key}:{chunk_index}")
+
+
+def index_chunks(object_key: str, chunks: list[Chunk], vectors: list[list[float]]) -> int:
+    """Replace a document's chunks in the index with the given chunks and vectors.
+
+    Existing chunks for the object key are deleted first, so re-indexing a
+    document that now has fewer chunks doesn't leave stale ones behind. Returns
+    the number of chunks written.
+    """
+    if len(chunks) != len(vectors):
+        raise ValueError(f"chunks ({len(chunks)}) and vectors ({len(vectors)}) length mismatch")
+
+    collection = _client().collections.get(COLLECTION_NAME)
+    delete_document(object_key)
+
+    if not chunks:
+        return 0
+
+    objects = [
+        DataObject(
+            properties={"text": chunk.text, "object_key": chunk.object_key, "chunk_index": chunk.chunk_index},
+            vector=vector,
+            uuid=_chunk_uuid(chunk.object_key, chunk.chunk_index),
+        )
+        for chunk, vector in zip(chunks, vectors, strict=True)
+    ]
+    collection.data.insert_many(objects)
+    return len(objects)
+
+
+def delete_document(object_key: str) -> int:
+    """Remove all chunks for a document. A no-op (returns 0) if none are indexed."""
+    collection = _client().collections.get(COLLECTION_NAME)
+    result = collection.data.delete_many(where=Filter.by_property("object_key").equal(object_key))
+    return result.successful
+
+
+def search(query_vector: list[float], object_keys: list[str], limit: int) -> list[dict]:
+    """Return the top chunks nearest to the query vector, scoped to object_keys.
+
+    Each result carries its text, source object key, chunk index, and distance.
+    An empty object_keys list searches the whole collection.
+    """
+    collection = _client().collections.get(COLLECTION_NAME)
+    filters = Filter.by_property("object_key").contains_any(object_keys) if object_keys else None
+
+    response = collection.query.near_vector(
+        near_vector=query_vector,
+        limit=limit,
+        filters=filters,
+        return_metadata=MetadataQuery(distance=True),
+    )
+    return [
+        {
+            "text": obj.properties["text"],
+            "object_key": obj.properties["object_key"],
+            "chunk_index": int(obj.properties["chunk_index"]),
+            "distance": obj.metadata.distance,
+        }
+        for obj in response.objects
+    ]
+
+
+def close_client() -> None:
+    """Close the cached Weaviate client and clear the cache (used on shutdown)."""
+    if _client.cache_info().currsize:
+        _client().close()
+        _client.cache_clear()

--- a/services/genai/app/vectorstore.py
+++ b/services/genai/app/vectorstore.py
@@ -98,7 +98,9 @@ def index_chunks(object_key: str, chunks: list[Chunk], vectors: list[list[float]
         )
         for chunk, vector in zip(chunks, vectors, strict=True)
     ]
-    collection.data.insert_many(objects)
+    result = collection.data.insert_many(objects)
+    if result.has_errors:
+        raise RuntimeError(f"failed to index {len(result.errors)} of {len(objects)} chunks for {object_key}: {result.errors}")
     return len(objects)
 
 

--- a/services/genai/app/vectorstore.py
+++ b/services/genai/app/vectorstore.py
@@ -21,9 +21,11 @@ import weaviate
 from weaviate.classes.config import Configure, DataType, Property
 from weaviate.classes.data import DataObject
 from weaviate.classes.query import Filter, MetadataQuery
+from weaviate.exceptions import UnexpectedStatusCodeError
 from weaviate.util import generate_uuid5
 
 from app.embeddings import Chunk
+from app.env import int_env
 
 COLLECTION_NAME = "DocumentChunk"
 
@@ -36,7 +38,7 @@ def _connection_params() -> dict:
     secure = parsed.scheme == "https"
     host = parsed.hostname or "weaviate"
     http_port = parsed.port or (443 if secure else 80)
-    grpc_port = int(os.getenv("WEAVIATE_GRPC_PORT", str(_DEFAULT_GRPC_PORT)))
+    grpc_port = int_env("WEAVIATE_GRPC_PORT", _DEFAULT_GRPC_PORT, minimum=1)
     return {
         "http_host": host,
         "http_port": http_port,
@@ -55,18 +57,27 @@ def _client() -> weaviate.WeaviateClient:
 
 
 def _ensure_collection(client: weaviate.WeaviateClient) -> None:
-    """Create the chunk collection on first use if it doesn't exist yet."""
+    """Create the chunk collection on first use if it doesn't exist yet.
+
+    exists() + create() isn't atomic, so two concurrent first requests can race
+    to create it. If create fails but the collection now exists, another worker
+    won the race and we treat it as success; otherwise the failure is real.
+    """
     if client.collections.exists(COLLECTION_NAME):
         return
-    client.collections.create(
-        name=COLLECTION_NAME,
-        vector_config=Configure.Vectors.self_provided(),
-        properties=[
-            Property(name="text", data_type=DataType.TEXT),
-            Property(name="object_key", data_type=DataType.TEXT),
-            Property(name="chunk_index", data_type=DataType.INT),
-        ],
-    )
+    try:
+        client.collections.create(
+            name=COLLECTION_NAME,
+            vector_config=Configure.Vectors.self_provided(),
+            properties=[
+                Property(name="text", data_type=DataType.TEXT),
+                Property(name="object_key", data_type=DataType.TEXT),
+                Property(name="chunk_index", data_type=DataType.INT),
+            ],
+        )
+    except UnexpectedStatusCodeError:
+        if not client.collections.exists(COLLECTION_NAME):
+            raise
 
 
 def _chunk_uuid(object_key: str, chunk_index: int) -> str:
@@ -83,6 +94,8 @@ def index_chunks(object_key: str, chunks: list[Chunk], vectors: list[list[float]
     """
     if len(chunks) != len(vectors):
         raise ValueError(f"chunks ({len(chunks)}) and vectors ({len(vectors)}) length mismatch")
+    if any(chunk.object_key != object_key for chunk in chunks):
+        raise ValueError(f"all chunks must belong to object_key {object_key!r}")
 
     collection = _client().collections.get(COLLECTION_NAME)
     delete_document(object_key)
@@ -92,9 +105,9 @@ def index_chunks(object_key: str, chunks: list[Chunk], vectors: list[list[float]
 
     objects = [
         DataObject(
-            properties={"text": chunk.text, "object_key": chunk.object_key, "chunk_index": chunk.chunk_index},
+            properties={"text": chunk.text, "object_key": object_key, "chunk_index": chunk.chunk_index},
             vector=vector,
-            uuid=_chunk_uuid(chunk.object_key, chunk.chunk_index),
+            uuid=_chunk_uuid(object_key, chunk.chunk_index),
         )
         for chunk, vector in zip(chunks, vectors, strict=True)
     ]

--- a/services/genai/pyproject.toml
+++ b/services/genai/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "prometheus-fastapi-instrumentator~=8.0.2",
     "boto3~=1.43.36",
     "pypdf~=6.14.2",
+    "weaviate-client~=4.22.0",
 ]
 
 [dependency-groups]
@@ -45,6 +46,9 @@ select = ["E", "F", "I", "W", "UP", "B"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["."]
+markers = [
+    "integration: tests that need a running Weaviate; skipped when none is reachable",
+]
 filterwarnings = [
     # asyncio.iscoroutinefunction is deprecated in Python 3.14; langchain_core
     # still uses it internally -- nothing we can do until upstream fixes it.

--- a/services/genai/pyproject.toml
+++ b/services/genai/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "pydantic~=2.13.4",
     "langchain-openai~=1.3.3",
     "langchain-ollama~=1.1.0",
+    "langchain-text-splitters~=1.1.2",
     "prometheus-fastapi-instrumentator~=8.0.2",
     "boto3~=1.43.36",
     "pypdf~=6.14.2",

--- a/services/genai/pyproject.toml
+++ b/services/genai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "alexandria-genai"
-version = "1.4.0"
+version = "1.5.0"
 description = "GenAI microservice for Alexandria"
 requires-python = "~=3.14.0"
 dependencies = [

--- a/services/genai/tests/test_embeddings.py
+++ b/services/genai/tests/test_embeddings.py
@@ -1,0 +1,127 @@
+"""Unit tests for the chunking and embedding module.
+
+Embedding tests mock the client so no API key or network access is required,
+mirroring the LLM-mocked tests for summarize/qa.
+"""
+
+import os
+from unittest.mock import patch
+
+from app.embeddings import (
+    Chunk,
+    chunk_text,
+    embed_chunks,
+    embed_query,
+    get_embedding_model_name,
+    get_embeddings,
+)
+
+
+class _FakeEmbeddings:
+    """Stand-in for a LangChain Embeddings client returning deterministic vectors."""
+
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        return [[float(len(t)), float(i)] for i, t in enumerate(texts)]
+
+    def embed_query(self, text: str) -> list[float]:
+        return [float(len(text)), 0.0]
+
+
+# --- chunking ---
+
+
+def test_chunk_text_carries_source_metadata():
+    chunks = chunk_text("some text " * 300, "documents/report.pdf")
+
+    assert len(chunks) > 1
+    assert all(isinstance(c, Chunk) for c in chunks)
+    assert all(c.object_key == "documents/report.pdf" for c in chunks)
+    assert [c.chunk_index for c in chunks] == list(range(len(chunks)))
+
+
+def test_chunk_text_blank_returns_empty():
+    assert chunk_text("   \n  ", "k") == []
+
+
+def test_chunk_text_respects_env_size_and_overlap():
+    text = "abcdefghij" * 50  # 500 chars, no whitespace to split on
+
+    with patch.dict(os.environ, {"CHUNK_SIZE": "100", "CHUNK_OVERLAP": "0"}):
+        chunks = chunk_text(text, "k")
+
+    assert len(chunks) == 5
+    assert all(len(c.text) <= 100 for c in chunks)
+
+
+def test_chunk_text_single_short_chunk():
+    chunks = chunk_text("short doc", "k")
+
+    assert len(chunks) == 1
+    assert chunks[0].text == "short doc"
+    assert chunks[0].chunk_index == 0
+
+
+# --- provider selection ---
+
+
+def test_get_embeddings_defaults_to_logos():
+    with patch.dict(os.environ, {"LLM_API_KEY": "lg-test"}, clear=False):
+        os.environ.pop("EMBEDDING_PROVIDER", None)
+        client = get_embeddings()
+
+    assert type(client).__name__ == "OpenAIEmbeddings"
+
+
+def test_get_embeddings_ollama_selectable():
+    with patch.dict(os.environ, {"EMBEDDING_PROVIDER": "ollama"}):
+        client = get_embeddings()
+
+    assert type(client).__name__ == "OllamaEmbeddings"
+
+
+def test_get_embeddings_unknown_provider_raises():
+    with patch.dict(os.environ, {"EMBEDDING_PROVIDER": "bogus"}):
+        try:
+            get_embeddings()
+            raise AssertionError("expected ValueError")
+        except ValueError as e:
+            assert "bogus" in str(e)
+
+
+def test_get_embedding_model_name_per_provider():
+    with patch.dict(os.environ, {"EMBEDDING_PROVIDER": "logos"}, clear=False):
+        os.environ.pop("EMBEDDING_MODEL", None)
+        assert get_embedding_model_name() == "Qwen/Qwen3-Embedding-8B"
+
+    with patch.dict(os.environ, {"EMBEDDING_PROVIDER": "openai"}, clear=False):
+        os.environ.pop("EMBEDDING_MODEL", None)
+        assert get_embedding_model_name() == "text-embedding-3-small"
+
+    with patch.dict(os.environ, {"EMBEDDING_PROVIDER": "ollama", "EMBEDDING_MODEL": "custom-embed"}):
+        assert get_embedding_model_name() == "custom-embed"
+
+
+# --- embedding with a mocked client ---
+
+
+def test_embed_chunks_returns_one_vector_per_chunk():
+    chunks = [Chunk("k", 0, "alpha"), Chunk("k", 1, "beta beta")]
+
+    with patch("app.embeddings.get_embeddings", return_value=_FakeEmbeddings()):
+        vectors = embed_chunks(chunks)
+
+    assert len(vectors) == len(chunks)
+    assert vectors[0] == [5.0, 0.0]
+    assert vectors[1] == [9.0, 1.0]
+
+
+def test_embed_chunks_empty_input_skips_client():
+    with patch("app.embeddings.get_embeddings", side_effect=AssertionError("must not call client")):
+        assert embed_chunks([]) == []
+
+
+def test_embed_query_returns_single_vector():
+    with patch("app.embeddings.get_embeddings", return_value=_FakeEmbeddings()):
+        vector = embed_query("hello")
+
+    assert vector == [5.0, 0.0]

--- a/services/genai/tests/test_embeddings.py
+++ b/services/genai/tests/test_embeddings.py
@@ -7,6 +7,8 @@ mirroring the LLM-mocked tests for summarize/qa.
 import os
 from unittest.mock import patch
 
+import pytest
+
 from app.embeddings import (
     Chunk,
     chunk_text,
@@ -61,6 +63,12 @@ def test_chunk_text_single_short_chunk():
     assert chunks[0].chunk_index == 0
 
 
+def test_chunk_text_rejects_invalid_chunk_size():
+    with patch.dict(os.environ, {"CHUNK_SIZE": "abc"}):
+        with pytest.raises(RuntimeError, match="CHUNK_SIZE"):
+            chunk_text("some text to split", "k")
+
+
 # --- provider selection ---
 
 
@@ -70,6 +78,45 @@ def test_get_embeddings_defaults_to_logos():
         client = get_embeddings()
 
     assert type(client).__name__ == "OpenAIEmbeddings"
+
+
+def test_embedding_creds_default_to_provider_when_nothing_set():
+    with patch("langchain_openai.OpenAIEmbeddings") as mock_emb, patch.dict(os.environ, {"EMBEDDING_PROVIDER": "logos"}, clear=False):
+        for var in ("EMBEDDING_BASE_URL", "LLM_BASE_URL", "EMBEDDING_API_KEY", "LLM_API_KEY"):
+            os.environ.pop(var, None)
+        get_embeddings()
+
+    kwargs = mock_emb.call_args.kwargs
+    assert kwargs["base_url"] == "https://logos.aet.cit.tum.de/v1"
+    assert kwargs["api_key"] == ""
+
+
+def test_embedding_creds_reuse_llm_vars_when_no_override():
+    env = {"EMBEDDING_PROVIDER": "logos", "LLM_BASE_URL": "http://llm.local/v1", "LLM_API_KEY": "lg-llm"}
+    with patch("langchain_openai.OpenAIEmbeddings") as mock_emb, patch.dict(os.environ, env, clear=False):
+        os.environ.pop("EMBEDDING_BASE_URL", None)
+        os.environ.pop("EMBEDDING_API_KEY", None)
+        get_embeddings()
+
+    kwargs = mock_emb.call_args.kwargs
+    assert kwargs["base_url"] == "http://llm.local/v1"
+    assert kwargs["api_key"] == "lg-llm"
+
+
+def test_embedding_specific_vars_override_llm_vars():
+    env = {
+        "EMBEDDING_PROVIDER": "openai",
+        "LLM_BASE_URL": "http://llm.local/v1",
+        "LLM_API_KEY": "lg-llm",
+        "EMBEDDING_BASE_URL": "https://api.openai.com/v1",
+        "EMBEDDING_API_KEY": "sk-emb",
+    }
+    with patch("langchain_openai.OpenAIEmbeddings") as mock_emb, patch.dict(os.environ, env):
+        get_embeddings()
+
+    kwargs = mock_emb.call_args.kwargs
+    assert kwargs["base_url"] == "https://api.openai.com/v1"
+    assert kwargs["api_key"] == "sk-emb"
 
 
 def test_get_embeddings_ollama_selectable():

--- a/services/genai/tests/test_env.py
+++ b/services/genai/tests/test_env.py
@@ -1,0 +1,41 @@
+"""Unit tests for the environment helpers."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from app.env import int_env
+
+
+def test_int_env_returns_default_when_unset():
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("SOME_INT", None)
+        assert int_env("SOME_INT", 7, minimum=1) == 7
+
+
+def test_int_env_returns_default_when_empty():
+    with patch.dict(os.environ, {"SOME_INT": ""}):
+        assert int_env("SOME_INT", 7, minimum=1) == 7
+
+
+def test_int_env_parses_valid_value():
+    with patch.dict(os.environ, {"SOME_INT": "12"}):
+        assert int_env("SOME_INT", 7, minimum=1) == 12
+
+
+def test_int_env_rejects_non_integer():
+    with patch.dict(os.environ, {"SOME_INT": "abc"}):
+        with pytest.raises(RuntimeError, match="must be an integer"):
+            int_env("SOME_INT", 7, minimum=1)
+
+
+def test_int_env_rejects_below_minimum():
+    with patch.dict(os.environ, {"SOME_INT": "0"}):
+        with pytest.raises(RuntimeError, match="must be >= 1"):
+            int_env("SOME_INT", 7, minimum=1)
+
+
+def test_int_env_allows_zero_when_minimum_is_zero():
+    with patch.dict(os.environ, {"SOME_INT": "0"}):
+        assert int_env("SOME_INT", 7, minimum=0) == 0

--- a/services/genai/tests/test_main.py
+++ b/services/genai/tests/test_main.py
@@ -41,6 +41,7 @@ def test_openapi_schema_exposes_all_endpoints():
     assert "/genai/extract" in paths
     assert "/genai/ask" in paths
     assert "/genai/index" in paths
+    assert "/genai/index/{object_key}" in paths
     # metrics is an operational endpoint, not part of the public API surface
     assert "/genai/metrics" not in paths
 
@@ -259,3 +260,23 @@ def test_index_returns_422_for_empty_document():
 def test_index_rejects_missing_object_key():
     response = client.post("/genai/index", json={})
     assert response.status_code == 422
+
+
+# --- delete index ---
+
+
+def test_delete_index_removes_chunks_for_object_key():
+    with patch("app.main.delete_document", return_value=4) as mock_delete:
+        response = client.delete("/genai/index/uploads/abc/report.txt")
+
+    assert response.status_code == 200
+    assert response.json() == {"objectKey": "uploads/abc/report.txt", "chunksDeleted": 4}
+    mock_delete.assert_called_once_with("uploads/abc/report.txt")
+
+
+def test_delete_index_is_idempotent_for_unindexed_document():
+    with patch("app.main.delete_document", return_value=0):
+        response = client.delete("/genai/index/never-indexed.txt")
+
+    assert response.status_code == 200
+    assert response.json()["chunksDeleted"] == 0

--- a/services/genai/tests/test_main.py
+++ b/services/genai/tests/test_main.py
@@ -40,6 +40,7 @@ def test_openapi_schema_exposes_all_endpoints():
     assert "/genai/summarize" in paths
     assert "/genai/extract" in paths
     assert "/genai/ask" in paths
+    assert "/genai/index" in paths
     # metrics is an operational endpoint, not part of the public API surface
     assert "/genai/metrics" not in paths
 
@@ -234,4 +235,60 @@ def test_ask_skips_unreadable_objects():
 
 def test_ask_rejects_empty_question():
     response = client.post("/genai/ask", json={"question": "  ", "objectKeys": ["key-1"]})
+    assert response.status_code == 422
+
+
+# --- index ---
+
+
+def test_index_chunks_embeds_and_stores_document():
+    captured = {}
+
+    def fake_index(object_key, chunks, vectors):
+        captured["object_key"] = object_key
+        captured["num_chunks"] = len(chunks)
+        return len(chunks)
+
+    fake_chunks = [object(), object(), object()]
+
+    with (
+        patch("app.main.fetch_text", return_value="a long document body"),
+        patch("app.main.chunk_text", return_value=fake_chunks),
+        patch("app.main.embed_chunks", return_value=[[0.1], [0.2], [0.3]]),
+        patch("app.main.index_chunks", side_effect=fake_index),
+        patch("app.main.get_embedding_model_name", return_value="Qwen/Qwen3-Embedding-8B"),
+    ):
+        response = client.post("/genai/index", json={"objectKey": "uploads/abc/report.txt"})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body == {
+        "objectKey": "uploads/abc/report.txt",
+        "chunksIndexed": 3,
+        "embeddingModel": "Qwen/Qwen3-Embedding-8B",
+    }
+    assert captured["object_key"] == "uploads/abc/report.txt"
+    assert captured["num_chunks"] == 3
+
+
+def test_index_returns_404_for_missing_object():
+    with patch("app.main.fetch_text", side_effect=ObjectNotFoundError("missing")):
+        response = client.post("/genai/index", json={"objectKey": "missing"})
+    assert response.status_code == 404
+
+
+def test_index_returns_415_for_unsupported_file():
+    with patch("app.main.fetch_text", side_effect=UnsupportedFileError("not text")):
+        response = client.post("/genai/index", json={"objectKey": "image.png"})
+    assert response.status_code == 415
+
+
+def test_index_returns_422_for_empty_document():
+    with patch("app.main.fetch_text", return_value="   "):
+        response = client.post("/genai/index", json={"objectKey": "blank.txt"})
+    assert response.status_code == 422
+
+
+def test_index_rejects_missing_object_key():
+    response = client.post("/genai/index", json={})
     assert response.status_code == 422

--- a/services/genai/tests/test_main.py
+++ b/services/genai/tests/test_main.py
@@ -164,13 +164,10 @@ def test_extract_rejects_missing_object_key():
 # --- ask ---
 
 
-def test_ask_returns_answer_and_sources():
-    with (
-        patch("app.main.fetch_text", return_value="doc body"),
-        patch(
-            "app.main.answer_question",
-            return_value=("The answer is 42.", ["key-1"], "openai/gpt-oss-120b"),
-        ),
+def test_ask_returns_answer_and_cited_sources():
+    with patch(
+        "app.main.answer_question",
+        return_value=("The answer is 42.", ["key-1"], "openai/gpt-oss-120b"),
     ):
         response = client.post(
             "/genai/ask",
@@ -184,53 +181,23 @@ def test_ask_returns_answer_and_sources():
     assert body["modelUsed"] == "openai/gpt-oss-120b"
 
 
-def test_ask_fetches_each_object_and_passes_documents():
+def test_ask_passes_question_and_object_keys_to_retrieval():
     captured = {}
 
-    def fake_answer(question, object_keys, documents):
-        captured["documents"] = documents
-        return ("Revenue grew 15%.", [d["id"] for d in documents], "openai/gpt-oss-120b")
+    def fake_answer(question, object_keys):
+        captured["question"] = question
+        captured["object_keys"] = object_keys
+        return ("answer", ["key-1"], "test-model")
 
-    with (
-        patch("app.main.fetch_text", side_effect=lambda k: f"content of {k}"),
-        patch("app.main.answer_question", side_effect=fake_answer),
-    ):
+    with patch("app.main.answer_question", side_effect=fake_answer):
         response = client.post(
             "/genai/ask",
             json={"question": "What was revenue growth?", "objectKeys": ["key-1", "key-2"]},
         )
 
     assert response.status_code == 200
-    assert captured["documents"] == [
-        {"id": "key-1", "content": "content of key-1"},
-        {"id": "key-2", "content": "content of key-2"},
-    ]
-
-
-def test_ask_skips_unreadable_objects():
-    def flaky_fetch(key):
-        if key == "bad":
-            raise ObjectNotFoundError(key)
-        return "good content"
-
-    captured = {}
-
-    def fake_answer(question, object_keys, documents):
-        captured["documents"] = documents
-        return ("answer", [d["id"] for d in documents], "test-model")
-
-    with (
-        patch("app.main.fetch_text", side_effect=flaky_fetch),
-        patch("app.main.answer_question", side_effect=fake_answer),
-    ):
-        response = client.post(
-            "/genai/ask",
-            json={"question": "Q?", "objectKeys": ["good", "bad"]},
-        )
-
-    assert response.status_code == 200
-    assert captured["documents"] == [{"id": "good", "content": "good content"}]
-    assert response.json()["sourceObjectKeys"] == ["good"]
+    assert captured["question"] == "What was revenue growth?"
+    assert captured["object_keys"] == ["key-1", "key-2"]
 
 
 def test_ask_rejects_empty_question():

--- a/services/genai/tests/test_qa.py
+++ b/services/genai/tests/test_qa.py
@@ -7,6 +7,7 @@ running services are needed.
 import os
 from unittest.mock import patch
 
+import pytest
 from langchain_core.messages import AIMessage
 from langchain_core.runnables import RunnableLambda
 
@@ -94,6 +95,17 @@ def test_top_k_is_read_from_env():
         answer_question("q", ["doc-1"])
 
     assert captured["k"] == 9
+
+
+def test_answer_question_rejects_invalid_top_k():
+    with (
+        patch.dict(os.environ, {"RAG_TOP_K": "abc"}),
+        patch("app.qa.embed_query", return_value=[0.1]),
+        patch("app.qa.search", return_value=[]),
+        patch("app.qa.get_model_name", return_value="m"),
+    ):
+        with pytest.raises(RuntimeError, match="RAG_TOP_K"):
+            answer_question("q", ["doc-1"])
 
 
 def test_answer_is_stripped():

--- a/services/genai/tests/test_qa.py
+++ b/services/genai/tests/test_qa.py
@@ -1,74 +1,108 @@
-"""Unit tests for the Q&A module."""
+"""Unit tests for the retrieval-augmented Q&A module.
 
+Weaviate retrieval, the embedder, and the LLM are all mocked, so no network or
+running services are needed.
+"""
+
+import os
 from unittest.mock import patch
 
 from langchain_core.messages import AIMessage
 from langchain_core.runnables import RunnableLambda
 
+from app.qa import _NO_CONTEXT_MESSAGE, answer_question
 
-def _make_fake_llm(response: str):
+
+def _fake_llm(response: str):
     return RunnableLambda(lambda _: AIMessage(content=response))
 
 
-def test_ask_without_document_contents_returns_answer():
-    fake_llm = _make_fake_llm("The answer is 42.")
+def _hit(object_key: str, chunk_index: int, text: str) -> dict:
+    return {"object_key": object_key, "chunk_index": chunk_index, "text": text, "distance": 0.1}
 
-    with patch("app.qa.get_llm", return_value=fake_llm), patch("app.qa.get_model_name", return_value="openai/gpt-oss-120b"):
-        from app.qa import answer_question
 
-        answer, source_keys, model = answer_question(
-            question="What is the answer?",
-            object_keys=["id-1", "id-2"],
-            documents=None,
-        )
+def test_answer_uses_retrieved_chunks_and_cites_sources():
+    hits = [_hit("doc-1", 0, "Revenue grew 15%."), _hit("doc-2", 3, "Costs were flat.")]
 
-    assert answer == "The answer is 42."
-    assert source_keys == ["id-1", "id-2"]
+    with (
+        patch("app.qa.embed_query", return_value=[0.1, 0.2]),
+        patch("app.qa.search", return_value=hits),
+        patch("app.qa.get_llm", return_value=_fake_llm("Revenue grew by 15%.")),
+        patch("app.qa.get_model_name", return_value="openai/gpt-oss-120b"),
+    ):
+        answer, sources, model = answer_question("How did revenue change?", ["doc-1", "doc-2"])
+
+    assert answer == "Revenue grew by 15%."
+    assert sources == ["doc-1", "doc-2"]
     assert model == "openai/gpt-oss-120b"
 
 
-def test_ask_with_document_contents_uses_context():
-    fake_llm = _make_fake_llm("Based on the documents, the revenue grew by 15%.")
+def test_sources_are_deduplicated_in_retrieval_order():
+    hits = [_hit("doc-2", 0, "a"), _hit("doc-1", 1, "b"), _hit("doc-2", 2, "c")]
 
-    with patch("app.qa.get_llm", return_value=fake_llm), patch("app.qa.get_model_name", return_value="openai/gpt-oss-120b"):
-        from app.qa import answer_question
+    with (
+        patch("app.qa.embed_query", return_value=[0.0]),
+        patch("app.qa.search", return_value=hits),
+        patch("app.qa.get_llm", return_value=_fake_llm("answer")),
+        patch("app.qa.get_model_name", return_value="m"),
+    ):
+        _, sources, _ = answer_question("q", ["doc-1", "doc-2"])
 
-        answer, source_keys, model = answer_question(
-            question="What was the revenue growth?",
-            object_keys=["doc-1", "doc-2"],
-            documents=[
-                {"id": "doc-1", "content": "Q4 revenue grew by 15% year-over-year."},
-                {"id": "doc-2", "content": "Operating costs remained stable."},
-            ],
-        )
-
-    assert "15%" in answer
-    assert set(source_keys) == {"doc-1", "doc-2"}
-    assert model == "openai/gpt-oss-120b"
+    assert sources == ["doc-2", "doc-1"]
 
 
-def test_ask_with_document_contents_returns_only_content_ids():
-    fake_llm = _make_fake_llm("Some answer.")
+def test_empty_object_keys_returns_fallback_without_searching():
+    with (
+        patch("app.qa.search", side_effect=AssertionError("must not search")),
+        patch("app.qa.embed_query", side_effect=AssertionError("must not embed")),
+        patch("app.qa.get_model_name", return_value="m"),
+    ):
+        answer, sources, model = answer_question("q", [])
 
-    with patch("app.qa.get_llm", return_value=fake_llm), patch("app.qa.get_model_name", return_value="test-model"):
-        from app.qa import answer_question
-
-        _, source_keys, _ = answer_question(
-            question="Something?",
-            object_keys=["all-1", "all-2", "all-3"],
-            documents=[{"id": "content-doc", "content": "relevant text"}],
-        )
-
-    # when content is provided, source_keys come from the content, not document_ids
-    assert source_keys == ["content-doc"]
+    assert answer == _NO_CONTEXT_MESSAGE
+    assert sources == []
+    assert model == "m"
 
 
-def test_ask_strips_whitespace_from_answer():
-    fake_llm = _make_fake_llm("  Answer with spaces.  ")
+def test_empty_retrieval_returns_fallback_without_calling_llm():
+    with (
+        patch("app.qa.embed_query", return_value=[0.1]),
+        patch("app.qa.search", return_value=[]),
+        patch("app.qa.get_llm", side_effect=AssertionError("must not call llm")),
+        patch("app.qa.get_model_name", return_value="m"),
+    ):
+        answer, sources, _ = answer_question("q", ["doc-1"])
 
-    with patch("app.qa.get_llm", return_value=fake_llm), patch("app.qa.get_model_name", return_value="test-model"):
-        from app.qa import answer_question
+    assert answer == _NO_CONTEXT_MESSAGE
+    assert sources == []
 
-        answer, _, _ = answer_question("Question?", ["id-1"], None)
 
-    assert answer == "Answer with spaces."
+def test_top_k_is_read_from_env():
+    captured = {}
+
+    def fake_search(vector, keys, k):
+        captured["k"] = k
+        return [_hit("doc-1", 0, "x")]
+
+    with (
+        patch.dict(os.environ, {"RAG_TOP_K": "9"}),
+        patch("app.qa.embed_query", return_value=[0.1]),
+        patch("app.qa.search", side_effect=fake_search),
+        patch("app.qa.get_llm", return_value=_fake_llm("a")),
+        patch("app.qa.get_model_name", return_value="m"),
+    ):
+        answer_question("q", ["doc-1"])
+
+    assert captured["k"] == 9
+
+
+def test_answer_is_stripped():
+    with (
+        patch("app.qa.embed_query", return_value=[0.1]),
+        patch("app.qa.search", return_value=[_hit("doc-1", 0, "x")]),
+        patch("app.qa.get_llm", return_value=_fake_llm("  spaced answer  ")),
+        patch("app.qa.get_model_name", return_value="m"),
+    ):
+        answer, _, _ = answer_question("q", ["doc-1"])
+
+    assert answer == "spaced answer"

--- a/services/genai/tests/test_vectorstore.py
+++ b/services/genai/tests/test_vectorstore.py
@@ -102,3 +102,11 @@ def test_delete_is_idempotent(store):
 
     assert store.delete_document(key) == 1
     assert store.delete_document(key) == 0
+
+
+def test_index_chunks_rejects_mismatched_object_key():
+    # Validation happens before any Weaviate call, so this needs no live instance.
+    from app import vectorstore
+
+    with pytest.raises(ValueError, match="must belong to object_key"):
+        vectorstore.index_chunks("doc-a", [Chunk("doc-b", 0, "x")], [_vec(1.0)])

--- a/services/genai/tests/test_vectorstore.py
+++ b/services/genai/tests/test_vectorstore.py
@@ -16,8 +16,11 @@ import os
 import uuid
 
 import pytest
+from weaviate.exceptions import WeaviateConnectionError, WeaviateGRPCUnavailableError, WeaviateStartUpError
 
 from app.embeddings import Chunk
+
+_UNREACHABLE = (WeaviateConnectionError, WeaviateStartUpError, WeaviateGRPCUnavailableError)
 
 pytestmark = pytest.mark.integration
 
@@ -36,7 +39,7 @@ def store():
     vectorstore = pytest.importorskip("app.vectorstore")
     try:
         vectorstore._client()
-    except Exception as e:  # noqa: BLE001 - any connection failure means "no Weaviate, skip"
+    except _UNREACHABLE as e:
         pytest.skip(f"Weaviate not reachable: {e}")
 
     yield vectorstore
@@ -86,6 +89,7 @@ def test_search_is_scoped_to_requested_keys(store):
         store.index_chunks(key_b, [Chunk(key_b, 0, "b")], [_vec(1.0, 0.0)])
 
         hits = store.search(_vec(1.0, 0.0), [key_a], 10)
+        assert hits
         assert all(h["object_key"] == key_a for h in hits)
     finally:
         store.delete_document(key_a)

--- a/services/genai/tests/test_vectorstore.py
+++ b/services/genai/tests/test_vectorstore.py
@@ -1,0 +1,100 @@
+"""Integration tests for the Weaviate vector store.
+
+These run against a real Weaviate and are skipped when none is reachable. The
+intended way to run them is the compose test profile, which starts a throwaway
+Weaviate and runs the suite in a container against it:
+
+    docker compose run --rm genai-test
+
+Each test uses unique object keys and cleans up the keys it created, so the
+suite never deletes whole collections or touches data it didn't write. Weaviate
+locks a self-provided collection to the dimension of its first inserted vector,
+so every test here uses the same vector width.
+"""
+
+import os
+import uuid
+
+import pytest
+
+from app.embeddings import Chunk
+
+pytestmark = pytest.mark.integration
+
+_DIM = 3
+
+
+def _vec(*values: float) -> list[float]:
+    """Pad/truncate to the fixed test dimension so all inserts agree."""
+    v = list(values) + [0.0] * _DIM
+    return v[:_DIM]
+
+
+@pytest.fixture(scope="module")
+def store():
+    os.environ.setdefault("WEAVIATE_URL", "http://localhost:8080")
+    vectorstore = pytest.importorskip("app.vectorstore")
+    try:
+        vectorstore._client()
+    except Exception as e:  # noqa: BLE001 - any connection failure means "no Weaviate, skip"
+        pytest.skip(f"Weaviate not reachable: {e}")
+
+    yield vectorstore
+
+    vectorstore.close_client()
+
+
+def _key() -> str:
+    return f"test/{uuid.uuid4()}.txt"
+
+
+def test_index_then_search_returns_scoped_chunks(store):
+    key = _key()
+    chunks = [Chunk(key, 0, "alpha"), Chunk(key, 1, "beta"), Chunk(key, 2, "gamma")]
+    vectors = [_vec(1.0, 0.0, 0.0), _vec(0.0, 1.0, 0.0), _vec(0.0, 0.0, 1.0)]
+
+    try:
+        assert store.index_chunks(key, chunks, vectors) == 3
+
+        hits = store.search(_vec(1.0, 0.0, 0.0), [key], 3)
+        assert hits[0]["chunk_index"] == 0
+        assert hits[0]["object_key"] == key
+        assert {h["chunk_index"] for h in hits} == {0, 1, 2}
+    finally:
+        store.delete_document(key)
+
+
+def test_reindex_with_fewer_chunks_drops_stale(store):
+    key = _key()
+    chunks = [Chunk(key, 0, "a"), Chunk(key, 1, "b"), Chunk(key, 2, "c")]
+    vectors = [_vec(1.0), _vec(0.0, 1.0), _vec(1.0, 1.0)]
+
+    try:
+        store.index_chunks(key, chunks, vectors)
+        store.index_chunks(key, chunks[:1], vectors[:1])
+
+        hits = store.search(_vec(1.0), [key], 10)
+        assert [h["chunk_index"] for h in hits] == [0]
+    finally:
+        store.delete_document(key)
+
+
+def test_search_is_scoped_to_requested_keys(store):
+    key_a, key_b = _key(), _key()
+    try:
+        store.index_chunks(key_a, [Chunk(key_a, 0, "a")], [_vec(1.0, 0.0)])
+        store.index_chunks(key_b, [Chunk(key_b, 0, "b")], [_vec(1.0, 0.0)])
+
+        hits = store.search(_vec(1.0, 0.0), [key_a], 10)
+        assert all(h["object_key"] == key_a for h in hits)
+    finally:
+        store.delete_document(key_a)
+        store.delete_document(key_b)
+
+
+def test_delete_is_idempotent(store):
+    key = _key()
+    store.index_chunks(key, [Chunk(key, 0, "x")], [_vec(1.0)])
+
+    assert store.delete_document(key) == 1
+    assert store.delete_document(key) == 0

--- a/services/genai/uv.lock
+++ b/services/genai/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.14.*"
 
 [[package]]
 name = "alexandria-genai"
-version = "1.4.0"
+version = "1.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },
@@ -94,30 +94,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.43.36"
+version = "1.43.38"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/9f/897287e955db0f50b12fd69ef45956e4fd2c7ddb48c736872f7ea2314443/boto3-1.43.36.tar.gz", hash = "sha256:587d7ee92a12e440ad12b0e7f11f3358f0c4d65b19f64726efc94aaf194aff28", size = 112690, upload-time = "2026-06-23T02:47:14.561Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/ee/97798453d8e9dba0c60458870b07c78ac685fc21cdddd8eb3e20190249c6/boto3-1.43.38.tar.gz", hash = "sha256:a8d1e175a87a743e755237d884d7e5f4606e61e5602e9823469a1a630e379b3c", size = 112691, upload-time = "2026-06-30T19:55:31.789Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/f1/274303f52483ecf199eae6f8d9b6f5951670397ee4d72c06cfd4eb644612/boto3-1.43.36-py3-none-any.whl", hash = "sha256:42942dde254673abcbc9e6e60017c88341a4f49d99d24e1f2e290fb38138c26f", size = 140031, upload-time = "2026-06-23T02:47:13.178Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/60/e0e3baeb394e084c5136a46b8e944ba87a26bb1f67f7b3064eb035bb7e77/boto3-1.43.38-py3-none-any.whl", hash = "sha256:edffb4a8f49c0a61e8f4aa4104cc2da3c362de8042fc0819216d5e5ce5d38380", size = 140030, upload-time = "2026-06-30T19:55:29.494Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.43.36"
+version = "1.43.38"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7c/37/da9e7f6ca73ac73afd7f0bb7f238aa5daba35c081e98d7f48a7c399599c0/botocore-1.43.36.tar.gz", hash = "sha256:4cae47d1b2d426316b85a0087d9e69e048f13bc003b5177d74639fe9dfd28205", size = 15625488, upload-time = "2026-06-23T02:47:03.192Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/6c/815f49f0c582396b1a4c37df554ffab6bb420abd5a96d5329183a97022de/botocore-1.43.38.tar.gz", hash = "sha256:70fbd5c74f5742f5975ddcc61e6afb5174cb80577c2ccc17c6898ad3a49b51f3", size = 15628316, upload-time = "2026-06-30T19:55:19.2Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/19/934f81592527a3f7f9b943c893e334c721a4644948642bc33885d584e9ec/botocore-1.43.36-py3-none-any.whl", hash = "sha256:3c65fdc39ed01d8dfde1e961b34038aed03c459f8ddf80717a12ac006475e49d", size = 15313630, upload-time = "2026-06-23T02:46:59.327Z" },
+    { url = "https://files.pythonhosted.org/packages/22/b4/fdff7920b3776b37f8b42d4e6eabb141974fa88f9fb1aae5c2224bdaf635/botocore-1.43.38-py3-none-any.whl", hash = "sha256:54c1c41aff82422d2b88a8a7d782fde8ae1299a45f088d00011d85c4bc44b0cc", size = 15312254, upload-time = "2026-06-30T19:55:14.837Z" },
 ]
 
 [[package]]
@@ -576,7 +576,7 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.9.3"
+version = "0.9.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -594,9 +594,9 @@ dependencies = [
     { name = "xxhash" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7e/b7/43f80940a758ceb48714ccc10c7acb9564be4f0d4786e8ed5d46deb0be39/langsmith-0.9.3.tar.gz", hash = "sha256:868a007b3ecda002914b21212a953c77fcb1d71a8a09a94562c3b57941d3df3a", size = 4577380, upload-time = "2026-06-26T15:56:30.45Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/05/04a1371a13be979750c2987dfbbe71c163ae2aa1b4b1f57e20be8c8fd052/langsmith-0.9.5.tar.gz", hash = "sha256:2429122dc24a77b712e3982e44789dfec85b1ed6d0a542529d5373498c939c9d", size = 4577515, upload-time = "2026-07-01T16:17:05.609Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/fb/dc9f70b5581371fba7b01ba0704fe859bfcd12c4dad82b42ec12bd4160b1/langsmith-0.9.3-py3-none-any.whl", hash = "sha256:aac85686868a7e61d77858b880230e510583c61ea48ac0a197e6ceff64ffb22b", size = 619927, upload-time = "2026-06-26T15:56:28.301Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/22/0e6177f5f4377cd112766b610c232214b175f3cd427aab86c497745aada3/langsmith-0.9.5-py3-none-any.whl", hash = "sha256:2b1c20c80ef58ca6a0d603b0df3c82ee4bfdeadbd5de560fa3cc1d90bff2dc44", size = 603917, upload-time = "2026-07-01T16:17:03.693Z" },
 ]
 
 [[package]]

--- a/services/genai/uv.lock
+++ b/services/genai/uv.lock
@@ -11,6 +11,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "langchain-ollama" },
     { name = "langchain-openai" },
+    { name = "langchain-text-splitters" },
     { name = "prometheus-fastapi-instrumentator" },
     { name = "pydantic" },
     { name = "pypdf" },
@@ -31,6 +32,7 @@ requires-dist = [
     { name = "fastapi", specifier = "~=0.138.2" },
     { name = "langchain-ollama", specifier = "~=1.1.0" },
     { name = "langchain-openai", specifier = "~=1.3.3" },
+    { name = "langchain-text-splitters", specifier = "~=1.1.2" },
     { name = "prometheus-fastapi-instrumentator", specifier = "~=8.0.2" },
     { name = "pydantic", specifier = "~=2.13.4" },
     { name = "pypdf", specifier = "~=6.14.2" },
@@ -427,6 +429,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d2/59/b5959aea96faa9146e2e49a7a22882b3528c62efafe9a6a95beab30c2305/langchain_protocol-0.0.18.tar.gz", hash = "sha256:ec3e11782f1ed0c9db38e5a9ed01b0e7a0d3fba406faa8aef6594b73c56a63e6", size = 6150, upload-time = "2026-06-18T17:08:26.959Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/99/2e/d82db9eec13ad0f72e7aaad5c4bc730ab111934fdc83c85523206eb9b0a0/langchain_protocol-0.0.18-py3-none-any.whl", hash = "sha256:70b53a86fbf9cedc863555effe44da192ab02d556ddbf2cf95b8873adcf41b5a", size = 7221, upload-time = "2026-06-18T17:08:25.996Z" },
+]
+
+[[package]]
+name = "langchain-text-splitters"
+version = "1.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/9f/6c545900fefb7b00ddfa3f16b80d61338a0ec68c31c5451eeeab99082760/langchain_text_splitters-1.1.2.tar.gz", hash = "sha256:782a723db0a4746ac91e251c7c1d57fd23636e4f38ed733074e28d7a86f41627", size = 293580, upload-time = "2026-04-16T14:20:39.162Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/26/1ef06f56198d631296d646a6223de35bcc6cf9795ceb2442816bc963b84c/langchain_text_splitters-1.1.2-py3-none-any.whl", hash = "sha256:a2de0d799ff31886429fd6e2e0032df275b60ec817c19059a7b46181cc1c2f10", size = 35903, upload-time = "2026-04-16T14:20:38.243Z" },
 ]
 
 [[package]]

--- a/services/genai/uv.lock
+++ b/services/genai/uv.lock
@@ -16,6 +16,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pypdf" },
     { name = "uvicorn", extra = ["standard"] },
+    { name = "weaviate-client" },
 ]
 
 [package.dev-dependencies]
@@ -37,6 +38,7 @@ requires-dist = [
     { name = "pydantic", specifier = "~=2.13.4" },
     { name = "pypdf", specifier = "~=6.14.2" },
     { name = "uvicorn", extras = ["standard"], specifier = "~=0.49.0" },
+    { name = "weaviate-client", specifier = "~=4.22.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -78,6 +80,19 @@ wheels = [
 ]
 
 [[package]]
+name = "authlib"
+version = "1.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "joserfc" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/98/7d93f30d029643c0275dbc0bd6d5a6f670661ee6c9a94d93af7ab4887600/authlib-1.7.2.tar.gz", hash = "sha256:2cea25fefcd4e7173bdf1372c0afc265c8034b23a8cd5dcb6a9164b826c64231", size = 176511, upload-time = "2026-05-06T08:10:23.116Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/95/adcb68e20c34162e9135f370d6e31737719c2b6f94bc953fe7ed1f10fe21/authlib-1.7.2-py2.py3-none-any.whl", hash = "sha256:3e1faedc9d87e7d56a164eca3ccb6ace0d61b94abe83e92242f8dc8bba9b4a9f", size = 259548, upload-time = "2026-05-06T08:10:21.436Z" },
+]
+
+[[package]]
 name = "boto3"
 version = "1.43.36"
 source = { registry = "https://pypi.org/simple" }
@@ -112,6 +127,39 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
 ]
 
 [[package]]
@@ -177,6 +225,56 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "49.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db", size = 4032100, upload-time = "2026-06-12T20:02:32.143Z" },
+    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
+    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/09/f42b1d190c5ba75f72062a387f8030d1d75f6ab035788f1d9c4b01de6525/cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e", size = 3810026, upload-time = "2026-06-12T20:02:39.262Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9e/db72b3ae7fc9cfad53e630e56c6ae83b9b6ff0bf3718ffb8012d20b3aabf/cryptography-49.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:73a205dce83953d131a4aa1e0fd917a2fd1c5b1eef251e9d7152efefcbf5caf7", size = 4013892, upload-time = "2026-06-12T20:02:10.735Z" },
+    { url = "https://files.pythonhosted.org/packages/86/12/c48a424f38db03027be9f7ed5c7dc5de9933dbee992865f98b13727a009d/cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d", size = 4678835, upload-time = "2026-06-12T20:02:48.743Z" },
+    { url = "https://files.pythonhosted.org/packages/68/28/8a3ad4653662c93fc44dc4e5d8fd374c25c42e07b34bbfbadf49cf57a5a8/cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa", size = 4697239, upload-time = "2026-06-12T20:02:56.03Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b2/2193fc74f81aee4f9b62733133b73b5176718932ed8f2e4b03fa040480a6/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb", size = 4685593, upload-time = "2026-06-12T20:02:50.666Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f1/1d3eaa243bfc5de4a187b22aa8c048b3e4980bfbe830ac46e6bac2e66947/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d", size = 5289961, upload-time = "2026-06-12T20:01:46.468Z" },
+    { url = "https://files.pythonhosted.org/packages/58/39/2d51306721330c486495853eda1c567880ff036de15a14c4b74f399934af/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561", size = 4731145, upload-time = "2026-06-12T20:02:16.832Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/983e838c7fd0d87fd8c969bcdd328edaf5f756e38df5281637424c155873/cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122", size = 4321719, upload-time = "2026-06-12T20:02:52.611Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f5/8f571d7e27c55bce9f76f026143bcb1e040a4233149ecca0bea5fa5dd5f7/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505", size = 4685209, upload-time = "2026-06-12T20:02:07.282Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/84/0e27016a6fc5a0886f797018b26aa42f40c09a82332bff77822a451deaaa/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866", size = 5246285, upload-time = "2026-06-12T20:01:32.439Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2d/5e1fb307cb5931881516b464c98774b3f2c36b5d4bb9a2830253cf553cad/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8", size = 4730441, upload-time = "2026-06-12T20:02:01.469Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c0/bff5a02ee731d207d6a1ed51732549d8c53d2bc8da1d10ec6f2844201d68/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3", size = 4815869, upload-time = "2026-06-12T20:01:36.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/814681d14248d95d73d5c3eea0c39a94eb8302df966f670a2c60de90974b/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27", size = 4960948, upload-time = "2026-06-12T20:02:18.688Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/93ecac273d3738939d023612ad12cca9a3740a5345d69fda04134c43fd96/cryptography-49.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:33cd0565932807baddb67b96dbee92f2c374b5c89dee09fd74079aeb8c8dba61", size = 3799153, upload-time = "2026-06-12T20:01:39.059Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/5bb823f5bedcf80718cea7fbc95ec5515cca3769633c4b01a32be7f30e7c/cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a", size = 4025947, upload-time = "2026-06-12T20:01:25.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
+    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e6/f60198ea8d9dfa15fff9ed4ca02ce362f6eadd9ba757dcc50634c4257b63/cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001", size = 3785547, upload-time = "2026-06-12T20:02:26.847Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -199,6 +297,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0c/a9/9f8f7e00195c29836e9bf58bbbaf579e29878b8a67851efff93d9b6d4eb7/fastapi-0.138.2.tar.gz", hash = "sha256:6432359d067a432134620e7c5e4c6e5063e7f37815bbbbf20acef14b0d2e3fc8", size = 420423, upload-time = "2026-06-29T12:44:12.556Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f2/b3/38be2c074bdd0c986340db1d72d7b2321b805b1c5a68069aa00b5d31fd02/fastapi-0.138.2-py3-none-any.whl", hash = "sha256:db90c1ffb5517fba5d4a9f80e866daa008747e646310c9ce155c8c535f9d1615", size = 129271, upload-time = "2026-06-29T12:44:13.905Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.78.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/8a/3d098f35c143a89520e568e6539cc098fcd294495910e359889ce8741c84/grpcio-1.78.0.tar.gz", hash = "sha256:7382b95189546f375c174f53a5fa873cef91c4b8005faa05cc5b3beea9c4f1c5", size = 12852416, upload-time = "2026-02-06T09:57:18.093Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/f2/b56e43e3c968bfe822fa6ce5bca10d5c723aa40875b48791ce1029bb78c7/grpcio-1.78.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:e87cbc002b6f440482b3519e36e1313eb5443e9e9e73d6a52d43bd2004fcfd8e", size = 5920591, upload-time = "2026-02-06T09:56:20.758Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/81/1f3b65bd30c334167bfa8b0d23300a44e2725ce39bba5b76a2460d85f745/grpcio-1.78.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:c41bc64626db62e72afec66b0c8a0da76491510015417c127bfc53b2fe6d7f7f", size = 11813685, upload-time = "2026-02-06T09:56:24.315Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/1c/bbe2f8216a5bd3036119c544d63c2e592bdf4a8ec6e4a1867592f4586b26/grpcio-1.78.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8dfffba826efcf366b1e3ccc37e67afe676f290e13a3b48d31a46739f80a8724", size = 6487803, upload-time = "2026-02-06T09:56:27.367Z" },
+    { url = "https://files.pythonhosted.org/packages/16/5c/a6b2419723ea7ddce6308259a55e8e7593d88464ce8db9f4aa857aba96fa/grpcio-1.78.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:74be1268d1439eaaf552c698cdb11cd594f0c49295ae6bb72c34ee31abbe611b", size = 7173206, upload-time = "2026-02-06T09:56:29.876Z" },
+    { url = "https://files.pythonhosted.org/packages/df/1e/b8801345629a415ea7e26c83d75eb5dbe91b07ffe5210cc517348a8d4218/grpcio-1.78.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:be63c88b32e6c0f1429f1398ca5c09bc64b0d80950c8bb7807d7d7fb36fb84c7", size = 6693826, upload-time = "2026-02-06T09:56:32.305Z" },
+    { url = "https://files.pythonhosted.org/packages/34/84/0de28eac0377742679a510784f049738a80424b17287739fc47d63c2439e/grpcio-1.78.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:3c586ac70e855c721bda8f548d38c3ca66ac791dc49b66a8281a1f99db85e452", size = 7277897, upload-time = "2026-02-06T09:56:34.915Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/9c/ad8685cfe20559a9edb66f735afdcb2b7d3de69b13666fdfc542e1916ebd/grpcio-1.78.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:35eb275bf1751d2ffbd8f57cdbc46058e857cf3971041521b78b7db94bdaf127", size = 8252404, upload-time = "2026-02-06T09:56:37.553Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/05/33a7a4985586f27e1de4803887c417ec7ced145ebd069bc38a9607059e2b/grpcio-1.78.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:207db540302c884b8848036b80db352a832b99dfdf41db1eb554c2c2c7800f65", size = 7696837, upload-time = "2026-02-06T09:56:40.173Z" },
+    { url = "https://files.pythonhosted.org/packages/73/77/7382241caf88729b106e49e7d18e3116216c778e6a7e833826eb96de22f7/grpcio-1.78.0-cp314-cp314-win32.whl", hash = "sha256:57bab6deef2f4f1ca76cc04565df38dc5713ae6c17de690721bdf30cb1e0545c", size = 4142439, upload-time = "2026-02-06T09:56:43.258Z" },
+    { url = "https://files.pythonhosted.org/packages/48/b2/b096ccce418882fbfda4f7496f9357aaa9a5af1896a9a7f60d9f2b275a06/grpcio-1.78.0-cp314-cp314-win_amd64.whl", hash = "sha256:dce09d6116df20a96acfdbf85e4866258c3758180e8c49845d6ba8248b6d0bbb", size = 4929852, upload-time = "2026-02-06T09:56:45.885Z" },
 ]
 
 [[package]]
@@ -349,6 +468,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
+name = "joserfc"
+version = "1.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/26/abe1ad855eb334b5ebc9c6495d4798e12bee70e5e8e815d54570710b8312/joserfc-1.7.2.tar.gz", hash = "sha256:537ffb8888b2df039cb5b6d017d7cff6f09d521ce65d89cc9b8ab752b1cff947", size = 233183, upload-time = "2026-06-29T09:03:10.868Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/80/d1b30336582cced4dce0dae776508a6011723e32f907bc7a702c0b25890a/joserfc-1.7.2-py3-none-any.whl", hash = "sha256:ddd818c0ca9b4f17bbc2d72cb3966e6ded7502be089316c62c3cc64ae86132b5", size = 70426, upload-time = "2026-06-29T09:03:09.393Z" },
 ]
 
 [[package]]
@@ -561,6 +692,30 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1b/e9/2065686d1dfa62296fdc158b6e8fd25b0cb3dca09b0632cabeb5ae81fe4d/prometheus_fastapi_instrumentator-8.0.2.tar.gz", hash = "sha256:3c252e748151768a7aefd66824a04a870144f71de48a67aed211749a9ca2a548", size = 21342, upload-time = "2026-06-23T09:39:31.611Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c6/c7/fa2b3f469a2e6001b829e0d6bc8680755349aa1329a87bf48731e9d5d30a/prometheus_fastapi_instrumentator-8.0.2-py3-none-any.whl", hash = "sha256:746002ec1e2c58b93f61444e1d104de959a9463a6a3f1c8909ac3757e16c3866", size = 20549, upload-time = "2026-06-23T09:39:32.616Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "6.33.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
 ]
 
 [[package]]
@@ -1001,6 +1156,15 @@ wheels = [
 ]
 
 [[package]]
+name = "validators"
+version = "0.35.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/66/a435d9ae49850b2f071f7ebd8119dd4e84872b01630d6736761e6e7fd847/validators-0.35.0.tar.gz", hash = "sha256:992d6c48a4e77c81f1b4daba10d16c3a9bb0dbb79b3a19ea847ff0928e70497a", size = 73399, upload-time = "2025-05-01T05:42:06.7Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/6e/3e955517e22cbdd565f2f8b2e73d52528b14b8bcfdb04f62466b071de847/validators-0.35.0-py3-none-any.whl", hash = "sha256:e8c947097eae7892cb3d26868d637f79f47b4a0554bc6b80065dfe5aac3705dd", size = 44712, upload-time = "2025-05-01T05:42:04.203Z" },
+]
+
+[[package]]
 name = "watchfiles"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1034,6 +1198,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/51/cf/3b10b268b4b7f0fc26e9debb5eef1998b515887840f444cd3ec80c688755/watchfiles-1.2.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:4c887eba18b7945ac73067a8b4a66f21cd46c2539b2bc68588f7be6c7eb6d26b", size = 463494, upload-time = "2026-05-18T04:31:33.826Z" },
     { url = "https://files.pythonhosted.org/packages/3d/3e/a4302545cd589262a0dc7d140e86f7688eba3f9c72776c27f7e23b8864c4/watchfiles-1.2.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:3416ff151bb6b5a8d8d11664974fbef4d9305b9b2957839ab5a270468fd8df30", size = 629383, upload-time = "2026-05-18T04:31:15.596Z" },
     { url = "https://files.pythonhosted.org/packages/db/99/d5649df0a9a410d45b7c882304d0b790903ac9b6e8f2cfd12114e0c6b9f2/watchfiles-1.2.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:0e831a271c035d89789cffc386b6aa1375f39f1cd25eb7ca0997e4970d152fc5", size = 656093, upload-time = "2026-05-18T04:31:58.707Z" },
+]
+
+[[package]]
+name = "weaviate-client"
+version = "4.22.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "authlib" },
+    { name = "grpcio" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "pydantic" },
+    { name = "validators" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/34/2a/73cf7d6c7c6aa638738dfcb0d318e0404aab3c0673f82a1a4d89455b21a5/weaviate_client-4.22.0.tar.gz", hash = "sha256:0c50fbef546a522262a87d1138cde0509c7a8a48e702e967be33472e9f7fbae3", size = 860126, upload-time = "2026-06-18T06:08:30.202Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/a3/27353ea3fbf9e7d4f03375176a838c632d009f5167d801adcbb5f6d3bd07/weaviate_client-4.22.0-py3-none-any.whl", hash = "sha256:ff2dbc8d1fc25739942402c22d1aba2350a16ba4a6b6ed0ba140689c70adf1d9", size = 652691, upload-time = "2026-06-18T06:08:28.622Z" },
 ]
 
 [[package]]

--- a/services/spring/app/src/main/java/com/alexandria/app/config/OpenApiConfig.java
+++ b/services/spring/app/src/main/java/com/alexandria/app/config/OpenApiConfig.java
@@ -12,7 +12,7 @@ import org.springframework.context.annotation.Configuration;
 @OpenAPIDefinition(
         info = @Info(
                 title = "Alexandria API",
-                version = "1.4.0",
+                version = "1.5.0",
                 description = "Document management and knowledge extraction platform",
                 license = @License(name = "MIT", identifier = "MIT")
         ),


### PR DESCRIPTION
## What does this PR do?

Builds the Weaviate-backed RAG pipeline for the GenAI service (epic #180). Until now `/genai/ask` pulled whole documents from object storage and stuffed the full text into one prompt. This replaces that with a real retrieve-then-generate flow: documents get chunked, embedded, and indexed in Weaviate, and a question retrieves only the relevant chunks and answers from those with backlinks to the source documents.

Worked through the sub-issues in order:

- Weaviate as a container in compose + Helm, config via env (Closes #181)
- provider-configurable embeddings + chunking module (Closes #182)
- chunk/embed/index a document via `POST /genai/index` (Closes #183)
- rewire `/genai/ask` to retrieve from Weaviate and cite sources (Closes #184)
- drop a document's chunks via `DELETE /genai/index/{objectKey}` (Closes #185)
- docs updated to match (#186, see reviewer notes)

All of it is genai-side only. The Spring service still needs to call the new index/delete endpoints, see the note for @ladu-tu below.

A few design choices worth knowing:

- Embeddings reuse `LLM_BASE_URL` / `LLM_API_KEY` rather than separate embedding creds, since they run on the same Logos/OpenAI gateway as the chat model. Default embedding model is `Qwen/Qwen3-Embedding-8B` via Logos, with OpenAI and Ollama selectable through `EMBEDDING_PROVIDER`.
- The Weaviate collection uses self-provided vectors (no Weaviate vectorizer), so it isn't pinned to a fixed dimension. The catch: Weaviate locks the collection to the first vector's width, so switching to an embedding model of a different size means re-indexing. This is documented in the System Overview and the genai README.
- Indexing is exposed as an explicit `POST /genai/index` endpoint (rather than folding it into the existing add flow) so Spring can trigger and retry it cleanly, and so delete mirrors it.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Docs
- [x] CI / infra

## Definition of Done

- [x] CI is green
- [x] If the API changed: `api/openapi.yaml` is updated and lint passes
- [x] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [x] Tests added or updated for the changed behaviour
- [x] Docs updated where it matters (README, ADRs, comments)

## Notes for the reviewer

@ladu-tu, the Spring service needs wiring to actually use this. The endpoints are in place and tested on the genai side, but nothing calls them yet. What's needed:

- On document add (both `createDocument` and `uploadDocument` in `KnowledgeBaseService`), call `POST /genai/index` with `{"objectKey": "..."}`, alongside the existing summarize/extract calls and wrapped in the same try/catch so a genai failure doesn't break the upload.
- On document delete (`deleteDocument`), call `DELETE /genai/index/{objectKey}` so the index stays in sync.
- `GenAiClient` will need an `index(objectKey)` and a delete method plus the matching request/response records (the index response is `{objectKey, chunksIndexed, embeddingModel}`).

I left the Spring side untouched on purpose so it stays your call how to integrate it.

**Other things to look at:**

- Pre-existing gap (@BjarneHa): the Helm genai deployment has no LLM config (`LLM_API_KEY` / `LLM_PROVIDER`), so embeddings won't have a key in-cluster either. Probably worth its own issue before we deploy RAG to the cluster.
- The real-Weaviate tests in `test_vectorstore.py` are marked `integration` and skip when no Weaviate is reachable, so plain `uv run pytest` and CI stay green. Run the full suite (including them) with `docker compose run --rm genai-test`, which spins up a throwaway in-network Weaviate and runs the tests in a container against it. Weaviate has no published ports anywhere, so nothing is reachable from the host and the tests never touch a real instance.

## Changes after review

Follow-up commits addressing the review:

GenAI service:
- Embeddings can run on a different endpoint/key than the chat model via `EMBEDDING_BASE_URL` / `EMBEDDING_API_KEY` (fall back to `LLM_*`, so single-provider setups are unchanged).
- Numeric config (`RAG_TOP_K`, `CHUNK_SIZE`, `CHUNK_OVERLAP`, `WEAVIATE_GRPC_PORT`) is validated and fails loudly on a bad value.
- `summarize`/`extract`/`index` now declare their 404/415 responses in the spec.
- `index_chunks` raises on `insert_many` partial failures and rejects mixed-`objectKey` batches; collection bootstrap tolerates a concurrent-create race.

Helm:
- genai ConfigMap exposes `WEAVIATE_GRPC_PORT`; the Weaviate Deployment uses its own replica count (1) and a `Recreate` strategy for the single RWO volume.

Tests:
- Integration-test skip narrowed to connection errors; scoped-search test asserts non-empty results.

Deliberately not changed:
- KICS findings on the Weaviate manifests: either false positives (the data volume must stay writable) or consistent with the rest of the chart (UID, namespace, image tags, automount). Worth a chart-wide hardening pass, not a patch on just the new files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added GenAI document indexing and deletion endpoints with chunk-based retrieval and citation-based answers.
  * Introduced configurable embeddings/RAG settings (provider/model, chunk size/overlap, top‑K) and Weaviate connectivity.
  * Added Weaviate support for local and Kubernetes deployments, including persistent storage.

* **Bug Fixes**
  * Improved “ask” responses to return “no relevant context” when retrieval yields no matches.

* **Documentation**
  * Updated API and GenAI/system overview docs to reflect the indexing/retrieval workflow.

* **Tests**
  * Expanded unit and Weaviate-backed integration coverage for embeddings, retrieval, indexing, and deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->