### PR TITLE
Chore: Set Grafana password from env var in Helm deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -785,6 +785,7 @@ jobs:
             --set "s3.secretKey=$S3_SECRET_KEY" \
             --set "seaweedfs.s3.credentials.admin.accessKey=$S3_ACCESS_KEY" \
             --set "seaweedfs.s3.credentials.admin.secretKey=$S3_SECRET_KEY" \
+            --set "grafana.adminPassword=$GRAFANA_ADMIN_PASSWORD" \
             --wait \
             --timeout 5m
 


### PR DESCRIPTION
## What does this PR do?

<!-- Short description of the change. Reference any related issue: Closes #123 -->
The helm deployment failed because of the Grafana password not being passed to it. This PR fixes it.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [X] CI / infra

## Definition of Done

- [ ] CI is green
- [ ] If the API changed: `api/openapi.yaml` is updated and lint passes
- [ ] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [ ] Tests added or updated for the changed behaviour
- [ ] Docs updated where it matters (README, ADRs, comments)

## Notes for the reviewer

<!-- Anything they should look at first, gotchas, screenshots, ... -->
