### PR TITLE
Task: Pin Spring GenAI client to HTTP 1.1 to avoid failing upgrade request

### DIFF
--- a/services/spring/app/src/main/java/com/alexandria/app/knowledgebase/GenAiClient.java
+++ b/services/spring/app/src/main/java/com/alexandria/app/knowledgebase/GenAiClient.java
@@ -5,8 +5,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
 
 import java.util.List;
+import java.net.http.HttpClient;
 
 @Component
 public class GenAiClient {
@@ -14,7 +16,12 @@ public class GenAiClient {
     private final RestClient restClient;
 
     public GenAiClient(@Value("${genai.base-url:http://localhost:8000}") String baseUrl) {
+        HttpClient httpClient = HttpClient.newBuilder()
+                .version(HttpClient.Version.HTTP_1_1)
+                .build();
+        JdkClientHttpRequestFactory factory = new JdkClientHttpRequestFactory(httpClient);
         this.restClient = RestClient.builder()
+                .requestFactory(factory)
                 .baseUrl(baseUrl)
                 .build();
     }
@@ -46,17 +53,24 @@ public class GenAiClient {
                 .body(AskResponse.class);
     }
 
-    public record SummarizeRequest(String objectKey) {}
+    public record SummarizeRequest(String objectKey) {
+    }
 
-    public record SummarizeResponse(String summary, String modelUsed) {}
+    public record SummarizeResponse(String summary, String modelUsed) {
+    }
 
-    public record ExtractRequest(String objectKey) {}
+    public record ExtractRequest(String objectKey) {
+    }
 
-    public record ExtractResponse(List<ExtractedEntityDto> entities, String modelUsed) {}
+    public record ExtractResponse(List<ExtractedEntityDto> entities, String modelUsed) {
+    }
 
-    public record ExtractedEntityDto(String name, EntityType type, Double confidence) {}
+    public record ExtractedEntityDto(String name, EntityType type, Double confidence) {
+    }
 
-    public record AskRequest(String question, List<String> objectKeys) {}
+    public record AskRequest(String question, List<String> objectKeys) {
+    }
 
-    public record AskResponse(String answer, List<String> sourceObjectKeys, String modelUsed) {}
+    public record AskResponse(String answer, List<String> sourceObjectKeys, String modelUsed) {
+    }
 }

--- a/services/spring/app/src/main/java/com/alexandria/app/knowledgebase/GenAiClient.java
+++ b/services/spring/app/src/main/java/com/alexandria/app/knowledgebase/GenAiClient.java
@@ -18,8 +18,10 @@ public class GenAiClient {
     public GenAiClient(@Value("${genai.base-url:http://localhost:8000}") String baseUrl) {
         HttpClient httpClient = HttpClient.newBuilder()
                 .version(HttpClient.Version.HTTP_1_1)
+                .connectTimeout(java.time.Duration.ofSeconds(5))
                 .build();
         JdkClientHttpRequestFactory factory = new JdkClientHttpRequestFactory(httpClient);
+        factory.setReadTimeout(java.time.Duration.ofSeconds(30));
         this.restClient = RestClient.builder()
                 .requestFactory(factory)
                 .baseUrl(baseUrl)


### PR DESCRIPTION
## What does this PR do?

<!-- Short description of the change. Reference any related issue: Closes #123 -->
The GenAI document summarization upon document upload failed on the GenAI side with
```bash
GenAI summarization failed for document XXX: 422 Unprocessable Content: "{"detail":[{"type":"missing","loc":["body"],"msg":"Field required","input":null}]}"
``` 
The issue was that the Spring GenAI client wanted to connect using HTTP/2 (default RestClient behavior). The upgrade request from HTTP/1.1 was sent alongside the payload containing the object key, but was rejected by uvicorn, which then lost the body, leading to the FastAPI failure. I've solved this issue by pinning the Spring RestClient to HTTP/1.1

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] CI / infra

## Definition of Done

- [x] CI is green
- [ ] If the API changed: `api/openapi.yaml` is updated and lint passes
- [ ] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [ ] Tests added or updated for the changed behaviour
- [ ] Docs updated where it matters (README, ADRs, comments)

## Notes for the reviewer

<!-- Anything they should look at first, gotchas, screenshots, ... -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the app’s backend HTTP setup to use a dedicated client configuration, improving consistency and request handling.
  * Reformatted several data response/request definitions for readability; no API fields or behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->