### PR TITLE
Fix: correctly set helm configuration in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,6 @@ env:
   # ----------- GenAI -----------
   LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
 
-
 jobs:
   # ---------------------------------------------------------------------
   # Detect what changed so downstream jobs can self-skip cleanly.
@@ -784,8 +783,8 @@ jobs:
             --set "postgres-db.auth.password=$POSTGRES_PASSWORD" \
             --set "s3.accessKey=$S3_ACCESS_KEY" \
             --set "s3.secretKey=$S3_SECRET_KEY" \
-            --set "seaweedfs.s3.credentials.admin.accessKey=$S3_ACCESS_KEY"
-            --set "seaweedfs.s3.credentials.admin.secretKey=$S3_SECRET_KEY"
+            --set "seaweedfs.s3.credentials.admin.accessKey=$S3_ACCESS_KEY" \
+            --set "seaweedfs.s3.credentials.admin.secretKey=$S3_SECRET_KEY" \
             --wait \
             --timeout 5m
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read # to clone the repo for scanning
-      actions: read  # to inspect workflow metadata
+      actions: read # to inspect workflow metadata
     steps:
       - uses: actions/checkout@v7
         with:
@@ -247,11 +247,11 @@ jobs:
       - name: Run kics Scan
         uses: checkmarx/kics-action@05aa5eb70eede1355220f4ca5238d96b397e30a6 # v2.1.20
         with:
-          path: 'docker-compose.yml,infra/k8s/alexandria,infra/azure/terraform'
+          path: "docker-compose.yml,infra/k8s/alexandria,infra/azure/terraform"
           config_path: .kics.yml
-          output_formats: 'sarif'
-          output_path: 'kics-results/'
-          ignore_on_exit: 'results'
+          output_formats: "sarif"
+          output_path: "kics-results/"
+          ignore_on_exit: "results"
 
       - name: Upload kics SARIF
         if: always()
@@ -472,9 +472,9 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.service.name }}
           tags: |
+            type=sha,format=short
             type=ref,event=branch
             type=ref,event=pr
-            type=sha,format=short
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
 
       - name: Login to GHCR
@@ -778,10 +778,14 @@ jobs:
             --namespace alexandria \
             --set "image.tag=$IMAGE_TAG" \
             --set "spring.database.password=$POSTGRES_PASSWORD" \
-            --set "keycloak.adminUser=$KC_BOOTSTRAP_ADMIN_USERNAME" \
-            --set "keycloak.adminPassword=$KC_BOOTSTRAP_ADMIN_PASSWORD" \
-            --set "keycloak.database.password=$POSTGRES_PASSWORD" \
+            --set "keycloak.keycloak.adminUser=$KC_BOOTSTRAP_ADMIN_USERNAME" \
+            --set "keycloak.keycloak.adminPassword=$KC_BOOTSTRAP_ADMIN_PASSWORD" \
+            --set "keycloak.keycloak.database.password=$POSTGRES_PASSWORD" \
             --set "postgres-db.auth.password=$POSTGRES_PASSWORD" \
+            --set "s3.accessKey=$S3_ACCESS_KEY" \
+            --set "s3.secretKey=$S3_SECRET_KEY" \
+            --set "seaweedfs.s3.credentials.admin.accessKey=$S3_ACCESS_KEY"
+            --set "seaweedfs.s3.credentials.admin.secretKey=$S3_SECRET_KEY"
             --wait \
             --timeout 5m
 


### PR DESCRIPTION
## What does this PR do?

Fixes issue where secrets from the repository would not be used for the deployment of the helm chart. Additionally, fixes issue where image tag for docker containers would be the name of the branch, instead of the exact tag based on the commit hash.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [x] CI / infra

## Definition of Done

- [ ] CI is green
- [ ] If the API changed: `api/openapi.yaml` is updated and lint passes
- [ ] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [ ] Tests added or updated for the changed behaviour
- [ ] Docs updated where it matters (README, ADRs, comments)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI and deployment configuration for more consistent pipeline behavior.
  * Improved container image tagging order and standardized configuration formatting.
  * Adjusted deployment settings to use updated authentication and storage credential values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->