### PR TITLE
Task: Bump to Java 25 and switch Spring service base images with fewer CVEs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ permissions:
   contents: read
 
 env:
-  JAVA_VERSION: "21"
+  JAVA_VERSION: "25"
   JAVA_DISTRIBUTION: "temurin"
   REGISTRY: ghcr.io
   IMAGE_NAMESPACE: ${{ github.repository }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ permissions:
 
 env:
   JAVA_VERSION: "25"
-  JAVA_DISTRIBUTION: "temurin"
+  JAVA_DISTRIBUTION: "zulu"
   REGISTRY: ghcr.io
   IMAGE_NAMESPACE: ${{ github.repository }}
   POSTGRES_HOST: ${{ vars.POSTGRES_HOST }}

--- a/services/spring/Dockerfile
+++ b/services/spring/Dockerfile
@@ -1,8 +1,7 @@
 # syntax=docker/dockerfile:1
 
-# Base image digests
-ARG JDK_IMAGE=eclipse-temurin:21-jdk-alpine@sha256:4fb80de7aeb277ad949cfbe89b4f504e50bb34c57fd908c5825236473d71e986
-ARG JRE_IMAGE=eclipse-temurin:21-jre-alpine@sha256:704db3c40204a44f471191446ddd9cda5d60dab40f0e15c6507b815ed897238b
+ARG JDK_IMAGE=amazoncorretto:25-alpine@sha256:32d81edae73e1670244827c2f12e5bcf0d335f035b538455fe9d02eb0771d41b
+ARG JRE_IMAGE=azul/zulu-openjdk-alpine:25-jre-headless@sha256:e8cb8b9d571afa0fb9c459e43e9c03c05ef1993018b1c038597e4c6536ab331d
 
 
 # Build stage

--- a/services/spring/Dockerfile
+++ b/services/spring/Dockerfile
@@ -1,11 +1,7 @@
 # syntax=docker/dockerfile:1
 
-ARG JDK_IMAGE=amazoncorretto:25-alpine@sha256:32d81edae73e1670244827c2f12e5bcf0d335f035b538455fe9d02eb0771d41b
-ARG JRE_IMAGE=azul/zulu-openjdk-alpine:25-jre-headless@sha256:e8cb8b9d571afa0fb9c459e43e9c03c05ef1993018b1c038597e4c6536ab331d
-
-
 # Build stage
-FROM ${JDK_IMAGE} AS build
+FROM azul/zulu-openjdk-alpine:25@sha256:b3c19142e9989390bd6b5d0a738ab4184359752019404388e8fafe16666cd4f3 AS build
 
 WORKDIR /app
 
@@ -18,7 +14,7 @@ COPY app/src/ src/
 RUN ./gradlew bootJar --no-daemon
 
 # Run stage
-FROM ${JRE_IMAGE}
+FROM azul/zulu-openjdk-alpine:25-jre-headless@sha256:e8cb8b9d571afa0fb9c459e43e9c03c05ef1993018b1c038597e4c6536ab331d
 
 WORKDIR /app
 

--- a/services/spring/app/build.gradle
+++ b/services/spring/app/build.gradle
@@ -15,11 +15,11 @@ openApi {
 }
 
 group = 'com.alexandria'
-version = '0.0.1-SNAPSHOT'
+version = '1.5.1'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

<!-- Short description of the change. Reference any related issue: Closes #123 -->
Bumps the Spring service to Java 25, as required by the project description (Best Practices Microservices section). Additionally, the spring service base images have been swapped out to ones without critical/high CVEs.

Closes #171 and closes #226.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [X] CI / infra

## Definition of Done

- [x] CI is green
- [ ] If the API changed: `api/openapi.yaml` is updated and lint passes
- [X] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [ ] Tests added or updated for the changed behaviour
- [ ] Docs updated where it matters (README, ADRs, comments)

## Notes for the reviewer

<!-- Anything they should look at first, gotchas, screenshots, ... -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded the Java runtime/tooling to version 25 across build and CI environments.
  * Switched container images to pinned Zulu OpenJDK 25 base images for more consistent builds and deployments.
  * Updated the application version to 1.5.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->