### PR TITLE
Task: Add startup probe to helm deployment to avoid kill loop

### DIFF
--- a/infra/k8s/alexandria/templates/knowledgebase-service-deployment.yaml
+++ b/infra/k8s/alexandria/templates/knowledgebase-service-deployment.yaml
@@ -80,11 +80,17 @@ spec:
                   key: s3-secret-key
           resources:
             {{- toYaml .Values.knowledgebaseService.resources | nindent 12 }}
+          startupProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
           livenessProbe:
             httpGet:
               path: /actuator/health/liveness
               port: http
-            initialDelaySeconds: 30
             periodSeconds: 15
             timeoutSeconds: 5
             failureThreshold: 3
@@ -92,7 +98,6 @@ spec:
             httpGet:
               path: /actuator/health/readiness
               port: http
-            initialDelaySeconds: 15
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3

--- a/infra/k8s/alexandria/templates/qa-service-deployment.yaml
+++ b/infra/k8s/alexandria/templates/qa-service-deployment.yaml
@@ -70,11 +70,17 @@ spec:
                   key: postgres-password
           resources:
             {{- toYaml .Values.qaService.resources | nindent 12 }}
+          startupProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
           livenessProbe:
             httpGet:
               path: /actuator/health/liveness
               port: http
-            initialDelaySeconds: 30
             periodSeconds: 15
             timeoutSeconds: 5
             failureThreshold: 3
@@ -82,7 +88,6 @@ spec:
             httpGet:
               path: /actuator/health/readiness
               port: http
-            initialDelaySeconds: 15
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3

--- a/infra/k8s/alexandria/templates/user-service-deployment.yaml
+++ b/infra/k8s/alexandria/templates/user-service-deployment.yaml
@@ -70,11 +70,17 @@ spec:
                   key: postgres-password
           resources:
             {{- toYaml .Values.userService.resources | nindent 12 }}
+          startupProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
           livenessProbe:
             httpGet:
               path: /actuator/health/liveness
               port: http
-            initialDelaySeconds: 30
             periodSeconds: 15
             timeoutSeconds: 5
             failureThreshold: 3
@@ -82,7 +88,6 @@ spec:
             httpGet:
               path: /actuator/health/readiness
               port: http
-            initialDelaySeconds: 15
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3


### PR DESCRIPTION
## What does this PR do?

<!-- Short description of the change. Reference any related issue: Closes #123 -->
Adds a startup probe to the helm deployment to avoid a kill loop happening because the spring microservice pods start up too slow.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [X] CI / infra

## Definition of Done

- [ ] CI is green
- [ ] If the API changed: `api/openapi.yaml` is updated and lint passes
- [ ] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [ ] Tests added or updated for the changed behaviour
- [ ] Docs updated where it matters (README, ADRs, comments)

## Notes for the reviewer

<!-- Anything they should look at first, gotchas, screenshots, ... -->
