### PR TITLE
Chore: Change port for E2E tests after client image change

### DIFF
--- a/services/client/playwright.config.ts
+++ b/services/client/playwright.config.ts
@@ -29,8 +29,8 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('')`.
-     * The full stack (local and CI) is served via Traefik on port 80. */
-    baseURL: 'http://client',
+     * The SPA is served on port 8080. */
+    baseURL: 'http://client:8080',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',

--- a/services/client/tests/globalSetup.ts
+++ b/services/client/tests/globalSetup.ts
@@ -52,10 +52,10 @@ export default async function globalSetup() {
   const profile = JSON.parse(Buffer.from(padded, "base64").toString("utf-8"));
 
   // Build the oidc-client-ts User object
-  // The `authority` inside the running browser is http://client/auth/realms/alexandria
-  // because the Playwright browser navigates to http://client and the app sets:
+  // The `authority` inside the running browser is http://client:8080/auth/realms/alexandria
+  // because the Playwright browser navigates to http://client:8080 and the app sets:
   //   authority: `${window.location.origin}/auth/realms/alexandria`
-  const authority = "http://client/auth/realms/alexandria";
+  const authority = "http://client:8080/auth/realms/alexandria";
   const clientId = "alexandria-client";
   const storageKey = `oidc.user:${authority}:${clientId}`;
 


### PR DESCRIPTION
## What does this PR do?

<!-- Short description of the change. Reference any related issue: Closes #123 -->
PR #244 changed to client image to a more secure one. However, that image exposes different ports than the original one, which wasn't updated for the E2E tests wich is why that CI step failed. This PR sets the correct ports.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [X] CI / infra

## Definition of Done

- [x] CI is green
- [ ] If the API changed: `api/openapi.yaml` is updated and lint passes
- [x] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [ ] Tests added or updated for the changed behaviour
- [X] Docs updated where it matters (README, ADRs, comments)

## Notes for the reviewer

<!-- Anything they should look at first, gotchas, screenshots, ... -->
