### PR TITLE
CI: Update trivy-action SHA to match current v0.36.0 tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -466,7 +466,7 @@ jobs:
 
       - name: Run Trivy Scan (Image)
         if: env.RUN_JOB == 'true'
-        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
           format: sarif


### PR DESCRIPTION
## What does this PR do?

Fixes the zizmor job failing on main during the impostor-commit audit. The SHA pinned for `aquasecurity/trivy-action` (`a9c7b0f...`) no longer exists in the repo; the `v0.36.0` tag was re-pushed to a different commit (`ed142fd...`). Zizmor correctly flagged this as a potential supply chain issue.

Updated the SHA to the current one that `v0.36.0` actually points to.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] CI / infra

## Definition of Done

- [ ] CI is green
- [ ] If the API changed: `api/openapi.yaml` is updated and lint passes
- [ ] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [ ] Tests added or updated for the changed behaviour
- [ ] Docs updated where it matters (README, ADRs, comments)

## Notes for the reviewer


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pinned version of the image vulnerability scanning action in the CI workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->