### PR TITLE
CI: Bump action versions to latest releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,7 +274,7 @@ jobs:
 
       - name: Setup Java
         if: env.RUN_JOB == 'true'
-        uses: actions/setup-java@v5.3.0
+        uses: actions/setup-java@v5.4.0
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}
@@ -431,7 +431,7 @@ jobs:
       - name: Extract Image Metadata
         if: env.RUN_JOB == 'true'
         id: meta
-        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.service.name }}
           tags: |
@@ -442,7 +442,7 @@ jobs:
 
       - name: Login to GHCR
         if: github.event_name == 'push' && env.RUN_JOB == 'true'
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        uses: docker/login-action@c99871dec2022cc055c062a10cc1a1310835ceb4 # v4.3.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -451,7 +451,7 @@ jobs:
       - name: Build (and Push on main)
         if: env.RUN_JOB == 'true'
         id: build
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ${{ matrix.service.context }}
           file: ${{ matrix.service.dockerfile }}


### PR DESCRIPTION
## What does this PR do?

Bumps four GitHub Actions in `ci.yml` to their latest releases:

| Action | Old | New |
|--------|-----|-----|
| `actions/setup-java` | `v5.3.0` | `v5.4.0` |
| `docker/metadata-action` | `80c7e9... # v6` | `dc8028... # v6.2.0` |
| `docker/login-action` | `650006... # v4` | `c99871... # v4.3.0` |
| `docker/build-push-action` | `f9f304... # v7` | `53b7df... # v7.3.0` |

The other 14 actions were already at their latest release.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [x] CI / infra

## Definition of Done

- [ ] CI is green
- [ ] If the API changed: `api/openapi.yaml` is updated and lint passes
- [ ] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [ ] Tests added or updated for the changed behaviour
- [ ] Docs updated where it matters (README, ADRs, comments)

## Notes for the reviewer

Straightforward version bumps, no behavioural changes. actionlint and yamllint passed locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated several CI workflow actions to newer versions for build and Docker jobs.
  * Improved the reliability of automated builds and image publishing by using the latest action releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->