### PR TITLE
Chore: Fix wrong keycloak password path, pass POSTGRES_USER env variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -776,10 +776,13 @@ jobs:
           helm upgrade --install alexandria . \
             --namespace alexandria \
             --set "image.tag=$IMAGE_TAG" \
+            --set "spring.database.username=$POSTGRES_USER" \
             --set "spring.database.password=$POSTGRES_PASSWORD" \
             --set "keycloak.keycloak.adminUser=$KC_BOOTSTRAP_ADMIN_USERNAME" \
             --set "keycloak.keycloak.adminPassword=$KC_BOOTSTRAP_ADMIN_PASSWORD" \
-            --set "keycloak.keycloak.database.password=$POSTGRES_PASSWORD" \
+            --set "keycloak.database.username=$POSTGRES_USER" \
+            --set "keycloak.database.password=$POSTGRES_PASSWORD" \
+            --set "postgres-db.auth.username=$POSTGRES_USER" \
             --set "postgres-db.auth.password=$POSTGRES_PASSWORD" \
             --set "s3.accessKey=$S3_ACCESS_KEY" \
             --set "s3.secretKey=$S3_SECRET_KEY" \


### PR DESCRIPTION
## What does this PR do?

<!-- Short description of the change. Reference any related issue: Closes #123 -->
PR #260 fixed the keycloak configuration for the helm deployment, but introduced a new bug that was easily overseen: The correct path for the Postgres password was `keycloak.database.password` and not `keycloak.keycloak.database.password`.

I also fixed a minor issue; the `POSTGRES_USER` env variable wasn't passed to the helm deployment.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [X] CI / infra

## Definition of Done

- [ ] CI is green
- [ ] If the API changed: `api/openapi.yaml` is updated and lint passes
- [ ] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [ ] Tests added or updated for the changed behaviour
- [ ] Docs updated where it matters (README, ADRs, comments)

## Notes for the reviewer

<!-- Anything they should look at first, gotchas, screenshots, ... -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment configuration by ensuring database usernames are supplied alongside their corresponding passwords.
  * Updated application, authentication, and database services to use the configured database credentials consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->