### PR TITLE
Fix: Move GenAI docs endpoints under /genai/ prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,23 +17,23 @@ Alexandria consists of three main subsystems orchestrated via Docker Compose and
 
 ## Setup
 
-
 ### Traefik Reverse Proxy
 
 All services are accessed through Traefik as the reverse proxy. See [`docs/traefik.md`](docs/traefik.md) for architecture, routing, and configuration details.
 
 **Quick reference:**
-| URL | Service |
-|-----|---------|
-| http://localhost/ | Client |
-| http://localhost/api/v1/... | Spring API |
-| http://localhost/user-service/docs | user-service API docs |
+
+| URL                                         | Service                        |
+| ------------------------------------------- | ------------------------------ |
+| http://localhost/                           | Client                         |
+| http://localhost/api/v1/...                 | Spring API                     |
+| http://localhost/user-service/docs          | user-service API docs          |
 | http://localhost/knowledgebase-service/docs | knowledgebase-service API docs |
-| http://localhost/qa-service/docs | qa-service API docs |
-| http://localhost/genai/docs | GenAI API documentation |
-| http://localhost/auth/ | Keycloak |
-| http://localhost/grafana/ | Grafana dashboards |
-| http://localhost/prometheus/ | Prometheus |
+| http://localhost/qa-service/docs            | qa-service API docs            |
+| http://localhost/genai/docs                 | GenAI API documentation        |
+| http://localhost/auth/                      | Keycloak                       |
+| http://localhost/grafana/                   | Grafana dashboards             |
+| http://localhost/prometheus/                | Prometheus                     |
 
 ### Infrastructure & Deployment
 
@@ -54,6 +54,7 @@ To run the full hook set manually:
 Our `docker-compose.yml` includes both pre-built image references and local build contexts. You can choose to pull images for instant startup or build them locally.
 
 **Pull and Run (Fastest):**
+
 1. `docker compose pull && docker compose up -d`
 2. Open http://localhost/ to view the site.
 
@@ -65,7 +66,8 @@ To build the images from your local source: `docker compose up --build --force-r
 For local development, `docker compose up` works out of the box; safe defaults are embedded in `docker-compose.yml`. For production or CI, copy `.env.example` to `.env` and set the values as needed.
 
 #### Troubleshooting
-- Make sure to remove all containers *and* docker volumes if you change to a local .env file. Otherwise, e.g., the postgres service will use the old password, leading to failed connections on the server side. This can be achieved by running `docker compose rm <container>` and `docker volume rm <volume>`.
+
+- Make sure to remove all containers _and_ docker volumes if you change to a local .env file. Otherwise, e.g., the postgres service will use the old password, leading to failed connections on the server side. This can be achieved by running `docker compose rm <container>` and `docker volume rm <volume>`.
 
 ### Server
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -240,7 +240,7 @@ services:
     labels:
       - "traefik.enable=true"
       # Only allow access to docs endpoints
-      - "traefik.http.routers.genai.rule=PathPrefix(`/docs`) || PathPrefix(`/redoc`) || PathPrefix(`/openapi.json`)"
+      - "traefik.http.routers.genai.rule=PathPrefix(`/genai/docs`) || PathPrefix(`/genai/redoc`) || PathPrefix(`/genai/openapi.json`)"
       - "traefik.http.routers.genai.entrypoints=web"
       - "traefik.http.routers.genai.priority=20"
       - "traefik.http.services.genai.loadbalancer.server.port=8000"

--- a/docs/traefik.md
+++ b/docs/traefik.md
@@ -27,6 +27,7 @@ Alexandria uses [Traefik](https://traefik.io/) as the reverse proxy and API gate
 ```
 
 **Public services** (accessible via Traefik):
+
 - Client (frontend)
 - Spring (REST API)
 - Keycloak (OIDC provider)
@@ -34,6 +35,7 @@ Alexandria uses [Traefik](https://traefik.io/) as the reverse proxy and API gate
 - Grafana and Prometheus (monitoring)
 
 **Private services** (internal Docker network only):
+
 - PostgreSQL
 - GenAI (except health and docs endpoints)
 
@@ -41,18 +43,18 @@ Traefik also exposes its own Prometheus metrics on a separate internal `metrics`
 
 ## Routing Table
 
-| Path | Service | Internal Port | Description |
-|------|---------|---------------|-------------|
-| `/` | Client | 80 | Static frontend (catch-all, lowest priority) |
-| `/api/v1/*` | Spring (user, knowledgebase, qa) | 8080 | REST API |
-| `/<service>-service/docs` | Spring | 8080 | Per-service API documentation UI |
-| `/<service>-service/v3/api-docs` | Spring | 8080 | Per-service OpenAPI spec |
-| `/auth/*` | Keycloak | 8180 | OIDC provider |
-| `/docs` | GenAI | 8000 | FastAPI documentation UI |
-| `/redoc` | GenAI | 8000 | FastAPI documentation UI (ReDoc) |
-| `/openapi.json` | GenAI | 8000 | FastAPI OpenAPI spec |
-| `/grafana/*` | Grafana | 3000 | Monitoring dashboards |
-| `/prometheus/*` | Prometheus | 9090 | Metrics store and query UI |
+| Path                             | Service                          | Internal Port | Description                                  |
+| -------------------------------- | -------------------------------- | ------------- | -------------------------------------------- |
+| `/`                              | Client                           | 80            | Static frontend (catch-all, lowest priority) |
+| `/api/v1/*`                      | Spring (user, knowledgebase, qa) | 8080          | REST API                                     |
+| `/<service>-service/docs`        | Spring                           | 8080          | Per-service API documentation UI             |
+| `/<service>-service/v3/api-docs` | Spring                           | 8080          | Per-service OpenAPI spec                     |
+| `/auth/*`                        | Keycloak                         | 8180          | OIDC provider                                |
+| `/genai/docs`                    | GenAI                            | 8000          | FastAPI documentation UI                     |
+| `/genai/redoc`                   | GenAI                            | 8000          | FastAPI documentation UI (ReDoc)             |
+| `/genai/openapi.json`            | GenAI                            | 8000          | FastAPI OpenAPI spec                         |
+| `/grafana/*`                     | Grafana                          | 3000          | Monitoring dashboards                        |
+| `/prometheus/*`                  | Prometheus                       | 9090          | Metrics store and query UI                   |
 
 ## Local Development
 
@@ -64,19 +66,19 @@ docker compose up -d
 
 ### Access Services
 
-| URL | Service |
-|-----|---------|
-| http://localhost/ | Client (frontend) |
-| http://localhost/api/... | Spring API |
-| http://localhost/user-service/docs | user-service API documentation |
+| URL                                         | Service                                 |
+| ------------------------------------------- | --------------------------------------- |
+| http://localhost/                           | Client (frontend)                       |
+| http://localhost/api/...                    | Spring API                              |
+| http://localhost/user-service/docs          | user-service API documentation          |
 | http://localhost/knowledgebase-service/docs | knowledgebase-service API documentation |
-| http://localhost/qa-service/docs | qa-service API documentation |
-| http://localhost/auth/ | Keycloak admin |
-| http://localhost/docs | GenAI API documentation |
-| http://localhost/redoc | GenAI API documentation (ReDoc) |
-| http://localhost/openapi.json | GenAI OpenAPI spec |
-| http://localhost/grafana/ | Grafana dashboards |
-| http://localhost/prometheus/ | Prometheus |
+| http://localhost/qa-service/docs            | qa-service API documentation            |
+| http://localhost/auth/                      | Keycloak admin                          |
+| http://localhost/genai/docs                 | GenAI API documentation                 |
+| http://localhost/genai/redoc                | GenAI API documentation (ReDoc)         |
+| http://localhost/genai/openapi.json         | GenAI OpenAPI spec                      |
+| http://localhost/grafana/                   | Grafana dashboards                      |
+| http://localhost/prometheus/                | Prometheus                              |
 
 ### Access Traefik Dashboard
 
@@ -102,6 +104,7 @@ my-new-service:
 ```
 
 Key points:
+
 - `traefik.enable=true` - Opt-in to Traefik routing (required since `exposedbydefault=false`)
 - `priority` - Higher values take precedence; client uses `1` as catch-all
 - `loadbalancer.server.port` - The container's internal port
@@ -117,21 +120,25 @@ docker compose logs traefik
 ### Verify Service Registration
 
 Open the Traefik dashboard at `http://traefik.localhost/` and check:
+
 - **Routers**: Shows all configured routes
 - **Services**: Shows backend services and their health
 
 ### Common Issues
 
 **Service not accessible:**
+
 1. Check if the service has `traefik.enable=true` label
 2. Verify the service is on the `alexandria` network
 3. Check the port in `loadbalancer.server.port` matches the container's exposed port
 
 **Path conflicts:**
+
 - Use `priority` to resolve conflicts (higher = matched first)
 - More specific paths should have higher priority than catch-all routes
 
 **502 Bad Gateway:**
+
 - The backend service is not running or not healthy
 - Check `docker compose ps` and `docker compose logs <service>`
 
@@ -148,7 +155,7 @@ curl -sI http://localhost/knowledgebase-service/docs
 curl http://localhost/auth/
 
 # Test GenAI docs
-curl http://localhost/docs
+curl http://localhost/genai/docs
 ```
 
 ## Production Considerations

--- a/infra/k8s/alexandria/templates/ingress.yaml
+++ b/infra/k8s/alexandria/templates/ingress.yaml
@@ -108,21 +108,21 @@ spec:
                 name: {{ include "alexandria.fullname" . }}-qa-service
                 port:
                   number: 8080
-          - path: /docs
+          - path: /genai/docs
             pathType: Prefix
             backend:
               service:
                 name: {{ include "alexandria.fullname" . }}-genai
                 port:
                   number: 8000
-          - path: /redoc
+          - path: /genai/redoc
             pathType: Prefix
             backend:
               service:
                 name: {{ include "alexandria.fullname" . }}-genai
                 port:
                   number: 8000
-          - path: /openapi.json
+          - path: /genai/openapi.json
             pathType: Prefix
             backend:
               service:

--- a/services/genai/README.md
+++ b/services/genai/README.md
@@ -21,7 +21,7 @@ The processing endpoints take object keys, not raw text. The service downloads t
 
 `ask` takes `{"question": "...", "objectKeys": [...]}` and answers with retrieval-augmented generation: the question is embedded, matched against the indexed chunks of the listed documents, and the top matches are passed to the LLM. The response returns `sourceObjectKeys`, the documents whose chunks actually fed the answer. When nothing relevant is found (or no documents are in scope), it says so instead of guessing.
 
-FastAPI also exposes `/openapi.json` and `/docs` (Swagger UI) out of the box.
+FastAPI also exposes `/genai/openapi.json` and `/genai/docs` (Swagger UI) out of the box.
 
 `/genai/metrics` is served by [prometheus-fastapi-instrumentator](https://github.com/trallnag/prometheus-fastapi-instrumentator) and exposes HTTP request count, latency, and Python process metrics. Prometheus scrapes it directly over the internal network (`http://genai:8000/genai/metrics`), so it is not routed through Traefik or the k8s ingress.
 

--- a/services/genai/app/main.py
+++ b/services/genai/app/main.py
@@ -26,6 +26,9 @@ app = FastAPI(
     title="Alexandria GenAI",
     description="GenAI microservice for the Alexandria document platform.",
     version=SERVICE_VERSION,
+    docs_url="/genai/docs",
+    redoc_url="/genai/redoc",
+    openapi_url="/genai/openapi.json",
     openapi_tags=[
         {"name": "health", "description": "Health check endpoints"},
         {"name": "hello", "description": "Hello endpoints"},

--- a/services/genai/tests/test_main.py
+++ b/services/genai/tests/test_main.py
@@ -32,7 +32,7 @@ def test_hello_returns_plain_text_greeting():
 
 
 def test_openapi_schema_exposes_all_endpoints():
-    response = client.get("/openapi.json")
+    response = client.get("/genai/openapi.json")
     assert response.status_code == 200
     paths = response.json()["paths"]
     assert "/genai/health" in paths


### PR DESCRIPTION
## What does this PR do?

Moves the GenAI service's auto-generated documentation endpoints (Swagger UI, ReDoc, OpenAPI spec) from the root level to the `/genai/` prefix, matching the convention used by all other genai endpoints. This prevents path collisions and keeps the routing table clean.

See #146

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] CI / infra

## Definition of Done

- [ ] CI is green
- [ ] If the API changed: `api/openapi.yaml` is updated and lint passes
- [x] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [x] Tests added or updated for the changed behaviour
- [x] Docs updated where it matters (README, ADRs, comments)

## Notes for the reviewer

The root README already had `http://localhost/genai/docs` so no change needed there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GenAI documentation and API reference are now available under a dedicated `/genai/` path.

* **Bug Fixes**
  * Updated routing so GenAI Swagger/OpenAPI links resolve correctly across local and cluster deployments.

* **Documentation**
  * Refreshed README and Traefik guidance to use `/genai/docs`, `/genai/redoc`, and `/genai/openapi.json`.
  * Minor README formatting tweaks.

* **Tests**
  * Updated integration tests to validate the new `/genai/openapi.json` location and related exposed endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->