### PR TITLE
Task: Implement GenAI indexing calls to Spring service

### DIFF
--- a/services/spring/knowledgebase-service/src/main/java/com/alexandria/knowledgebase/KnowledgeBaseService.java
+++ b/services/spring/knowledgebase-service/src/main/java/com/alexandria/knowledgebase/KnowledgeBaseService.java
@@ -2,12 +2,12 @@ package com.alexandria.knowledgebase;
 
 import com.alexandria.knowledgebase.document.*;
 import com.alexandria.knowledgebase.dto.UpdateDocumentRequest;
-import com.alexandria.knowledgebase.search.SearchQuery;
-import com.alexandria.knowledgebase.search.SearchQueryRepository;
 import com.alexandria.knowledgebase.integration.GenAiClient;
 import com.alexandria.knowledgebase.integration.GenAiClient.ExtractResponse;
 import com.alexandria.knowledgebase.integration.GenAiClient.ExtractedEntityDto;
 import com.alexandria.knowledgebase.integration.GenAiClient.SummarizeResponse;
+import com.alexandria.knowledgebase.search.SearchQuery;
+import com.alexandria.knowledgebase.search.SearchQueryRepository;
 import jakarta.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,6 +57,7 @@ public class KnowledgeBaseService {
         if (textContent != null && !textContent.isBlank()) {
             processSummary(document);
             processEntities(document);
+            processIndexing(document);
         }
 
         return document;
@@ -79,6 +80,7 @@ public class KnowledgeBaseService {
 
         processSummary(document);
         processEntities(document);
+        processIndexing(document);
 
         return document;
     }
@@ -105,6 +107,14 @@ public class KnowledgeBaseService {
         } catch (Exception e) {
             log.warn(
                     "GenAI entity extraction failed for document {}: {}", document.getId(), e.getMessage());
+        }
+    }
+
+    private void processIndexing(Document document) {
+        try {
+            genAiClient.index(document.getObjectKey());
+        } catch (Exception e) {
+            log.warn("GenAI indexing failed for document {}: {}", document.getId(), e.getMessage());
         }
     }
 
@@ -163,6 +173,11 @@ public class KnowledgeBaseService {
         String objectKey = document.getObjectKey();
         documentService.delete(id, ownerSubject);
         objectStorageService.delete(objectKey);
+        try {
+            genAiClient.deleteIndex(objectKey);
+        } catch (Exception e) {
+            log.warn("GenAI index deletion failed for object key {}: {}", objectKey, e.getMessage());
+        }
     }
 
     @Transactional
@@ -226,6 +241,11 @@ public class KnowledgeBaseService {
                 objectStorageService.delete(doc.getObjectKey());
             } catch (Exception e) {
                 log.warn("Failed to delete S3 object for document {}: {}", doc.getId(), e.getMessage());
+            }
+            try {
+                genAiClient.deleteIndex(doc.getObjectKey());
+            } catch (Exception e) {
+                log.warn("GenAI index deletion failed for document {}: {}", doc.getId(), e.getMessage());
             }
         }
         documentService.deleteAllByOwner(userSubject);

--- a/services/spring/knowledgebase-service/src/main/java/com/alexandria/knowledgebase/integration/GenAiClient.java
+++ b/services/spring/knowledgebase-service/src/main/java/com/alexandria/knowledgebase/integration/GenAiClient.java
@@ -34,6 +34,14 @@ public class GenAiClient {
         return restClient.post().uri("/genai/ask").contentType(MediaType.APPLICATION_JSON).body(new AskRequest(question, objectKeys)).retrieve().body(AskResponse.class);
     }
 
+    public IndexResponse index(String objectKey) {
+        return restClient.post().uri("/genai/index").contentType(MediaType.APPLICATION_JSON).body(new IndexRequest(objectKey)).retrieve().body(IndexResponse.class);
+    }
+
+    public DeleteIndexResponse deleteIndex(String objectKey) {
+        return restClient.delete().uri("/genai/index/{objectKey}", objectKey).retrieve().body(DeleteIndexResponse.class);
+    }
+
     public record SummarizeRequest(String objectKey) {
     }
 
@@ -53,5 +61,14 @@ public class GenAiClient {
     }
 
     public record AskResponse(String answer, List<String> sourceObjectKeys, String modelUsed) {
+    }
+
+    public record IndexRequest(String objectKey) {
+    }
+
+    public record IndexResponse(String objectKey, Integer chunksIndexed, String embeddingModel) {
+    }
+
+    public record DeleteIndexResponse(String objectKey, Integer chunksDeleted) {
     }
 }

--- a/services/spring/knowledgebase-service/src/test/java/com/alexandria/knowledgebase/KnowledgeBaseServiceTest.java
+++ b/services/spring/knowledgebase-service/src/test/java/com/alexandria/knowledgebase/KnowledgeBaseServiceTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
 
 import java.util.List;
 import java.util.UUID;
@@ -61,6 +62,7 @@ class KnowledgeBaseServiceTest {
         when(documentService.save(any(Document.class))).thenAnswer(inv -> inv.getArgument(0));
         when(genAiClient.summarize(anyString())).thenReturn(new GenAiClient.SummarizeResponse("summary", "model"));
         when(genAiClient.extract(anyString())).thenReturn(new GenAiClient.ExtractResponse(List.of(), "model"));
+        when(genAiClient.index(anyString())).thenReturn(new GenAiClient.IndexResponse("/uploads/a.pdf", 3, "embed-model"));
 
         Document result = knowledgeBaseService.createDocument(
                 OWNER, "a.pdf", "/uploads/a.pdf", "application/pdf", 100L, "hello world");
@@ -68,6 +70,7 @@ class KnowledgeBaseServiceTest {
         assertThat(result.getOwnerSubject()).isEqualTo(OWNER);
         verify(genAiClient).summarize("/uploads/a.pdf");
         verify(genAiClient).extract("/uploads/a.pdf");
+        verify(genAiClient).index("/uploads/a.pdf");
     }
 
     @Test
@@ -80,6 +83,54 @@ class KnowledgeBaseServiceTest {
     }
 
     @Test
+    void unit_kb_createDocumentSurvivesGenAiIndexFailure() {
+        when(documentService.save(any(Document.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(genAiClient.summarize(anyString())).thenReturn(new GenAiClient.SummarizeResponse("summary", "model"));
+        when(genAiClient.extract(anyString())).thenReturn(new GenAiClient.ExtractResponse(List.of(), "model"));
+        when(genAiClient.index(anyString())).thenThrow(new RuntimeException("genai down"));
+
+        Document result = knowledgeBaseService.createDocument(
+                OWNER, "a.pdf", "/uploads/a.pdf", "application/pdf", 100L, "hello world");
+
+        assertThat(result.getOwnerSubject()).isEqualTo(OWNER);
+        verify(genAiClient).index("/uploads/a.pdf");
+    }
+
+    @Test
+    void unit_kb_uploadDocumentCallsIndexAlongsideSummarizeAndExtract() {
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "a.pdf", "application/pdf", "hello world".getBytes());
+        when(documentService.save(any(Document.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(textExtractor.extract(file)).thenReturn("hello world");
+        when(genAiClient.summarize(anyString())).thenReturn(new GenAiClient.SummarizeResponse("summary", "model"));
+        when(genAiClient.extract(anyString())).thenReturn(new GenAiClient.ExtractResponse(List.of(), "model"));
+        when(genAiClient.index(anyString())).thenReturn(new GenAiClient.IndexResponse("key", 1, "embed-model"));
+
+        Document result = knowledgeBaseService.uploadDocument(OWNER, file);
+
+        assertThat(result.getOwnerSubject()).isEqualTo(OWNER);
+        verify(genAiClient).summarize(result.getObjectKey());
+        verify(genAiClient).extract(result.getObjectKey());
+        verify(genAiClient).index(result.getObjectKey());
+    }
+
+    @Test
+    void unit_kb_uploadDocumentSurvivesGenAiIndexFailure() {
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "a.pdf", "application/pdf", "hello world".getBytes());
+        when(documentService.save(any(Document.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(textExtractor.extract(file)).thenReturn("hello world");
+        when(genAiClient.summarize(anyString())).thenReturn(new GenAiClient.SummarizeResponse("summary", "model"));
+        when(genAiClient.extract(anyString())).thenReturn(new GenAiClient.ExtractResponse(List.of(), "model"));
+        when(genAiClient.index(anyString())).thenThrow(new RuntimeException("genai down"));
+
+        Document result = knowledgeBaseService.uploadDocument(OWNER, file);
+
+        assertThat(result.getOwnerSubject()).isEqualTo(OWNER);
+        verify(genAiClient).index(result.getObjectKey());
+    }
+
+    @Test
     void unit_kb_getDocumentDelegatesToDocumentService() {
         UUID docId = UUID.randomUUID();
         Document doc = new Document(OWNER, "a.pdf", "/uploads/a.pdf", "application/pdf", 100L);
@@ -89,20 +140,22 @@ class KnowledgeBaseServiceTest {
     }
 
     @Test
-    void unit_kb_deleteDocumentRemovesFromS3AndDb() {
+    void unit_kb_deleteDocumentRemovesFromS3AndDbAndGenAiIndex() {
         UUID docId = UUID.randomUUID();
         Document doc = new Document(OWNER, "a.pdf", "/uploads/a.pdf", "application/pdf", 100L);
         when(documentService.findByIdAndOwner(docId, OWNER)).thenReturn(doc);
+        when(genAiClient.deleteIndex(anyString())).thenReturn(new GenAiClient.DeleteIndexResponse("/uploads/a.pdf", 3));
 
         knowledgeBaseService.deleteDocument(docId, OWNER);
 
-        org.mockito.InOrder inOrder = inOrder(documentService, objectStorageService);
+        org.mockito.InOrder inOrder = inOrder(documentService, objectStorageService, genAiClient);
         inOrder.verify(documentService).delete(docId, OWNER);
         inOrder.verify(objectStorageService).delete("/uploads/a.pdf");
+        inOrder.verify(genAiClient).deleteIndex("/uploads/a.pdf");
     }
 
     @Test
-    void unit_kb_deleteDocumentSkipsS3WhenDbDeleteFails() {
+    void unit_kb_deleteDocumentSkipsS3AndGenAiWhenDbDeleteFails() {
         UUID docId = UUID.randomUUID();
         Document doc = new Document(OWNER, "a.pdf", "/uploads/a.pdf", "application/pdf", 100L);
         when(documentService.findByIdAndOwner(docId, OWNER)).thenReturn(doc);
@@ -111,6 +164,21 @@ class KnowledgeBaseServiceTest {
         assertThatThrownBy(() -> knowledgeBaseService.deleteDocument(docId, OWNER)).isInstanceOf(RuntimeException.class);
 
         verify(objectStorageService, never()).delete(anyString());
+        verify(genAiClient, never()).deleteIndex(anyString());
+    }
+
+    @Test
+    void unit_kb_deleteDocumentSurvivesGenAiIndexFailure() {
+        UUID docId = UUID.randomUUID();
+        Document doc = new Document(OWNER, "a.pdf", "/uploads/a.pdf", "application/pdf", 100L);
+        when(documentService.findByIdAndOwner(docId, OWNER)).thenReturn(doc);
+        when(genAiClient.deleteIndex(anyString())).thenThrow(new RuntimeException("genai down"));
+
+        knowledgeBaseService.deleteDocument(docId, OWNER);
+
+        verify(documentService).delete(docId, OWNER);
+        verify(objectStorageService).delete("/uploads/a.pdf");
+        verify(genAiClient).deleteIndex("/uploads/a.pdf");
     }
 
     @Test
@@ -128,10 +196,40 @@ class KnowledgeBaseServiceTest {
     void unit_kb_deleteAllForUserPurgesEverything() {
         Document doc = new Document(OWNER, "a.pdf", "/uploads/a.pdf", "application/pdf", 1L);
         when(documentService.findByOwnerSubject(OWNER)).thenReturn(List.of(doc));
+        when(genAiClient.deleteIndex(anyString())).thenReturn(new GenAiClient.DeleteIndexResponse("/uploads/a.pdf", 3));
 
         knowledgeBaseService.deleteAllForUser(OWNER);
 
         verify(objectStorageService).delete("/uploads/a.pdf");
+        verify(genAiClient).deleteIndex("/uploads/a.pdf");
+        verify(documentService).deleteAllByOwner(OWNER);
+        verify(searchQueryRepository).deleteByUserSubject(OWNER);
+    }
+
+    @Test
+    void unit_kb_deleteAllForUserStillCallsGenAiWhenS3DeleteFails() {
+        Document doc = new Document(OWNER, "a.pdf", "/uploads/a.pdf", "application/pdf", 1L);
+        when(documentService.findByOwnerSubject(OWNER)).thenReturn(List.of(doc));
+        doThrow(new RuntimeException("s3 down")).when(objectStorageService).delete(anyString());
+        when(genAiClient.deleteIndex(anyString())).thenReturn(new GenAiClient.DeleteIndexResponse("/uploads/a.pdf", 0));
+
+        knowledgeBaseService.deleteAllForUser(OWNER);
+
+        verify(genAiClient).deleteIndex("/uploads/a.pdf");
+        verify(documentService).deleteAllByOwner(OWNER);
+        verify(searchQueryRepository).deleteByUserSubject(OWNER);
+    }
+
+    @Test
+    void unit_kb_deleteAllForUserSurvivesGenAiIndexFailure() {
+        Document doc = new Document(OWNER, "a.pdf", "/uploads/a.pdf", "application/pdf", 1L);
+        when(documentService.findByOwnerSubject(OWNER)).thenReturn(List.of(doc));
+        when(genAiClient.deleteIndex(anyString())).thenThrow(new RuntimeException("genai down"));
+
+        knowledgeBaseService.deleteAllForUser(OWNER);
+
+        verify(objectStorageService).delete("/uploads/a.pdf");
+        verify(genAiClient).deleteIndex("/uploads/a.pdf");
         verify(documentService).deleteAllByOwner(OWNER);
         verify(searchQueryRepository).deleteByUserSubject(OWNER);
     }


### PR DESCRIPTION
## What does this PR do?

<!-- Short description of the change. Reference any related issue: Closes #123 -->
This PR completes the RAG pipeline @DoPri started in #208. It adds calls to the `index` endpoint on the GenAI side whenever a document is uploaded or created; additionally, deletion of documents triggers the deletion of the corresponding chunks again by calling the GenAI service. Some unit tests have been added/expanded to cover the newly introduced features.

Closes #240.

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [X] CI / infra

## Definition of Done

- [x] CI is green
- [ ] If the API changed: `api/openapi.yaml` is updated and lint passes
- [X] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [X] Tests added or updated for the changed behaviour
- [ ] Docs updated where it matters (README, ADRs, comments)

## Notes for the reviewer

<!-- Anything they should look at first, gotchas, screenshots, ... -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Documents are now automatically added to GenAI indexing when created or uploaded.
  * Document removal now also clears related GenAI indexes, including bulk deletion for a user.

* **Bug Fixes**
  * GenAI indexing and de-indexing failures no longer block document create, upload, or delete actions.
  * Document cleanup now continues even if one indexing-related step fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->