### PR TITLE
Task: Add monitoring to helm chart and improve security

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,9 +18,9 @@ services:
       - "traefik.http.routers.client.rule=PathPrefix(`/`)"
       - "traefik.http.routers.client.entrypoints=web"
       - "traefik.http.routers.client.priority=1"
-      - "traefik.http.services.client.loadbalancer.server.port=80"
+      - "traefik.http.services.client.loadbalancer.server.port=8080"
     healthcheck:
-      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:80/"]
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8080/"]
       interval: 30s
       timeout: 3s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - "traefik.http.routers.client.priority=1"
       - "traefik.http.services.client.loadbalancer.server.port=8080"
     healthcheck:
-      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8080/"]
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://127.0.0.1:8080/"]
       interval: 30s
       timeout: 3s
       retries: 3

--- a/infra/grafana/dashboards/s3-storage.json
+++ b/infra/grafana/dashboards/s3-storage.json
@@ -49,8 +49,8 @@
 			"targets": [
 				{
 					"datasource": { "type": "prometheus", "uid": "prometheus" },
-					"expr": "up{job=\"s3-storage\"}",
-					"legendFormat": "s3-storage",
+					"expr": "up{job=~\"s3-storage|seaweed-volume\"}",
+					"legendFormat": "{{job}}",
 					"refId": "A"
 				}
 			],
@@ -81,7 +81,7 @@
 			"targets": [
 				{
 					"datasource": { "type": "prometheus", "uid": "prometheus" },
-					"expr": "SeaweedFS_build_info{job=\"s3-storage\"}",
+					"expr": "SeaweedFS_build_info{job=~\"s3-storage|seaweed-volume\"}",
 					"legendFormat": "{{version}}",
 					"instant": true,
 					"refId": "A"
@@ -121,7 +121,7 @@
 			"targets": [
 				{
 					"datasource": { "type": "prometheus", "uid": "prometheus" },
-					"expr": "100 * sum(SeaweedFS_volumeServer_resource{job=\"s3-storage\", type=\"used\"}) / sum(SeaweedFS_volumeServer_resource{job=\"s3-storage\", type=\"all\"})",
+					"expr": "100 * sum(SeaweedFS_volumeServer_resource{job=~\"s3-storage|seaweed-volume\", type=\"used\"}) / sum(SeaweedFS_volumeServer_resource{job=~\"s3-storage|seaweed-volume\", type=\"all\"})",
 					"legendFormat": "disk used %",
 					"refId": "A"
 				}
@@ -253,13 +253,13 @@
 			"targets": [
 				{
 					"datasource": { "type": "prometheus", "uid": "prometheus" },
-					"expr": "sum(SeaweedFS_volumeServer_resource{job=\"s3-storage\", type=\"used\"})",
+					"expr": "sum(SeaweedFS_volumeServer_resource{job=~\"s3-storage|seaweed-volume\", type=\"used\"})",
 					"legendFormat": "used",
 					"refId": "A"
 				},
 				{
 					"datasource": { "type": "prometheus", "uid": "prometheus" },
-					"expr": "sum(SeaweedFS_volumeServer_resource{job=\"s3-storage\", type=\"avail\"})",
+					"expr": "sum(SeaweedFS_volumeServer_resource{job=~\"s3-storage|seaweed-volume\", type=\"avail\"})",
 					"legendFormat": "available",
 					"refId": "B"
 				}

--- a/infra/grafana/dashboards/s3-storage.json
+++ b/infra/grafana/dashboards/s3-storage.json
@@ -50,7 +50,7 @@
 				{
 					"datasource": { "type": "prometheus", "uid": "prometheus" },
 					"expr": "up{job=~\"s3-storage|seaweed-volume\"}",
-					"legendFormat": "s3-storage",
+					"legendFormat": "{{instance}} ({{job}})",
 					"refId": "A"
 				}
 			],

--- a/infra/grafana/dashboards/s3-storage.json
+++ b/infra/grafana/dashboards/s3-storage.json
@@ -50,7 +50,7 @@
 				{
 					"datasource": { "type": "prometheus", "uid": "prometheus" },
 					"expr": "up{job=~\"s3-storage|seaweed-volume\"}",
-					"legendFormat": "{{job}}",
+					"legendFormat": "s3-storage",
 					"refId": "A"
 				}
 			],

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -21,7 +21,20 @@ kubectl config use-context <context>
 ```bash
 helm install alexandria infra/k8s/alexandria \
   --namespace alexandria --create-namespace \
-  --dependency-update
+  --dependency-update \
+  --set grafana.adminPassword=admin
+```
+
+Prometheus and Grafana live in their own namespace (`alexandria-monitoring` by
+default, override via `monitoring.namespace`) and are intentionally not exposed
+through the ingress. To reach them, port-forward:
+
+```bash
+kubectl -n alexandria-monitoring port-forward svc/alexandria-prometheus 9090:9090
+# open http://localhost:9090/prometheus
+
+kubectl -n alexandria-monitoring port-forward svc/alexandria-grafana 3000:3000
+# open http://localhost:3000
 ```
 
 ## Secrets Setup:

--- a/infra/k8s/alexandria/files/dashboards
+++ b/infra/k8s/alexandria/files/dashboards
@@ -1,0 +1,1 @@
+../../../grafana/dashboards

--- a/infra/k8s/alexandria/templates/_helpers.tpl
+++ b/infra/k8s/alexandria/templates/_helpers.tpl
@@ -48,3 +48,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- define "alexandria.s3Endpoint" -}}
 http://{{ .Release.Name }}-seaweedfs-s3:{{ .Values.seaweedfs.s3.port }}
 {{- end }}
+
+{{- define "alexandria.monitoringNamespace" -}}
+{{- default (printf "%s-monitoring" .Release.Namespace) .Values.monitoring.namespace }}
+{{- end }}

--- a/infra/k8s/alexandria/templates/client-deployment.yaml
+++ b/infra/k8s/alexandria/templates/client-deployment.yaml
@@ -20,9 +20,11 @@ spec:
         app.kubernetes.io/component: frontend
     spec:
       automountServiceAccountToken: false
-      # nginx (default image) has to bind to :80, so runAsNonRoot stays off here.
       securityContext:
-        runAsNonRoot: false
+        runAsNonRoot: true
+        runAsUser: 101
+        runAsGroup: 101
+        fsGroup: 101
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -37,13 +39,9 @@ spec:
                 - ALL
           ports:
             - name: http
-              containerPort: 80
+              containerPort: 8080
               protocol: TCP
           volumeMounts:
-            - name: nginx-cache
-              mountPath: /var/cache/nginx
-            - name: nginx-run
-              mountPath: /var/run
             - name: tmp
               mountPath: /tmp
           resources:
@@ -65,9 +63,5 @@ spec:
             timeoutSeconds: 3
             failureThreshold: 3
       volumes:
-        - name: nginx-cache
-          emptyDir: {}
-        - name: nginx-run
-          emptyDir: {}
         - name: tmp
           emptyDir: {}

--- a/infra/k8s/alexandria/templates/client-deployment.yaml
+++ b/infra/k8s/alexandria/templates/client-deployment.yaml
@@ -19,16 +19,30 @@ spec:
         app: client
         app.kubernetes.io/component: frontend
     spec:
+      # nginx (default image) has to bind to :80, so runAsNonRoot stays off here.
       securityContext:
         runAsNonRoot: false
       containers:
         - name: client
           image: {{ include "alexandria.image" (dict "Values" .Values "service" "client") }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
           ports:
             - name: http
               containerPort: 80
               protocol: TCP
+          volumeMounts:
+            - name: nginx-cache
+              mountPath: /var/cache/nginx
+            - name: nginx-run
+              mountPath: /var/run
+            - name: tmp
+              mountPath: /tmp
           resources:
             {{- toYaml .Values.client.resources | nindent 12 }}
           livenessProbe:
@@ -47,3 +61,10 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 3
+      volumes:
+        - name: nginx-cache
+          emptyDir: {}
+        - name: nginx-run
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}

--- a/infra/k8s/alexandria/templates/client-deployment.yaml
+++ b/infra/k8s/alexandria/templates/client-deployment.yaml
@@ -19,9 +19,12 @@ spec:
         app: client
         app.kubernetes.io/component: frontend
     spec:
+      automountServiceAccountToken: false
       # nginx (default image) has to bind to :80, so runAsNonRoot stays off here.
       securityContext:
         runAsNonRoot: false
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: client
           image: {{ include "alexandria.image" (dict "Values" .Values "service" "client") }}

--- a/infra/k8s/alexandria/templates/genai-deployment.yaml
+++ b/infra/k8s/alexandria/templates/genai-deployment.yaml
@@ -19,6 +19,7 @@ spec:
         app: genai
         app.kubernetes.io/component: ai-service
     spec:
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/infra/k8s/alexandria/templates/genai-deployment.yaml
+++ b/infra/k8s/alexandria/templates/genai-deployment.yaml
@@ -23,10 +23,18 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
         fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: genai
           image: {{ include "alexandria.image" (dict "Values" .Values "service" "genai") }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
           ports:
             - name: http
               containerPort: 8000
@@ -45,6 +53,9 @@ spec:
                 secretKeyRef:
                   name: {{ include "alexandria.fullname" . }}-spring-secrets
                   key: s3-secret-key
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
           resources:
             {{- toYaml .Values.genai.resources | nindent 12 }}
           livenessProbe:
@@ -63,3 +74,6 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/infra/k8s/alexandria/templates/grafana-config.yaml
+++ b/infra/k8s/alexandria/templates/grafana-config.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "alexandria.fullname" . }}-grafana-provisioning
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "alexandria.monitoringNamespace" . }}
   labels:
     {{- include "alexandria.labels" . | nindent 4 }}
 data:
@@ -34,7 +34,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "alexandria.fullname" . }}-grafana-dashboards
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "alexandria.monitoringNamespace" . }}
   labels:
     {{- include "alexandria.labels" . | nindent 4 }}
 data:

--- a/infra/k8s/alexandria/templates/grafana-config.yaml
+++ b/infra/k8s/alexandria/templates/grafana-config.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.grafana.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "alexandria.fullname" . }}-grafana-provisioning
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "alexandria.labels" . | nindent 4 }}
+data:
+  datasources.yaml: |
+    apiVersion: 1
+    datasources:
+      - name: Prometheus
+        uid: prometheus
+        type: prometheus
+        access: proxy
+        url: http://{{ include "alexandria.fullname" . }}-prometheus:9090/prometheus
+        isDefault: true
+        editable: false
+  dashboards.yaml: |
+    apiVersion: 1
+    providers:
+      - name: Alexandria
+        orgId: 1
+        folder: Alexandria
+        type: file
+        disableDeletion: false
+        editable: true
+        options:
+          path: /var/lib/grafana/dashboards
+          foldersFromFilesStructure: false
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "alexandria.fullname" . }}-grafana-dashboards
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "alexandria.labels" . | nindent 4 }}
+data:
+{{- range $path, $_ := .Files.Glob "files/dashboards/*.json" }}
+  {{ base $path }}: |-
+{{ $.Files.Get $path | indent 4 }}
+{{- end }}
+{{- end }}

--- a/infra/k8s/alexandria/templates/grafana-deployment.yaml
+++ b/infra/k8s/alexandria/templates/grafana-deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "alexandria.fullname" . }}-grafana
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "alexandria.monitoringNamespace" . }}
   labels:
     {{- include "alexandria.labels" . | nindent 4 }}
     app: grafana
@@ -44,10 +44,6 @@ spec:
               drop:
                 - ALL
           env:
-            - name: GF_SERVER_ROOT_URL
-              value: {{ if .Values.ingress.enabled }}https://{{ .Values.ingress.host }}/grafana/{{ else }}http://localhost:3000/grafana/{{ end }}
-            - name: GF_SERVER_SERVE_FROM_SUB_PATH
-              value: "true"
             - name: GF_USERS_ALLOW_SIGN_UP
               value: "false"
             - name: GF_SECURITY_ADMIN_PASSWORD
@@ -77,7 +73,7 @@ spec:
             {{- toYaml .Values.grafana.resources | nindent 12 }}
           livenessProbe:
             httpGet:
-              path: /grafana/api/health
+              path: /api/health
               port: http
             initialDelaySeconds: 30
             periodSeconds: 30
@@ -85,7 +81,7 @@ spec:
             failureThreshold: 3
           readinessProbe:
             httpGet:
-              path: /grafana/api/health
+              path: /api/health
               port: http
             initialDelaySeconds: 10
             periodSeconds: 10

--- a/infra/k8s/alexandria/templates/grafana-deployment.yaml
+++ b/infra/k8s/alexandria/templates/grafana-deployment.yaml
@@ -45,7 +45,7 @@ spec:
                 - ALL
           env:
             - name: GF_SERVER_ROOT_URL
-              value: /grafana
+              value: {{ if .Values.ingress.enabled }}https://{{ .Values.ingress.host }}/grafana/{{ else }}http://localhost:3000/grafana/{{ end }}
             - name: GF_SERVER_SERVE_FROM_SUB_PATH
               value: "true"
             - name: GF_USERS_ALLOW_SIGN_UP

--- a/infra/k8s/alexandria/templates/grafana-deployment.yaml
+++ b/infra/k8s/alexandria/templates/grafana-deployment.yaml
@@ -1,0 +1,115 @@
+{{- if .Values.grafana.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "alexandria.fullname" . }}-grafana
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "alexandria.labels" . | nindent 4 }}
+    app: grafana
+    app.kubernetes.io/component: monitoring
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "alexandria.selectorLabels" . | nindent 6 }}
+      app: grafana
+  template:
+    metadata:
+      labels:
+        {{- include "alexandria.selectorLabels" . | nindent 8 }}
+        app: grafana
+        app.kubernetes.io/component: monitoring
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/grafana-config.yaml") . | sha256sum }}
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 472
+        runAsGroup: 472
+        fsGroup: 472
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: grafana
+          image: {{ .Values.grafana.image.repository }}:{{ .Values.grafana.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          env:
+            - name: GF_SERVER_ROOT_URL
+              value: /grafana
+            - name: GF_SERVER_SERVE_FROM_SUB_PATH
+              value: "true"
+            - name: GF_USERS_ALLOW_SIGN_UP
+              value: "false"
+            - name: GF_SECURITY_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "alexandria.fullname" . }}-grafana
+                  key: admin-password
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/grafana
+            - name: datasources
+              mountPath: /etc/grafana/provisioning/datasources
+              readOnly: true
+            - name: dashboard-provider
+              mountPath: /etc/grafana/provisioning/dashboards
+              readOnly: true
+            - name: dashboards
+              mountPath: /var/lib/grafana/dashboards
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+          resources:
+            {{- toYaml .Values.grafana.resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /grafana/api/health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /grafana/api/health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "alexandria.fullname" . }}-grafana
+        - name: datasources
+          configMap:
+            name: {{ include "alexandria.fullname" . }}-grafana-provisioning
+            items:
+              - key: datasources.yaml
+                path: datasources.yaml
+        - name: dashboard-provider
+          configMap:
+            name: {{ include "alexandria.fullname" . }}-grafana-provisioning
+            items:
+              - key: dashboards.yaml
+                path: dashboards.yaml
+        - name: dashboards
+          configMap:
+            name: {{ include "alexandria.fullname" . }}-grafana-dashboards
+        - name: tmp
+          emptyDir: {}
+{{- end }}

--- a/infra/k8s/alexandria/templates/grafana-pvc.yaml
+++ b/infra/k8s/alexandria/templates/grafana-pvc.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "alexandria.fullname" . }}-grafana
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "alexandria.monitoringNamespace" . }}
   labels:
     {{- include "alexandria.labels" . | nindent 4 }}
 spec:

--- a/infra/k8s/alexandria/templates/grafana-pvc.yaml
+++ b/infra/k8s/alexandria/templates/grafana-pvc.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.grafana.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "alexandria.fullname" . }}-grafana
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "alexandria.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.grafana.persistence.size }}
+{{- end }}

--- a/infra/k8s/alexandria/templates/grafana-secret.yaml
+++ b/infra/k8s/alexandria/templates/grafana-secret.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.grafana.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "alexandria.fullname" . }}-grafana
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "alexandria.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  admin-password: {{ .Values.grafana.adminPassword | quote }}
+{{- end }}

--- a/infra/k8s/alexandria/templates/grafana-secret.yaml
+++ b/infra/k8s/alexandria/templates/grafana-secret.yaml
@@ -6,7 +6,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "alexandria.fullname" . }}-grafana
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "alexandria.monitoringNamespace" . }}
   labels:
     {{- include "alexandria.labels" . | nindent 4 }}
 type: Opaque

--- a/infra/k8s/alexandria/templates/grafana-secret.yaml
+++ b/infra/k8s/alexandria/templates/grafana-secret.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.grafana.enabled }}
+{{- if not .Values.grafana.adminPassword }}
+{{- fail "grafana.adminPassword must be set (e.g. via --set grafana.adminPassword=... or values-secrets.yaml) when grafana.enabled=true" }}
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/infra/k8s/alexandria/templates/grafana-service.yaml
+++ b/infra/k8s/alexandria/templates/grafana-service.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.grafana.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "alexandria.fullname" . }}-grafana
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "alexandria.labels" . | nindent 4 }}
+    app: grafana
+    app.kubernetes.io/component: monitoring
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "alexandria.selectorLabels" . | nindent 4 }}
+    app: grafana
+  ports:
+    - name: http
+      port: 3000
+      targetPort: http
+      protocol: TCP
+{{- end }}

--- a/infra/k8s/alexandria/templates/grafana-service.yaml
+++ b/infra/k8s/alexandria/templates/grafana-service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "alexandria.fullname" . }}-grafana
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "alexandria.monitoringNamespace" . }}
   labels:
     {{- include "alexandria.labels" . | nindent 4 }}
     app: grafana

--- a/infra/k8s/alexandria/templates/ingress.yaml
+++ b/infra/k8s/alexandria/templates/ingress.yaml
@@ -136,4 +136,22 @@ spec:
                 name: {{ include "alexandria.fullname" . }}-keycloak
                 port:
                   number: 8080
+          {{- if .Values.prometheus.enabled }}
+          - path: /prometheus
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "alexandria.fullname" . }}-prometheus
+                port:
+                  number: 9090
+          {{- end }}
+          {{- if .Values.grafana.enabled }}
+          - path: /grafana
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "alexandria.fullname" . }}-grafana
+                port:
+                  number: 3000
+          {{- end }}
 {{- end }}

--- a/infra/k8s/alexandria/templates/ingress.yaml
+++ b/infra/k8s/alexandria/templates/ingress.yaml
@@ -136,22 +136,4 @@ spec:
                 name: {{ include "alexandria.fullname" . }}-keycloak
                 port:
                   number: 8080
-          {{- if .Values.prometheus.enabled }}
-          - path: /prometheus
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ include "alexandria.fullname" . }}-prometheus
-                port:
-                  number: 9090
-          {{- end }}
-          {{- if .Values.grafana.enabled }}
-          - path: /grafana
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ include "alexandria.fullname" . }}-grafana
-                port:
-                  number: 3000
-          {{- end }}
 {{- end }}

--- a/infra/k8s/alexandria/templates/knowledgebase-service-deployment.yaml
+++ b/infra/k8s/alexandria/templates/knowledgebase-service-deployment.yaml
@@ -52,6 +52,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop:
                 - ALL
@@ -78,6 +79,9 @@ spec:
                 secretKeyRef:
                   name: {{ include "alexandria.fullname" . }}-spring-secrets
                   key: s3-secret-key
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
           resources:
             {{- toYaml .Values.knowledgebaseService.resources | nindent 12 }}
           startupProbe:
@@ -101,3 +105,6 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/infra/k8s/alexandria/templates/monitoring-namespace.yaml
+++ b/infra/k8s/alexandria/templates/monitoring-namespace.yaml
@@ -1,0 +1,9 @@
+{{- if and .Values.monitoring.createNamespace (or .Values.prometheus.enabled .Values.grafana.enabled) }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ include "alexandria.monitoringNamespace" . }}
+  labels:
+    {{- include "alexandria.labels" . | nindent 4 }}
+    app.kubernetes.io/component: monitoring
+{{- end }}

--- a/infra/k8s/alexandria/templates/prometheus-config.yaml
+++ b/infra/k8s/alexandria/templates/prometheus-config.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "alexandria.fullname" . }}-prometheus-config
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "alexandria.monitoringNamespace" . }}
   labels:
     {{- include "alexandria.labels" . | nindent 4 }}
 data:
@@ -24,28 +24,33 @@ data:
       - job_name: user-service
         metrics_path: /actuator/prometheus
         static_configs:
-          - targets: ["{{ include "alexandria.fullname" . }}-user-service:8080"]
+          - targets: ["{{ include "alexandria.fullname" . }}-user-service.{{ .Release.Namespace }}:8080"]
 
       - job_name: knowledgebase-service
         metrics_path: /actuator/prometheus
         static_configs:
-          - targets: ["{{ include "alexandria.fullname" . }}-knowledgebase-service:8080"]
+          - targets: ["{{ include "alexandria.fullname" . }}-knowledgebase-service.{{ .Release.Namespace }}:8080"]
 
       - job_name: qa-service
         metrics_path: /actuator/prometheus
         static_configs:
-          - targets: ["{{ include "alexandria.fullname" . }}-qa-service:8080"]
+          - targets: ["{{ include "alexandria.fullname" . }}-qa-service.{{ .Release.Namespace }}:8080"]
 
       - job_name: genai
         metrics_path: /genai/metrics
         static_configs:
-          - targets: ["{{ include "alexandria.fullname" . }}-genai:8000"]
+          - targets: ["{{ include "alexandria.fullname" . }}-genai.{{ .Release.Namespace }}:8000"]
 
+      # SeaweedFS runs as separate deployments in the helm chart (unlike the
+      # all-in-one compose container), so we split the scrape by component to
+      # keep dashboard/label semantics clean.
       - job_name: s3-storage
         static_configs:
-          - targets:
-              - "{{ .Release.Name }}-seaweedfs-s3:9327"
-              - "{{ .Release.Name }}-seaweedfs-volume:9327"
+          - targets: ["{{ .Release.Name }}-seaweedfs-s3.{{ .Release.Namespace }}:9327"]
+
+      - job_name: seaweed-volume
+        static_configs:
+          - targets: ["{{ .Release.Name }}-seaweedfs-volume.{{ .Release.Namespace }}:9327"]
 
   alert.rules.yml: |
     groups:

--- a/infra/k8s/alexandria/templates/prometheus-config.yaml
+++ b/infra/k8s/alexandria/templates/prometheus-config.yaml
@@ -1,0 +1,98 @@
+{{- if .Values.prometheus.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "alexandria.fullname" . }}-prometheus-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "alexandria.labels" . | nindent 4 }}
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 15s
+      evaluation_interval: 15s
+
+    rule_files:
+      - /etc/prometheus/alert.rules.yml
+
+    scrape_configs:
+      - job_name: prometheus
+        metrics_path: /prometheus/metrics
+        static_configs:
+          - targets: ["localhost:9090"]
+
+      - job_name: user-service
+        metrics_path: /actuator/prometheus
+        static_configs:
+          - targets: ["{{ include "alexandria.fullname" . }}-user-service:8080"]
+
+      - job_name: knowledgebase-service
+        metrics_path: /actuator/prometheus
+        static_configs:
+          - targets: ["{{ include "alexandria.fullname" . }}-knowledgebase-service:8080"]
+
+      - job_name: qa-service
+        metrics_path: /actuator/prometheus
+        static_configs:
+          - targets: ["{{ include "alexandria.fullname" . }}-qa-service:8080"]
+
+      - job_name: genai
+        metrics_path: /genai/metrics
+        static_configs:
+          - targets: ["{{ include "alexandria.fullname" . }}-genai:8000"]
+
+      - job_name: s3-storage
+        static_configs:
+          - targets:
+              - "{{ .Release.Name }}-seaweedfs-s3:9327"
+              - "{{ .Release.Name }}-seaweedfs-volume:9327"
+
+  alert.rules.yml: |
+    groups:
+      - name: alexandria
+        rules:
+          - alert: ServiceDown
+            expr: up == 0
+            for: 1m
+            labels:
+              severity: critical
+            annotations:
+              summary: "{{`{{ $labels.job }}`}} target is down"
+              description: "Prometheus has not been able to scrape {{`{{ $labels.instance }}`}} ({{`{{ $labels.job }}`}}) for over a minute."
+          - alert: SpringHighErrorRate
+            expr: |
+              sum by (job) (rate(http_server_requests_seconds_count{job=~"user-service|knowledgebase-service|qa-service", status=~"5.."}[5m]))
+                /
+              sum by (job) (rate(http_server_requests_seconds_count{job=~"user-service|knowledgebase-service|qa-service"}[5m]))
+                > 0.05
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: "{{`{{ $labels.job }}`}} 5xx error rate above 5%"
+              description: "More than 5% of {{`{{ $labels.job }}`}} requests have failed with a 5xx status over the last 5 minutes."
+          - alert: GenAiSlowResponses
+            expr: |
+              histogram_quantile(
+                0.95,
+                sum(rate(http_request_duration_seconds_bucket{job="genai"}[5m])) by (le)
+              ) > 2
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: "GenAI p95 latency above 2s"
+              description: "The 95th percentile of GenAI request latency has been above 2 seconds for 5 minutes."
+          - alert: S3StorageLowDiskSpace
+            expr: |
+              sum(SeaweedFS_volumeServer_resource{type="avail"})
+                /
+              sum(SeaweedFS_volumeServer_resource{type="all"})
+                < 0.10
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: "Object storage disk space below 10%"
+              description: "The SeaweedFS volume server has less than 10% available disk space for over 5 minutes. Document uploads are at risk."
+{{- end }}

--- a/infra/k8s/alexandria/templates/prometheus-deployment.yaml
+++ b/infra/k8s/alexandria/templates/prometheus-deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "alexandria.fullname" . }}-prometheus
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "alexandria.monitoringNamespace" . }}
   labels:
     {{- include "alexandria.labels" . | nindent 4 }}
     app: prometheus

--- a/infra/k8s/alexandria/templates/prometheus-deployment.yaml
+++ b/infra/k8s/alexandria/templates/prometheus-deployment.yaml
@@ -1,0 +1,87 @@
+{{- if .Values.prometheus.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "alexandria.fullname" . }}-prometheus
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "alexandria.labels" . | nindent 4 }}
+    app: prometheus
+    app.kubernetes.io/component: monitoring
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "alexandria.selectorLabels" . | nindent 6 }}
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        {{- include "alexandria.selectorLabels" . | nindent 8 }}
+        app: prometheus
+        app.kubernetes.io/component: monitoring
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/prometheus-config.yaml") . | sha256sum }}
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        fsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: prometheus
+          image: {{ .Values.prometheus.image.repository }}:{{ .Values.prometheus.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - --config.file=/etc/prometheus/prometheus.yml
+            - --storage.tsdb.path=/prometheus
+            - --web.external-url=/prometheus
+            - --web.route-prefix=/prometheus
+            - --storage.tsdb.retention.time={{ .Values.prometheus.retention }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          ports:
+            - name: http
+              containerPort: 9090
+              protocol: TCP
+          volumeMounts:
+            - name: config
+              mountPath: /etc/prometheus
+              readOnly: true
+            - name: data
+              mountPath: /prometheus
+          resources:
+            {{- toYaml .Values.prometheus.resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /prometheus/-/healthy
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /prometheus/-/ready
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "alexandria.fullname" . }}-prometheus-config
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "alexandria.fullname" . }}-prometheus
+{{- end }}

--- a/infra/k8s/alexandria/templates/prometheus-pvc.yaml
+++ b/infra/k8s/alexandria/templates/prometheus-pvc.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.prometheus.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "alexandria.fullname" . }}-prometheus
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "alexandria.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.prometheus.persistence.size }}
+{{- end }}

--- a/infra/k8s/alexandria/templates/prometheus-pvc.yaml
+++ b/infra/k8s/alexandria/templates/prometheus-pvc.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "alexandria.fullname" . }}-prometheus
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "alexandria.monitoringNamespace" . }}
   labels:
     {{- include "alexandria.labels" . | nindent 4 }}
 spec:

--- a/infra/k8s/alexandria/templates/prometheus-service.yaml
+++ b/infra/k8s/alexandria/templates/prometheus-service.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.prometheus.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "alexandria.fullname" . }}-prometheus
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "alexandria.labels" . | nindent 4 }}
+    app: prometheus
+    app.kubernetes.io/component: monitoring
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "alexandria.selectorLabels" . | nindent 4 }}
+    app: prometheus
+  ports:
+    - name: http
+      port: 9090
+      targetPort: http
+      protocol: TCP
+{{- end }}

--- a/infra/k8s/alexandria/templates/prometheus-service.yaml
+++ b/infra/k8s/alexandria/templates/prometheus-service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "alexandria.fullname" . }}-prometheus
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "alexandria.monitoringNamespace" . }}
   labels:
     {{- include "alexandria.labels" . | nindent 4 }}
     app: prometheus

--- a/infra/k8s/alexandria/templates/qa-service-deployment.yaml
+++ b/infra/k8s/alexandria/templates/qa-service-deployment.yaml
@@ -52,6 +52,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop:
                 - ALL
@@ -68,6 +69,9 @@ spec:
                 secretKeyRef:
                   name: {{ include "alexandria.fullname" . }}-spring-secrets
                   key: postgres-password
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
           resources:
             {{- toYaml .Values.qaService.resources | nindent 12 }}
           startupProbe:
@@ -91,3 +95,6 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/infra/k8s/alexandria/templates/user-service-deployment.yaml
+++ b/infra/k8s/alexandria/templates/user-service-deployment.yaml
@@ -52,6 +52,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop:
                 - ALL
@@ -68,6 +69,9 @@ spec:
                 secretKeyRef:
                   name: {{ include "alexandria.fullname" . }}-spring-secrets
                   key: postgres-password
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
           resources:
             {{- toYaml .Values.userService.resources | nindent 12 }}
           startupProbe:
@@ -91,3 +95,6 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/infra/k8s/alexandria/values-secrets.yaml.example
+++ b/infra/k8s/alexandria/values-secrets.yaml.example
@@ -5,6 +5,7 @@ keycloakAdminPassword: &keycloakAdminPassword "secure-admin-password" # Change t
 postgresPassword: &postgresPassword "postgres-password" # Change this!
 s3AccessKey: &s3AccessKey "admin" # Change this!
 s3SecretKey: &s3SecretKey "s3-secret-password" # Change this!
+grafanaAdminPassword: &grafanaAdminPassword "grafana-admin-password" # Change this!
 
 
 # Do not change this!
@@ -33,3 +34,6 @@ seaweedfs:
       admin:
         accessKey: *s3AccessKey
         secretKey: *s3SecretKey
+
+grafana:
+  adminPassword: *grafanaAdminPassword

--- a/infra/k8s/alexandria/values.yaml
+++ b/infra/k8s/alexandria/values.yaml
@@ -26,9 +26,10 @@ spring:
     usernameClaim: "preferred_username"
     rolesClaim: "roles"
 
-# CPU limits are sized so the sum of all `limits.cpu` in the alexandria
-# namespace stays under the 4 CPU quota enforced by the stud cluster
-# (ResourceQuota `default-h2d5c`).
+# Resource limits are sized to stay under the stud cluster ResourceQuota
+# `default-h2d5c` (3250m CPU / 5144Mi memory in the alexandria namespace).
+# Prometheus + Grafana live in alexandria-monitoring with its own 750m/1000Mi
+# quota, sized independently below.
 userService:
   resources:
     requests:
@@ -41,10 +42,10 @@ userService:
 knowledgebaseService:
   resources:
     requests:
-      cpu: 200m
+      cpu: 150m
       memory: 256Mi
     limits:
-      cpu: 400m
+      cpu: 300m
       memory: 512Mi
 
 qaService:
@@ -87,17 +88,25 @@ weaviate:
   resources:
     requests:
       cpu: 100m
-      memory: 256Mi
+      memory: 192Mi
     limits:
-      cpu: 500m
-      memory: 512Mi
+      cpu: 200m
+      memory: 384Mi
 
 ingress:
   enabled: true
   className: nginx
   host: alexandria.stud.k8s.aet.cit.tum.de
 
-# Self-hosted Prometheus and Grafana mirroring the docker-compose setup
+# Self-hosted Prometheus and Grafana mirroring the docker-compose setup.
+# They live in their own namespace (per "Monitoring Best Practices in Kubernetes"
+# §1). Neither is exposed through the ingress — port-forward to reach them:
+#   kubectl -n alexandria-monitoring port-forward svc/alexandria-prometheus 9090:9090
+#   kubectl -n alexandria-monitoring port-forward svc/alexandria-grafana 3000:3000
+monitoring:
+  namespace: ""
+  createNamespace: false
+
 prometheus:
   enabled: true
   image:
@@ -202,10 +211,10 @@ postgres-db:
         CREATE DATABASE alexandria;
   resources:
     requests:
-      memory: "512Mi"
+      memory: "384Mi"
       cpu: "250m"
     limits:
-      memory: "1Gi"
+      memory: "768Mi"
       cpu: "500m"
 
 s3:

--- a/infra/k8s/alexandria/values.yaml
+++ b/infra/k8s/alexandria/values.yaml
@@ -119,7 +119,7 @@ grafana:
   image:
     repository: grafana/grafana
     tag: 13.0.2
-  adminPassword: "admin"
+  adminPassword: ""
   persistence:
     size: 1Gi
   resources:

--- a/infra/k8s/alexandria/values.yaml
+++ b/infra/k8s/alexandria/values.yaml
@@ -97,6 +97,39 @@ ingress:
   className: nginx
   host: alexandria.stud.k8s.aet.cit.tum.de
 
+# Self-hosted Prometheus and Grafana mirroring the docker-compose setup
+prometheus:
+  enabled: true
+  image:
+    repository: prom/prometheus
+    tag: v3.12.0
+  retention: 15d
+  persistence:
+    size: 5Gi
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 300m
+      memory: 512Mi
+
+grafana:
+  enabled: true
+  image:
+    repository: grafana/grafana
+    tag: 13.0.2
+  adminPassword: "admin"
+  persistence:
+    size: 1Gi
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+
 keycloak:
   keycloak:
     adminPassword: "admin"

--- a/services/client/Dockerfile
+++ b/services/client/Dockerfile
@@ -11,6 +11,7 @@ RUN npm run build
 FROM nginxinc/nginx-unprivileged:stable-alpine
 COPY --from=build /app/dist /usr/share/nginx/html
 EXPOSE 8080
+
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD wget --quiet --tries=1 --spider http://localhost:8080/ || exit 1
+    CMD wget --quiet --tries=1 --spider http://127.0.0.1:8080/ || exit 1
 CMD ["nginx", "-g", "daemon off;"]

--- a/services/client/Dockerfile
+++ b/services/client/Dockerfile
@@ -7,9 +7,10 @@ RUN npm ci --silent || npm install --no-audit --no-fund --silent
 COPY . .
 RUN npm run build
 
-FROM nginx:stable-alpine
+
+FROM nginxinc/nginx-unprivileged:stable-alpine
 COPY --from=build /app/dist /usr/share/nginx/html
-EXPOSE 80
+EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD wget --quiet --tries=1 --spider http://localhost:80/ || exit 1
+    CMD wget --quiet --tries=1 --spider http://localhost:8080/ || exit 1
 CMD ["nginx", "-g", "daemon off;"]

--- a/services/client/README.md
+++ b/services/client/README.md
@@ -10,7 +10,7 @@ Build and run the production image (uses the multi-stage Dockerfile):
 ```bash
 # from repository root
 docker build -t team-bnd-client ./services/client
-docker run -p 8082:80 team-bnd-client
+docker run -p 8082:8080 team-bnd-client
 ```
 
 Or with docker-compose (builds the image and serves it with nginx):
@@ -54,5 +54,5 @@ npm run test:e2e
 Notes
 -----
 - The dev Dockerfile starts Vite with --host 0.0.0.0 so the dev server is reachable from the host when running in a container.
-- The production image serves the built files with nginx on port 80 inside the container (host port 8082 by default in docker-compose).
+- The production image is based on `nginxinc/nginx-unprivileged` and serves the built files on port 8080 inside the container (Traefik in docker-compose routes to it via the internal network, no host port published by default).
 - When starting the development server, `--build --renew-anon-volumes` has to be specified.


### PR DESCRIPTION
## What does this PR do?

<!-- Short description of the change. Reference any related issue: Closes #123 -->
This PR addresses and closes #172 and closes #143. Thus, we finally complete the monitoring implementation with Prometheus/Grafana (closes #138) and have adressed all issues discovered in the DevSecOps lecture (closes #169).
This PR improves the security of our helm deployment as described in the related issue. Additionally, Prometheus and Grafana are added as pods (analogously to the docker compose setup) and the relevant values have been updated.
## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [X] CI / infra

## Definition of Done

- [x] CI is green
- [ ] If the API changed: `api/openapi.yaml` is updated and lint passes
- [X] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [ ] Tests added or updated for the changed behaviour
- [ ] Docs updated where it matters (README, ADRs, comments)

## Notes for the reviewer

<!-- Anything they should look at first, gotchas, screenshots, ... -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional in-cluster monitoring with Prometheus and Grafana, including built-in dashboards and alerting.
  * Monitoring resources now use a dedicated namespace (configurable), with updated local access instructions.
* **Bug Fixes**
  * Updated client/container serving ports and health checks for improved compatibility across production and compose setup.
* **Security**
  * Hardened Kubernetes pods/containers with non-root execution, stricter seccomp, dropped capabilities, and read-only filesystems (with writable `/tmp` where needed).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->