### PR TITLE
GenAI: Add semantic search endpoint over the knowledge base

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1369,6 +1369,7 @@ components:
           title: Objectkeys
           type: array
         query:
+          maxLength: 1500
           title: Query
           type: string
       required:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -895,6 +895,43 @@ paths:
       summary: Delete Index
       tags:
         - ai
+  /genai/search:
+    post:
+      description: >-
+        Rank indexed documents by semantic similarity to the query.
+
+
+        The query is embedded and matched against the indexed chunks scoped to
+        the
+
+        requested object keys; chunk hits are rolled up to one entry per
+        document,
+
+        each carrying the closest chunk's snippet and a relevance score.
+      operationId: search_genai_search_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GenAiSearchRequest'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenAiSearchResponse'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      security: []
+      summary: Search
+      tags:
+        - ai
   /genai/summarize:
     post:
       description: Summarize the document stored under the given object key.
@@ -1317,6 +1354,63 @@ components:
         - chunksIndexed
         - embeddingModel
       title: GenAiIndexResponse
+      type: object
+    GenAiSearchRequest:
+      properties:
+        limit:
+          default: 10
+          maximum: 50
+          minimum: 1
+          title: Limit
+          type: integer
+        objectKeys:
+          items:
+            type: string
+          title: Objectkeys
+          type: array
+        query:
+          title: Query
+          type: string
+      required:
+        - query
+        - objectKeys
+      title: GenAiSearchRequest
+      type: object
+    GenAiSearchResponse:
+      properties:
+        embeddingModel:
+          title: Embeddingmodel
+          type: string
+        results:
+          items:
+            $ref: '#/components/schemas/GenAiSearchResult'
+          title: Results
+          type: array
+      required:
+        - results
+        - embeddingModel
+      title: GenAiSearchResponse
+      type: object
+    GenAiSearchResult:
+      properties:
+        chunkIndex:
+          title: Chunkindex
+          type: integer
+        objectKey:
+          title: Objectkey
+          type: string
+        score:
+          title: Score
+          type: number
+        snippet:
+          title: Snippet
+          type: string
+      required:
+        - objectKey
+        - score
+        - snippet
+        - chunkIndex
+      title: GenAiSearchResult
       type: object
     GenAiSummarizeRequest:
       properties:

--- a/services/genai/README.md
+++ b/services/genai/README.md
@@ -31,7 +31,7 @@ The processing endpoints take object keys, not raw text. The service downloads t
 
 `ask` takes `{"question": "...", "objectKeys": [...]}` and answers with retrieval-augmented generation: the question is embedded, matched against the indexed chunks of the listed documents, and the top matches are passed to the LLM. The response returns `sourceObjectKeys`, the documents whose chunks actually fed the answer. When nothing relevant is found (or no documents are in scope), it says so instead of guessing.
 
-`search` takes `{"query": "...", "objectKeys": [...], "limit": 10}` and returns documents ranked by semantic similarity to the query. The query is embedded and matched against the indexed chunks scoped to `objectKeys`; the chunk hits are rolled up to one entry per document, keeping each document's closest chunk. Every result carries a `snippet` (the matched chunk, truncated) and a `score` (higher is more relevant) so the client can show why a document matched. `limit` (1-50, default 10) caps the number of documents; an empty `objectKeys` returns no results. Only indexed documents are searchable, so this reuses the same embedding config and Weaviate collection as `/genai/index` and `/genai/ask`.
+`search` takes `{"query": "...", "objectKeys": [...], "limit": 10}` and returns documents ranked by semantic similarity to the query. The query (capped at 1500 characters) is embedded and matched against the indexed chunks scoped to `objectKeys`. Results are de-duplicated to one entry per document using Weaviate's `group_by` on `object_key`, so a document with many close chunks never crowds out the rest; each carries a `snippet` (the closest chunk, truncated at a word boundary) and a `score` in `[0, 1]` (higher is more relevant) so the client can show why a document matched. `limit` (1-50, default 10) caps the number of documents; an empty `objectKeys` returns no results. Only indexed documents are searchable, so this reuses the same embedding config and Weaviate collection as `/genai/index` and `/genai/ask`.
 
 FastAPI also exposes `/genai/openapi.json` and `/genai/docs` (Swagger UI) out of the box.
 
@@ -53,18 +53,17 @@ The service is configured entirely via environment variables. Copy `.env.example
 
 Document text is split into overlapping chunks and embedded into vectors for the RAG pipeline (see `app/embeddings.py`). The embedding provider is selected the same way as the LLM. By default the logos/openai providers reuse `LLM_BASE_URL` and `LLM_API_KEY` (so a single-provider setup needs no extra config), but you can point embeddings at a different endpoint/key via `EMBEDDING_BASE_URL` / `EMBEDDING_API_KEY`, e.g. to run chat on Logos and embeddings on OpenAI.
 
-| Variable             | Default                          | Description                                                             |
-| -------------------- | -------------------------------- | ----------------------------------------------------------------------- |
-| `EMBEDDING_PROVIDER` | `logos`                          | `logos`, `openai`, or `ollama`                                          |
-| `EMBEDDING_MODEL`    | `Qwen/Qwen3-Embedding-8B`        | Embedding model id (provider-specific default)                          |
-| `EMBEDDING_BASE_URL` | _(falls back to `LLM_BASE_URL`)_ | Override the embedding endpoint                                         |
-| `EMBEDDING_API_KEY`  | _(falls back to `LLM_API_KEY`)_  | Override the embedding API key                                          |
-| `CHUNK_SIZE`         | `1000`                           | Characters per chunk                                                    |
-| `CHUNK_OVERLAP`      | `200`                            | Character overlap between consecutive chunks                            |
-| `WEAVIATE_URL`       | `http://weaviate:8080`           | Weaviate HTTP endpoint                                                  |
-| `WEAVIATE_GRPC_PORT` | `50051`                          | Weaviate gRPC port (batch/query)                                        |
-| `RAG_TOP_K`          | `5`                              | Chunks retrieved per question in `/genai/ask`                           |
-| `SEARCH_CANDIDATES`  | `50`                             | Chunk hits pulled before de-duplicating to documents in `/genai/search` |
+| Variable             | Default                          | Description                                    |
+| -------------------- | -------------------------------- | ---------------------------------------------- |
+| `EMBEDDING_PROVIDER` | `logos`                          | `logos`, `openai`, or `ollama`                 |
+| `EMBEDDING_MODEL`    | `Qwen/Qwen3-Embedding-8B`        | Embedding model id (provider-specific default) |
+| `EMBEDDING_BASE_URL` | _(falls back to `LLM_BASE_URL`)_ | Override the embedding endpoint                |
+| `EMBEDDING_API_KEY`  | _(falls back to `LLM_API_KEY`)_  | Override the embedding API key                 |
+| `CHUNK_SIZE`         | `1000`                           | Characters per chunk                           |
+| `CHUNK_OVERLAP`      | `200`                            | Character overlap between consecutive chunks   |
+| `WEAVIATE_URL`       | `http://weaviate:8080`           | Weaviate HTTP endpoint                         |
+| `WEAVIATE_GRPC_PORT` | `50051`                          | Weaviate gRPC port (batch/query)               |
+| `RAG_TOP_K`          | `5`                              | Chunks retrieved per question in `/genai/ask`  |
 
 OpenAI defaults to `text-embedding-3-small`, Ollama to `nomic-embed-text`. Each provider/model emits a different vector size, and the Weaviate collection stores whatever the configured embedder produces rather than pinning a fixed dimension. Weaviate locks the collection to the first vector's width, so switching embedding providers to one with a different dimension means dropping and re-indexing the collection.
 

--- a/services/genai/README.md
+++ b/services/genai/README.md
@@ -1,6 +1,6 @@
 # Alexandria GenAI service
 
-Python/FastAPI microservice for AI-powered document processing. Uses LangChain to call an LLM for summarization, entity extraction, content-based tagging, and document Q&A.
+Python/FastAPI microservice for AI-powered document processing. Uses LangChain to call an LLM for summarization, entity extraction, content-based tagging, semantic search, and document Q&A.
 
 The processing endpoints take object keys, not raw text. The service downloads the referenced documents from the S3-compatible object storage (the same SeaweedFS bucket the Spring service uploads to), extracts their text (plain UTF-8 or PDF via pypdf), and feeds that to the LLM.
 
@@ -16,6 +16,7 @@ The processing endpoints take object keys, not raw text. The service downloads t
 | POST   | `/genai/index`             | Chunk, embed, and index the document at `objectKey`              |
 | DELETE | `/genai/index/{objectKey}` | Remove a document's chunks from the index                        |
 | POST   | `/genai/ask`               | Answer a question from indexed chunks of the given documents     |
+| POST   | `/genai/search`            | Rank indexed documents by semantic similarity to a query         |
 | GET    | `/genai/metrics`           | Prometheus metrics (in-network scraping only)                    |
 
 `summarize`, `extract`, `tag`, and `index` take `{"objectKey": "..."}`. A key that is missing returns 404 (415 if the object is neither UTF-8 text nor a PDF, 422 if it has no extractable text).
@@ -29,6 +30,8 @@ The processing endpoints take object keys, not raw text. The service downloads t
 `index` chunks and embeds the document into Weaviate for retrieval; `DELETE /genai/index/{objectKey}` removes its chunks. See the RAG section below.
 
 `ask` takes `{"question": "...", "objectKeys": [...]}` and answers with retrieval-augmented generation: the question is embedded, matched against the indexed chunks of the listed documents, and the top matches are passed to the LLM. The response returns `sourceObjectKeys`, the documents whose chunks actually fed the answer. When nothing relevant is found (or no documents are in scope), it says so instead of guessing.
+
+`search` takes `{"query": "...", "objectKeys": [...], "limit": 10}` and returns documents ranked by semantic similarity to the query. The query is embedded and matched against the indexed chunks scoped to `objectKeys`; the chunk hits are rolled up to one entry per document, keeping each document's closest chunk. Every result carries a `snippet` (the matched chunk, truncated) and a `score` (higher is more relevant) so the client can show why a document matched. `limit` (1-50, default 10) caps the number of documents; an empty `objectKeys` returns no results. Only indexed documents are searchable, so this reuses the same embedding config and Weaviate collection as `/genai/index` and `/genai/ask`.
 
 FastAPI also exposes `/genai/openapi.json` and `/genai/docs` (Swagger UI) out of the box.
 
@@ -50,17 +53,18 @@ The service is configured entirely via environment variables. Copy `.env.example
 
 Document text is split into overlapping chunks and embedded into vectors for the RAG pipeline (see `app/embeddings.py`). The embedding provider is selected the same way as the LLM. By default the logos/openai providers reuse `LLM_BASE_URL` and `LLM_API_KEY` (so a single-provider setup needs no extra config), but you can point embeddings at a different endpoint/key via `EMBEDDING_BASE_URL` / `EMBEDDING_API_KEY`, e.g. to run chat on Logos and embeddings on OpenAI.
 
-| Variable             | Default                          | Description                                    |
-| -------------------- | -------------------------------- | ---------------------------------------------- |
-| `EMBEDDING_PROVIDER` | `logos`                          | `logos`, `openai`, or `ollama`                 |
-| `EMBEDDING_MODEL`    | `Qwen/Qwen3-Embedding-8B`        | Embedding model id (provider-specific default) |
-| `EMBEDDING_BASE_URL` | _(falls back to `LLM_BASE_URL`)_ | Override the embedding endpoint                |
-| `EMBEDDING_API_KEY`  | _(falls back to `LLM_API_KEY`)_  | Override the embedding API key                 |
-| `CHUNK_SIZE`         | `1000`                           | Characters per chunk                           |
-| `CHUNK_OVERLAP`      | `200`                            | Character overlap between consecutive chunks   |
-| `WEAVIATE_URL`       | `http://weaviate:8080`           | Weaviate HTTP endpoint                         |
-| `WEAVIATE_GRPC_PORT` | `50051`                          | Weaviate gRPC port (batch/query)               |
-| `RAG_TOP_K`          | `5`                              | Chunks retrieved per question in `/genai/ask`  |
+| Variable             | Default                          | Description                                                             |
+| -------------------- | -------------------------------- | ----------------------------------------------------------------------- |
+| `EMBEDDING_PROVIDER` | `logos`                          | `logos`, `openai`, or `ollama`                                          |
+| `EMBEDDING_MODEL`    | `Qwen/Qwen3-Embedding-8B`        | Embedding model id (provider-specific default)                          |
+| `EMBEDDING_BASE_URL` | _(falls back to `LLM_BASE_URL`)_ | Override the embedding endpoint                                         |
+| `EMBEDDING_API_KEY`  | _(falls back to `LLM_API_KEY`)_  | Override the embedding API key                                          |
+| `CHUNK_SIZE`         | `1000`                           | Characters per chunk                                                    |
+| `CHUNK_OVERLAP`      | `200`                            | Character overlap between consecutive chunks                            |
+| `WEAVIATE_URL`       | `http://weaviate:8080`           | Weaviate HTTP endpoint                                                  |
+| `WEAVIATE_GRPC_PORT` | `50051`                          | Weaviate gRPC port (batch/query)                                        |
+| `RAG_TOP_K`          | `5`                              | Chunks retrieved per question in `/genai/ask`                           |
+| `SEARCH_CANDIDATES`  | `50`                             | Chunk hits pulled before de-duplicating to documents in `/genai/search` |
 
 OpenAI defaults to `text-embedding-3-small`, Ollama to `nomic-embed-text`. Each provider/model emits a different vector size, and the Weaviate collection stores whatever the configured embedder produces rather than pinning a fixed dimension. Weaviate locks the collection to the first vector's width, so switching embedding providers to one with a different dimension means dropping and re-indexing the collection.
 

--- a/services/genai/app/main.py
+++ b/services/genai/app/main.py
@@ -100,7 +100,7 @@ class GenAiAskResponse(BaseModel):
 
 
 class GenAiSearchRequest(BaseModel):
-    query: str
+    query: str = Field(max_length=1500)
     objectKeys: list[str]
     limit: int = Field(default=10, ge=1, le=50)
 

--- a/services/genai/app/main.py
+++ b/services/genai/app/main.py
@@ -3,7 +3,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import PlainTextResponse
 from prometheus_fastapi_instrumentator import Instrumentator
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from app.embeddings import chunk_text, embed_chunks, get_embedding_model_name
 from app.extract import extract_entities
@@ -88,9 +88,17 @@ class GenAiTagResponse(BaseModel):
     modelUsed: str
 
 
+def _reject_blank(value: str) -> str:
+    if not value.strip():
+        raise ValueError("must not be blank")
+    return value
+
+
 class GenAiAskRequest(BaseModel):
     question: str
     objectKeys: list[str]
+
+    _validate_question = field_validator("question")(_reject_blank)
 
 
 class GenAiAskResponse(BaseModel):
@@ -103,6 +111,8 @@ class GenAiSearchRequest(BaseModel):
     query: str = Field(max_length=1500)
     objectKeys: list[str]
     limit: int = Field(default=10, ge=1, le=50)
+
+    _validate_query = field_validator("query")(_reject_blank)
 
 
 class GenAiSearchResult(BaseModel):
@@ -209,9 +219,6 @@ def ask(request: GenAiAskRequest) -> GenAiAskResponse:
     The question is embedded and matched against the indexed chunks scoped to the
     requested object keys; the answer cites the documents its chunks came from.
     """
-    if not request.question.strip():
-        raise HTTPException(status_code=422, detail="question must not be empty")
-
     answer, source_keys, model = answer_question(request.question, request.objectKeys)
     return GenAiAskResponse(answer=answer, sourceObjectKeys=source_keys, modelUsed=model)
 
@@ -224,9 +231,6 @@ def search(request: GenAiSearchRequest) -> GenAiSearchResponse:
     requested object keys; chunk hits are rolled up to one entry per document,
     each carrying the closest chunk's snippet and a relevance score.
     """
-    if not request.query.strip():
-        raise HTTPException(status_code=422, detail="query must not be empty")
-
     results, model = search_documents(request.query, request.objectKeys, request.limit)
     return GenAiSearchResponse(
         results=[GenAiSearchResult(objectKey=r["object_key"], score=r["score"], snippet=r["snippet"], chunkIndex=r["chunk_index"]) for r in results],

--- a/services/genai/app/main.py
+++ b/services/genai/app/main.py
@@ -3,18 +3,19 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import PlainTextResponse
 from prometheus_fastapi_instrumentator import Instrumentator
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from app.embeddings import chunk_text, embed_chunks, get_embedding_model_name
 from app.extract import extract_entities
 from app.qa import answer_question
+from app.search import search_documents
 from app.storage import ObjectNotFoundError, UnsupportedFileError, fetch_text
 from app.summarize import summarize
 from app.tag import generate_tags
 from app.vectorstore import close_client, delete_document, index_chunks
 
 SERVICE_NAME = "alexandria-genai"
-SERVICE_VERSION = "2.1.0"
+SERVICE_VERSION = "2.2.0"
 
 
 @asynccontextmanager
@@ -96,6 +97,24 @@ class GenAiAskResponse(BaseModel):
     answer: str
     sourceObjectKeys: list[str]
     modelUsed: str
+
+
+class GenAiSearchRequest(BaseModel):
+    query: str
+    objectKeys: list[str]
+    limit: int = Field(default=10, ge=1, le=50)
+
+
+class GenAiSearchResult(BaseModel):
+    objectKey: str
+    score: float
+    snippet: str
+    chunkIndex: int
+
+
+class GenAiSearchResponse(BaseModel):
+    results: list[GenAiSearchResult]
+    embeddingModel: str
 
 
 class GenAiIndexRequest(BaseModel):
@@ -195,6 +214,24 @@ def ask(request: GenAiAskRequest) -> GenAiAskResponse:
 
     answer, source_keys, model = answer_question(request.question, request.objectKeys)
     return GenAiAskResponse(answer=answer, sourceObjectKeys=source_keys, modelUsed=model)
+
+
+@app.post("/genai/search", tags=["ai"], response_model=GenAiSearchResponse, openapi_extra={"security": []})
+def search(request: GenAiSearchRequest) -> GenAiSearchResponse:
+    """Rank indexed documents by semantic similarity to the query.
+
+    The query is embedded and matched against the indexed chunks scoped to the
+    requested object keys; chunk hits are rolled up to one entry per document,
+    each carrying the closest chunk's snippet and a relevance score.
+    """
+    if not request.query.strip():
+        raise HTTPException(status_code=422, detail="query must not be empty")
+
+    results, model = search_documents(request.query, request.objectKeys, request.limit)
+    return GenAiSearchResponse(
+        results=[GenAiSearchResult(objectKey=r["object_key"], score=r["score"], snippet=r["snippet"], chunkIndex=r["chunk_index"]) for r in results],
+        embeddingModel=model,
+    )
 
 
 @app.post("/genai/index", tags=["ai"], response_model=GenAiIndexResponse, responses=_DOCUMENT_ERROR_RESPONSES, openapi_extra={"security": []})

--- a/services/genai/app/search.py
+++ b/services/genai/app/search.py
@@ -1,62 +1,37 @@
 """Semantic search over indexed document chunks.
 
-Embeds the query, runs a vector similarity search in Weaviate, and rolls the
-chunk hits up to the document level so each document appears once, ranked by its
-closest-matching chunk. Reuses the same embedding config and vector store as the
-RAG pipeline; only documents that have been indexed are searchable.
-
-  SEARCH_CANDIDATES   chunk hits to pull before de-duplicating to documents
-                      (default 50)
+Embeds the query, runs a vector similarity search in Weaviate, and returns one
+result per document (its closest-matching chunk) so the knowledge base can rank
+documents by relevance without a single document's many chunks crowding out the
+rest. Reuses the same embedding config and vector store as the RAG pipeline;
+only documents that have been indexed are searchable.
 """
 
 from app.embeddings import embed_query, get_embedding_model_name
-from app.env import int_env
-from app.vectorstore import search
+from app.vectorstore import search_grouped
 
-_DEFAULT_CANDIDATES = 50
 _SNIPPET_MAX_CHARS = 300
-
-
-def _candidates() -> int:
-    return int_env("SEARCH_CANDIDATES", _DEFAULT_CANDIDATES, minimum=1)
 
 
 def _snippet(text: str) -> str:
     collapsed = " ".join(text.split())
     if len(collapsed) <= _SNIPPET_MAX_CHARS:
         return collapsed
-    return collapsed[:_SNIPPET_MAX_CHARS].rstrip() + "..."
+    truncated = collapsed[:_SNIPPET_MAX_CHARS]
+    # Cut at the last whitespace so the snippet doesn't end mid-word.
+    cut = truncated.rfind(" ")
+    if cut > 0:
+        truncated = truncated[:cut]
+    return truncated.rstrip() + "..."
 
 
 def _score(distance: float | None) -> float:
-    # Weaviate returns cosine distance (0 = identical). Flip it into a similarity
-    # score where higher means more relevant, which is friendlier for the client.
+    # Weaviate returns cosine distance (0 = identical, up to 2 for opposite
+    # vectors). Flip it into a similarity score where higher means more relevant,
+    # clamped at 0 so the score always stays in [0, 1].
     if distance is None:
         return 0.0
-    return round(1.0 - distance, 4)
-
-
-def _best_per_document(hits: list[dict], limit: int) -> list[dict]:
-    """Collapse chunk hits to one entry per document, keeping the nearest chunk.
-
-    Weaviate returns hits sorted by ascending distance, so the first hit seen for
-    an object key is its best match. Insertion order is preserved, so documents
-    come out ranked by their closest chunk.
-    """
-    best: dict[str, dict] = {}
-    for hit in hits:
-        key = hit["object_key"]
-        if key in best:
-            continue
-        best[key] = {
-            "object_key": key,
-            "score": _score(hit["distance"]),
-            "snippet": _snippet(hit["text"]),
-            "chunk_index": hit["chunk_index"],
-        }
-        if len(best) == limit:
-            break
-    return list(best.values())
+    return round(max(0.0, 1.0 - distance), 4)
 
 
 def search_documents(query: str, object_keys: list[str], limit: int) -> tuple[list[dict], str]:
@@ -70,11 +45,23 @@ def search_documents(query: str, object_keys: list[str], limit: int) -> tuple[li
 
     Returns:
         (results, embedding_model) where results is a list of dicts with
-        object_key, score, snippet, and chunk_index, one entry per document.
+        object_key, score (in [0, 1], higher is more relevant), snippet, and
+        chunk_index, one entry per document.
     """
     model = get_embedding_model_name()
     if not object_keys:
         return [], model
 
-    hits = search(embed_query(query), object_keys, _candidates())
-    return _best_per_document(hits, limit), model
+    hits = search_grouped(embed_query(query), object_keys, limit)
+    return (
+        [
+            {
+                "object_key": h["object_key"],
+                "score": _score(h["distance"]),
+                "snippet": _snippet(h["text"]),
+                "chunk_index": h["chunk_index"],
+            }
+            for h in hits
+        ],
+        model,
+    )

--- a/services/genai/app/search.py
+++ b/services/genai/app/search.py
@@ -1,0 +1,80 @@
+"""Semantic search over indexed document chunks.
+
+Embeds the query, runs a vector similarity search in Weaviate, and rolls the
+chunk hits up to the document level so each document appears once, ranked by its
+closest-matching chunk. Reuses the same embedding config and vector store as the
+RAG pipeline; only documents that have been indexed are searchable.
+
+  SEARCH_CANDIDATES   chunk hits to pull before de-duplicating to documents
+                      (default 50)
+"""
+
+from app.embeddings import embed_query, get_embedding_model_name
+from app.env import int_env
+from app.vectorstore import search
+
+_DEFAULT_CANDIDATES = 50
+_SNIPPET_MAX_CHARS = 300
+
+
+def _candidates() -> int:
+    return int_env("SEARCH_CANDIDATES", _DEFAULT_CANDIDATES, minimum=1)
+
+
+def _snippet(text: str) -> str:
+    collapsed = " ".join(text.split())
+    if len(collapsed) <= _SNIPPET_MAX_CHARS:
+        return collapsed
+    return collapsed[:_SNIPPET_MAX_CHARS].rstrip() + "..."
+
+
+def _score(distance: float | None) -> float:
+    # Weaviate returns cosine distance (0 = identical). Flip it into a similarity
+    # score where higher means more relevant, which is friendlier for the client.
+    if distance is None:
+        return 0.0
+    return round(1.0 - distance, 4)
+
+
+def _best_per_document(hits: list[dict], limit: int) -> list[dict]:
+    """Collapse chunk hits to one entry per document, keeping the nearest chunk.
+
+    Weaviate returns hits sorted by ascending distance, so the first hit seen for
+    an object key is its best match. Insertion order is preserved, so documents
+    come out ranked by their closest chunk.
+    """
+    best: dict[str, dict] = {}
+    for hit in hits:
+        key = hit["object_key"]
+        if key in best:
+            continue
+        best[key] = {
+            "object_key": key,
+            "score": _score(hit["distance"]),
+            "snippet": _snippet(hit["text"]),
+            "chunk_index": hit["chunk_index"],
+        }
+        if len(best) == limit:
+            break
+    return list(best.values())
+
+
+def search_documents(query: str, object_keys: list[str], limit: int) -> tuple[list[dict], str]:
+    """Return documents semantically similar to the query, ranked by relevance.
+
+    Args:
+        query: The free-text search query.
+        object_keys: Object keys to scope the search to (e.g. a user's documents).
+                     An empty list means "nothing to search".
+        limit: Maximum number of documents to return.
+
+    Returns:
+        (results, embedding_model) where results is a list of dicts with
+        object_key, score, snippet, and chunk_index, one entry per document.
+    """
+    model = get_embedding_model_name()
+    if not object_keys:
+        return [], model
+
+    hits = search(embed_query(query), object_keys, _candidates())
+    return _best_per_document(hits, limit), model

--- a/services/genai/app/vectorstore.py
+++ b/services/genai/app/vectorstore.py
@@ -128,10 +128,13 @@ def search(query_vector: list[float], object_keys: list[str], limit: int) -> lis
     """Return the top chunks nearest to the query vector, scoped to object_keys.
 
     Each result carries its text, source object key, chunk index, and distance.
-    An empty object_keys list searches the whole collection.
+    An empty object_keys list returns no results so the function never searches
+    outside the requested scope.
     """
+    if not object_keys:
+        return []
     collection = _client().collections.get(COLLECTION_NAME)
-    filters = Filter.by_property("object_key").contains_any(object_keys) if object_keys else None
+    filters = Filter.by_property("object_key").contains_any(object_keys)
 
     response = collection.query.near_vector(
         near_vector=query_vector,
@@ -156,12 +159,15 @@ def search_grouped(query_vector: list[float], object_keys: list[str], limit: int
     Uses Weaviate's group_by on ``object_key`` so each document appears once,
     ranked by its closest chunk. ``number_of_groups`` caps the documents returned
     and ``objects_per_group=1`` keeps only that closest chunk. An empty
-    ``object_keys`` list searches the whole collection.
+    ``object_keys`` list returns no results so the function never searches
+    outside the requested scope.
 
     Each result carries its text, source object key, chunk index, and distance.
     """
+    if not object_keys:
+        return []
     collection = _client().collections.get(COLLECTION_NAME)
-    filters = Filter.by_property("object_key").contains_any(object_keys) if object_keys else None
+    filters = Filter.by_property("object_key").contains_any(object_keys)
 
     response = collection.query.near_vector(
         near_vector=query_vector,

--- a/services/genai/app/vectorstore.py
+++ b/services/genai/app/vectorstore.py
@@ -20,7 +20,7 @@ from urllib.parse import urlparse
 import weaviate
 from weaviate.classes.config import Configure, DataType, Property
 from weaviate.classes.data import DataObject
-from weaviate.classes.query import Filter, MetadataQuery
+from weaviate.classes.query import Filter, GroupBy, MetadataQuery
 from weaviate.exceptions import UnexpectedStatusCodeError
 from weaviate.util import generate_uuid5
 
@@ -148,6 +148,42 @@ def search(query_vector: list[float], object_keys: list[str], limit: int) -> lis
         }
         for obj in response.objects
     ]
+
+
+def search_grouped(query_vector: list[float], object_keys: list[str], limit: int) -> list[dict]:
+    """Return one nearest chunk per distinct object_key (document-level results).
+
+    Uses Weaviate's group_by on ``object_key`` so each document appears once,
+    ranked by its closest chunk. ``number_of_groups`` caps the documents returned
+    and ``objects_per_group=1`` keeps only that closest chunk. An empty
+    ``object_keys`` list searches the whole collection.
+
+    Each result carries its text, source object key, chunk index, and distance.
+    """
+    collection = _client().collections.get(COLLECTION_NAME)
+    filters = Filter.by_property("object_key").contains_any(object_keys) if object_keys else None
+
+    response = collection.query.near_vector(
+        near_vector=query_vector,
+        limit=limit,
+        filters=filters,
+        group_by=GroupBy(prop="object_key", objects_per_group=1, number_of_groups=limit),
+        return_metadata=MetadataQuery(distance=True),
+    )
+    results = []
+    for group in response.groups.values():
+        if not group.objects:
+            continue
+        best = group.objects[0]
+        results.append(
+            {
+                "text": best.properties["text"],
+                "object_key": group.name,
+                "chunk_index": int(best.properties["chunk_index"]),
+                "distance": best.metadata.distance,
+            }
+        )
+    return results
 
 
 def close_client() -> None:

--- a/services/genai/pyproject.toml
+++ b/services/genai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "alexandria-genai"
-version = "2.1.0"
+version = "2.2.0"
 description = "GenAI microservice for Alexandria"
 requires-python = "~=3.14.0"
 dependencies = [

--- a/services/genai/tests/test_main.py
+++ b/services/genai/tests/test_main.py
@@ -369,6 +369,19 @@ def test_search_rejects_out_of_range_limit():
     assert response.status_code == 422
 
 
+def test_search_rejects_limit_above_max():
+    response = client.post("/genai/search", json={"query": "q", "objectKeys": ["k1"], "limit": 51})
+    assert response.status_code == 422
+
+
+def test_search_rejects_over_long_query():
+    response = client.post(
+        "/genai/search",
+        json={"query": "a" * 1501, "objectKeys": ["k1"]},
+    )
+    assert response.status_code == 422
+
+
 # --- index ---
 
 

--- a/services/genai/tests/test_main.py
+++ b/services/genai/tests/test_main.py
@@ -41,6 +41,7 @@ def test_openapi_schema_exposes_all_endpoints():
     assert "/genai/extract" in paths
     assert "/genai/tag" in paths
     assert "/genai/ask" in paths
+    assert "/genai/search" in paths
     assert "/genai/index" in paths
     assert "/genai/index/{object_key}" in paths
     # metrics is an operational endpoint, not part of the public API surface
@@ -287,6 +288,84 @@ def test_ask_passes_question_and_object_keys_to_retrieval():
 
 def test_ask_rejects_empty_question():
     response = client.post("/genai/ask", json={"question": "  ", "objectKeys": ["key-1"]})
+    assert response.status_code == 422
+
+
+# --- search ---
+
+
+def test_search_returns_ranked_documents_with_context():
+    results = [
+        {"object_key": "uploads/a/report.txt", "score": 0.91, "snippet": "revenue grew", "chunk_index": 2},
+        {"object_key": "uploads/b/memo.txt", "score": 0.80, "snippet": "cost review", "chunk_index": 0},
+    ]
+    with patch("app.main.search_documents", return_value=(results, "Qwen/Qwen3-Embedding-8B")):
+        response = client.post(
+            "/genai/search",
+            json={"query": "how did revenue change", "objectKeys": ["uploads/a/report.txt", "uploads/b/memo.txt"]},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["embeddingModel"] == "Qwen/Qwen3-Embedding-8B"
+    assert len(body["results"]) == 2
+    first = body["results"][0]
+    assert first["objectKey"] == "uploads/a/report.txt"
+    assert first["score"] == 0.91
+    assert first["snippet"] == "revenue grew"
+    assert first["chunkIndex"] == 2
+
+
+def test_search_passes_query_keys_and_limit_to_module():
+    captured = {}
+
+    def fake_search(query, object_keys, limit):
+        captured["query"] = query
+        captured["object_keys"] = object_keys
+        captured["limit"] = limit
+        return ([], "m")
+
+    with patch("app.main.search_documents", side_effect=fake_search):
+        client.post("/genai/search", json={"query": "climate", "objectKeys": ["k1", "k2"], "limit": 3})
+
+    assert captured["query"] == "climate"
+    assert captured["object_keys"] == ["k1", "k2"]
+    assert captured["limit"] == 3
+
+
+def test_search_defaults_limit_when_omitted():
+    captured = {}
+
+    def fake_search(query, object_keys, limit):
+        captured["limit"] = limit
+        return ([], "m")
+
+    with patch("app.main.search_documents", side_effect=fake_search):
+        client.post("/genai/search", json={"query": "q", "objectKeys": ["k1"]})
+
+    assert captured["limit"] == 10
+
+
+def test_search_returns_empty_results():
+    with patch("app.main.search_documents", return_value=([], "m")):
+        response = client.post("/genai/search", json={"query": "nothing matches", "objectKeys": ["k1"]})
+
+    assert response.status_code == 200
+    assert response.json()["results"] == []
+
+
+def test_search_rejects_empty_query():
+    response = client.post("/genai/search", json={"query": "  ", "objectKeys": ["k1"]})
+    assert response.status_code == 422
+
+
+def test_search_rejects_missing_query():
+    response = client.post("/genai/search", json={"objectKeys": ["k1"]})
+    assert response.status_code == 422
+
+
+def test_search_rejects_out_of_range_limit():
+    response = client.post("/genai/search", json={"query": "q", "objectKeys": ["k1"], "limit": 0})
     assert response.status_code == 422
 
 

--- a/services/genai/tests/test_search.py
+++ b/services/genai/tests/test_search.py
@@ -4,10 +4,7 @@ Weaviate retrieval and the embedder are mocked, so no network or running
 services are needed.
 """
 
-import os
 from unittest.mock import patch
-
-import pytest
 
 from app.search import search_documents
 
@@ -20,18 +17,16 @@ def test_returns_one_result_per_document_ranked_by_best_chunk():
     hits = [
         _hit("doc-1", 2, "closest chunk", 0.05),
         _hit("doc-2", 0, "second doc", 0.20),
-        _hit("doc-1", 5, "same doc, farther chunk", 0.30),
     ]
     with (
         patch("app.search.embed_query", return_value=[0.1, 0.2]),
-        patch("app.search.search", return_value=hits),
+        patch("app.search.search_grouped", return_value=hits),
         patch("app.search.get_embedding_model_name", return_value="Qwen/Qwen3-Embedding-8B"),
     ):
         results, model = search_documents("query", ["doc-1", "doc-2"], limit=10)
 
     assert model == "Qwen/Qwen3-Embedding-8B"
     assert [r["object_key"] for r in results] == ["doc-1", "doc-2"]
-    # doc-1 keeps its nearest chunk (index 2), not the later, farther one
     assert results[0]["chunk_index"] == 2
     assert results[0]["snippet"] == "closest chunk"
 
@@ -39,7 +34,7 @@ def test_returns_one_result_per_document_ranked_by_best_chunk():
 def test_score_is_similarity_derived_from_distance():
     with (
         patch("app.search.embed_query", return_value=[0.0]),
-        patch("app.search.search", return_value=[_hit("doc-1", 0, "x", 0.25)]),
+        patch("app.search.search_grouped", return_value=[_hit("doc-1", 0, "x", 0.25)]),
         patch("app.search.get_embedding_model_name", return_value="m"),
     ):
         results, _ = search_documents("q", ["doc-1"], limit=5)
@@ -47,21 +42,20 @@ def test_score_is_similarity_derived_from_distance():
     assert results[0]["score"] == 0.75
 
 
-def test_limit_caps_number_of_documents():
-    hits = [_hit(f"doc-{i}", 0, "t", 0.1 * i) for i in range(5)]
+def test_score_clamps_to_zero_for_very_distant_chunks():
     with (
-        patch("app.search.embed_query", return_value=[0.1]),
-        patch("app.search.search", return_value=hits),
+        patch("app.search.embed_query", return_value=[0.0]),
+        patch("app.search.search_grouped", return_value=[_hit("doc-1", 0, "x", 1.6)]),
         patch("app.search.get_embedding_model_name", return_value="m"),
     ):
-        results, _ = search_documents("q", ["doc-0"], limit=2)
+        results, _ = search_documents("q", ["doc-1"], limit=5)
 
-    assert [r["object_key"] for r in results] == ["doc-0", "doc-1"]
+    assert results[0]["score"] == 0.0
 
 
 def test_empty_object_keys_returns_no_results_without_searching():
     with (
-        patch("app.search.search", side_effect=AssertionError("must not search")),
+        patch("app.search.search_grouped", side_effect=AssertionError("must not search")),
         patch("app.search.embed_query", side_effect=AssertionError("must not embed")),
         patch("app.search.get_embedding_model_name", return_value="m"),
     ):
@@ -71,11 +65,11 @@ def test_empty_object_keys_returns_no_results_without_searching():
     assert model == "m"
 
 
-def test_long_snippet_is_truncated():
+def test_long_snippet_is_truncated_at_word_boundary():
     long_text = "word " * 200
     with (
         patch("app.search.embed_query", return_value=[0.1]),
-        patch("app.search.search", return_value=[_hit("doc-1", 0, long_text, 0.1)]),
+        patch("app.search.search_grouped", return_value=[_hit("doc-1", 0, long_text, 0.1)]),
         patch("app.search.get_embedding_model_name", return_value="m"),
     ):
         results, _ = search_documents("q", ["doc-1"], limit=5)
@@ -83,37 +77,11 @@ def test_long_snippet_is_truncated():
     snippet = results[0]["snippet"]
     assert snippet.endswith("...")
     assert len(snippet) <= _snippet_ceiling()
+    assert not snippet[:-3].endswith(" "), snippet
+    assert "  " not in snippet
 
 
 def _snippet_ceiling() -> int:
     from app.search import _SNIPPET_MAX_CHARS
 
     return _SNIPPET_MAX_CHARS + len("...")
-
-
-def test_candidate_over_fetch_is_read_from_env():
-    captured = {}
-
-    def fake_search(vector, keys, k):
-        captured["k"] = k
-        return []
-
-    with (
-        patch.dict(os.environ, {"SEARCH_CANDIDATES": "17"}),
-        patch("app.search.embed_query", return_value=[0.1]),
-        patch("app.search.search", side_effect=fake_search),
-        patch("app.search.get_embedding_model_name", return_value="m"),
-    ):
-        search_documents("q", ["doc-1"], limit=5)
-
-    assert captured["k"] == 17
-
-
-def test_rejects_invalid_candidate_env():
-    with (
-        patch.dict(os.environ, {"SEARCH_CANDIDATES": "abc"}),
-        patch("app.search.embed_query", return_value=[0.1]),
-        patch("app.search.get_embedding_model_name", return_value="m"),
-    ):
-        with pytest.raises(RuntimeError, match="SEARCH_CANDIDATES"):
-            search_documents("q", ["doc-1"], limit=5)

--- a/services/genai/tests/test_search.py
+++ b/services/genai/tests/test_search.py
@@ -1,0 +1,119 @@
+"""Unit tests for the semantic search module.
+
+Weaviate retrieval and the embedder are mocked, so no network or running
+services are needed.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from app.search import search_documents
+
+
+def _hit(object_key: str, chunk_index: int, text: str, distance: float) -> dict:
+    return {"object_key": object_key, "chunk_index": chunk_index, "text": text, "distance": distance}
+
+
+def test_returns_one_result_per_document_ranked_by_best_chunk():
+    hits = [
+        _hit("doc-1", 2, "closest chunk", 0.05),
+        _hit("doc-2", 0, "second doc", 0.20),
+        _hit("doc-1", 5, "same doc, farther chunk", 0.30),
+    ]
+    with (
+        patch("app.search.embed_query", return_value=[0.1, 0.2]),
+        patch("app.search.search", return_value=hits),
+        patch("app.search.get_embedding_model_name", return_value="Qwen/Qwen3-Embedding-8B"),
+    ):
+        results, model = search_documents("query", ["doc-1", "doc-2"], limit=10)
+
+    assert model == "Qwen/Qwen3-Embedding-8B"
+    assert [r["object_key"] for r in results] == ["doc-1", "doc-2"]
+    # doc-1 keeps its nearest chunk (index 2), not the later, farther one
+    assert results[0]["chunk_index"] == 2
+    assert results[0]["snippet"] == "closest chunk"
+
+
+def test_score_is_similarity_derived_from_distance():
+    with (
+        patch("app.search.embed_query", return_value=[0.0]),
+        patch("app.search.search", return_value=[_hit("doc-1", 0, "x", 0.25)]),
+        patch("app.search.get_embedding_model_name", return_value="m"),
+    ):
+        results, _ = search_documents("q", ["doc-1"], limit=5)
+
+    assert results[0]["score"] == 0.75
+
+
+def test_limit_caps_number_of_documents():
+    hits = [_hit(f"doc-{i}", 0, "t", 0.1 * i) for i in range(5)]
+    with (
+        patch("app.search.embed_query", return_value=[0.1]),
+        patch("app.search.search", return_value=hits),
+        patch("app.search.get_embedding_model_name", return_value="m"),
+    ):
+        results, _ = search_documents("q", ["doc-0"], limit=2)
+
+    assert [r["object_key"] for r in results] == ["doc-0", "doc-1"]
+
+
+def test_empty_object_keys_returns_no_results_without_searching():
+    with (
+        patch("app.search.search", side_effect=AssertionError("must not search")),
+        patch("app.search.embed_query", side_effect=AssertionError("must not embed")),
+        patch("app.search.get_embedding_model_name", return_value="m"),
+    ):
+        results, model = search_documents("q", [], limit=10)
+
+    assert results == []
+    assert model == "m"
+
+
+def test_long_snippet_is_truncated():
+    long_text = "word " * 200
+    with (
+        patch("app.search.embed_query", return_value=[0.1]),
+        patch("app.search.search", return_value=[_hit("doc-1", 0, long_text, 0.1)]),
+        patch("app.search.get_embedding_model_name", return_value="m"),
+    ):
+        results, _ = search_documents("q", ["doc-1"], limit=5)
+
+    snippet = results[0]["snippet"]
+    assert snippet.endswith("...")
+    assert len(snippet) <= _snippet_ceiling()
+
+
+def _snippet_ceiling() -> int:
+    from app.search import _SNIPPET_MAX_CHARS
+
+    return _SNIPPET_MAX_CHARS + len("...")
+
+
+def test_candidate_over_fetch_is_read_from_env():
+    captured = {}
+
+    def fake_search(vector, keys, k):
+        captured["k"] = k
+        return []
+
+    with (
+        patch.dict(os.environ, {"SEARCH_CANDIDATES": "17"}),
+        patch("app.search.embed_query", return_value=[0.1]),
+        patch("app.search.search", side_effect=fake_search),
+        patch("app.search.get_embedding_model_name", return_value="m"),
+    ):
+        search_documents("q", ["doc-1"], limit=5)
+
+    assert captured["k"] == 17
+
+
+def test_rejects_invalid_candidate_env():
+    with (
+        patch.dict(os.environ, {"SEARCH_CANDIDATES": "abc"}),
+        patch("app.search.embed_query", return_value=[0.1]),
+        patch("app.search.get_embedding_model_name", return_value="m"),
+    ):
+        with pytest.raises(RuntimeError, match="SEARCH_CANDIDATES"):
+            search_documents("q", ["doc-1"], limit=5)

--- a/services/genai/tests/test_search.py
+++ b/services/genai/tests/test_search.py
@@ -65,6 +65,24 @@ def test_empty_object_keys_returns_no_results_without_searching():
     assert model == "m"
 
 
+def test_search_grouped_returns_empty_for_empty_object_keys_without_querying():
+    from app.vectorstore import search_grouped
+
+    with patch("app.vectorstore._client", side_effect=AssertionError("must not touch weaviate")):
+        results = search_grouped([0.1, 0.2], [], limit=5)
+
+    assert results == []
+
+
+def test_search_returns_empty_for_empty_object_keys_without_querying():
+    from app.vectorstore import search
+
+    with patch("app.vectorstore._client", side_effect=AssertionError("must not touch weaviate")):
+        results = search([0.1, 0.2], [], limit=5)
+
+    assert results == []
+
+
 def test_long_snippet_is_truncated_at_word_boundary():
     long_text = "word " * 200
     with (

--- a/services/genai/uv.lock
+++ b/services/genai/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.14.*"
 
 [[package]]
 name = "alexandria-genai"
-version = "2.1.0"
+version = "2.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/services/spring/knowledgebase-service/src/main/java/com/alexandria/knowledgebase/config/OpenApiConfig.java
+++ b/services/spring/knowledgebase-service/src/main/java/com/alexandria/knowledgebase/config/OpenApiConfig.java
@@ -19,7 +19,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @OpenAPIDefinition(
         info = @Info(
-                title = "Alexandria KnowledgeBase Service API", version = "2.1.0", description = "Document management, tagging, and text search. Owns the documents/tags/search-queries tables and calls the GenAI service for summarization and entity extraction.", license = @License(name = "MIT", identifier = "MIT")
+                title = "Alexandria KnowledgeBase Service API", version = "2.2.0", description = "Document management, tagging, and text search. Owns the documents/tags/search-queries tables and calls the GenAI service for summarization and entity extraction.", license = @License(name = "MIT", identifier = "MIT")
         ), servers = @Server(url = "/", description = "Current server")
 )
 @SecurityScheme(

--- a/services/spring/qa-service/src/main/java/com/alexandria/qa/config/OpenApiConfig.java
+++ b/services/spring/qa-service/src/main/java/com/alexandria/qa/config/OpenApiConfig.java
@@ -19,7 +19,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @OpenAPIDefinition(
         info = @Info(
-                title = "Alexandria QA Service API", version = "2.1.0", description = "Question answering over a user's documents. Fetches document keys from knowledgebase-service and delegates answer generation to the GenAI service.", license = @License(name = "MIT", identifier = "MIT")
+                title = "Alexandria QA Service API", version = "2.2.0", description = "Question answering over a user's documents. Fetches document keys from knowledgebase-service and delegates answer generation to the GenAI service.", license = @License(name = "MIT", identifier = "MIT")
         ), servers = @Server(url = "/", description = "Current server")
 )
 @SecurityScheme(

--- a/services/spring/user-service/src/main/java/com/alexandria/user/config/OpenApiConfig.java
+++ b/services/spring/user-service/src/main/java/com/alexandria/user/config/OpenApiConfig.java
@@ -19,7 +19,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @OpenAPIDefinition(
         info = @Info(
-                title = "Alexandria User Service API", version = "2.1.0", description = "User account management. Owns the users table; exposes internal fan-out endpoints consumed by knowledgebase-service and qa-service.", license = @License(name = "MIT", identifier = "MIT")
+                title = "Alexandria User Service API", version = "2.2.0", description = "User account management. Owns the users table; exposes internal fan-out endpoints consumed by knowledgebase-service and qa-service.", license = @License(name = "MIT", identifier = "MIT")
         ), servers = @Server(url = "/", description = "Current server")
 )
 @SecurityScheme(


### PR DESCRIPTION
## What does this PR do?

Adds a semantic search capability to the GenAI service. New `POST /genai/search` embeds the query with the same embedding config as the RAG pipeline, runs a vector similarity search in Weaviate over the indexed chunks, and rolls the chunk hits up to the document level so each document appears once, ranked by its closest-matching chunk. Every result carries a snippet and a relevance score so the client can show why a document matched (#11).

Closes #188.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] CI / infra

## Definition of Done

- [x] CI is green
- [x] If the API changed: `api/openapi.yaml` is updated and lint passes
- [ ] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [x] Tests added or updated for the changed behaviour
- [x] Docs updated where it matters (README, ADRs, comments)

## Notes for the reviewer

- This branch is based on `feat/187-genai-tagging`. Merge #242 first, then this targets `main`; otherwise the diff will also show the tagging commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added `POST /genai/search` for semantic document search with `query`, scoped `objectKeys`, and optional `limit`.
  * Returns ranked results including `score`, `snippet`, `chunkIndex`, and the `embeddingModel`.

* **Bug Fixes**
  * Scoped searches with no document keys now return an empty result set (no broader/unscoped search).

* **Documentation**
  * Updated API documentation/contract and service docs to describe the new search request/response.

* **Tests**
  * Added API and unit test coverage for validation, ranking, scoring, and snippet behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->