### PR TITLE
CI: Disable Azure VM deployment (student credit expired)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -685,10 +685,15 @@ jobs:
 
   # ---------------------------------------------------------------------
   # Deploy to Azure VM
+  #
+  # Currently disabled: Our Azure for Students credit expired and the VM is gone.
+  # Everything below is kept intact. To re-enable, set the repo variable
+  # DEPLOY_AZURE to 'true' and make sure the AZURE_PUBLIC_IP / AZURE_USER vars
+  # and the AZURE_PRIVATE_KEY secret are set again.
   # ---------------------------------------------------------------------
   deploy:
     name: Deploy to Azure VM
-    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    if: vars.DEPLOY_AZURE == 'true' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     runs-on: ubuntu-latest
     needs: [build-image, ci-summary]
     environment: AZURE

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ All services are accessed through Traefik as the reverse proxy. See [`docs/traef
 
 ### Infrastructure & Deployment
 
-- **Azure VM (Terraform + Ansible)**: Provisioning details live under [`infra/azure/README.md`](infra/azure/README.md).
+- **Azure VM (Terraform + Ansible)**: _Currently disabled_ since our Azure for Students credit expired. The config is kept under [`infra/azure/README.md`](infra/azure/README.md) and can be brought back later again.
 - **Kubernetes (Helm)**: Cluster deployment and troubleshooting details live under [`infra/k8s/README.md`](infra/k8s/README.md).
 
 ### Git Repository


### PR DESCRIPTION
## What does this PR do?

Turns off the Azure VM deployment now that our Azure for Students credit expired and the VM is gone. The `deploy` job in `.github/workflows/ci.yml` was firing on every push to main and would just fail, so I gated it behind a `vars.DEPLOY_AZURE == 'true'` check on top of the existing branch condition. The variable isn't set, so the job just skips. Nothing else about the job changed.

Deploys to main now go only to the stud cluster (`deploy-stud`), which is untouched. I left all the `infra/azure/` Terraform and Ansible config in place on purpose. README's infra section now says Azure is disabled instead of implying it's live.

Re-enabling is a config toggle, no workflow edit: set the repo variable `DEPLOY_AZURE` to `true` and make sure the `AZURE_PUBLIC_IP` / `AZURE_USER` vars and the `AZURE_PRIVATE_KEY` secret are set again.

Closes #269

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [x] CI / infra

## Definition of Done

- [x] CI is green
- [ ] If the API changed: `api/openapi.yaml` is updated and lint passes
- [ ] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [ ] Tests added or updated for the changed behaviour
- [x] Docs updated where it matters (README, ADRs, comments)

## Notes for the reviewer

The Azure job is disabled, not deleted, and it's gated on a repo variable so there's no `if: false` and therefore no actionlint constant-condition warning to suppress. To bring Azure back: set `DEPLOY_AZURE=true` and re-add the AZURE vars/secret.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Azure VM deployment is now disabled by default and only runs when explicitly enabled on the default branch.
  * Added guidance for re-enabling Azure deployment when infrastructure access is available.

* **Documentation**
  * Updated deployment documentation to reflect the current Azure VM availability status.
  * Retained the reference to Azure configuration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->