### PR TITLE
Task: Fix Azure and Rancher deployment after Spring service split.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,7 +91,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 3
-      start_period: 80s
+      start_period: 180s
     depends_on:
       postgres-db:
         condition: service_healthy
@@ -144,7 +144,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 3
-      start_period: 80s
+      start_period: 180s
     depends_on:
       s3-storage:
         condition: service_healthy
@@ -197,7 +197,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 3
-      start_period: 80s
+      start_period: 180s
     depends_on:
       postgres-db:
         condition: service_healthy

--- a/infra/k8s/alexandria/values.yaml
+++ b/infra/k8s/alexandria/values.yaml
@@ -26,22 +26,25 @@ spring:
     usernameClaim: "preferred_username"
     rolesClaim: "roles"
 
+# CPU limits are sized so the sum of all `limits.cpu` in the alexandria
+# namespace stays under the 4 CPU quota enforced by the stud cluster
+# (ResourceQuota `default-h2d5c`).
 userService:
   resources:
     requests:
       cpu: 100m
       memory: 192Mi
     limits:
-      cpu: 300m
+      cpu: 200m
       memory: 384Mi
 
 knowledgebaseService:
   resources:
     requests:
-      cpu: 250m
+      cpu: 200m
       memory: 256Mi
     limits:
-      cpu: 500m
+      cpu: 400m
       memory: 512Mi
 
 qaService:
@@ -50,7 +53,7 @@ qaService:
       cpu: 100m
       memory: 192Mi
     limits:
-      cpu: 300m
+      cpu: 200m
       memory: 384Mi
 
 client:
@@ -59,7 +62,7 @@ client:
       cpu: 50m
       memory: 64Mi
     limits:
-      cpu: 250m
+      cpu: 100m
       memory: 128Mi
 
 genai:
@@ -166,11 +169,11 @@ postgres-db:
         CREATE DATABASE alexandria;
   resources:
     requests:
+      memory: "512Mi"
+      cpu: "250m"
+    limits:
       memory: "1Gi"
       cpu: "500m"
-    limits:
-      memory: "2Gi"
-      cpu: "1000m"
 
 s3:
   # endpoint: override to use external S3 (e.g. AWS). Leave empty to auto-derive from release name.


### PR DESCRIPTION
## What does this PR do?

<!-- Short description of the change. Reference any related issue: Closes #123 -->
Raises healthcheck start_period for slower Azure deployment and decreases resource usage of pods to stay inside Rancher resource limits.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [X] CI / infra

## Definition of Done

- [ ] CI is green
- [ ] If the API changed: `api/openapi.yaml` is updated and lint passes
- [ ] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [ ] Tests added or updated for the changed behaviour
- [ ] Docs updated where it matters (README, ADRs, comments)

## Notes for the reviewer

<!-- Anything they should look at first, gotchas, screenshots, ... -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased startup grace time for key backend services, helping prevent premature health-check failures during slow starts.
  * Adjusted deployment resource settings to better fit cluster limits, which may improve overall service stability and reduce scheduling issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->