### PR TITLE
Feat: Limit extracted entities via maxEntities request field

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -7,7 +7,7 @@ info:
   license:
     name: MIT
     identifier: MIT
-  version: 2.2.0
+  version: 2.3.0
 servers:
   - url: /
     description: Current server
@@ -1286,6 +1286,12 @@ components:
       type: object
     GenAiExtractRequest:
       properties:
+        maxEntities:
+          default: 20
+          maximum: 100
+          minimum: 1
+          title: Maxentities
+          type: integer
         objectKey:
           title: Objectkey
           type: string

--- a/services/client/src/api/schema.d.ts
+++ b/services/client/src/api/schema.d.ts
@@ -799,6 +799,11 @@ export interface components {
         };
         /** GenAiExtractRequest */
         GenAiExtractRequest: {
+            /**
+             * Maxentities
+             * @default 20
+             */
+            maxEntities: number;
             /** Objectkey */
             objectKey: string;
         };

--- a/services/genai/README.md
+++ b/services/genai/README.md
@@ -23,7 +23,7 @@ The processing endpoints take object keys, not raw text. The service downloads t
 
 `summarize` returns `{"summary": "...", "modelUsed": "..."}`: a concise 2-4 sentence, third-person summary of the document's main points.
 
-`extract` returns `{"entities": [...], "modelUsed": "..."}` with typed entities (`PERSON`, `DATE`, `TOPIC`, `ORGANIZATION`) and confidence scores.
+`extract` returns `{"entities": [...], "modelUsed": "..."}` with typed entities (`PERSON`, `DATE`, `TOPIC`, `ORGANIZATION`) and confidence scores. To keep a long document from producing an unscannable list, the result is capped: callers may pass `{"objectKey": "...", "maxEntities": N}` (1-100, default 20) and the highest-confidence entities up to that limit are returned.
 
 `tag` returns `{"tags": [...], "modelUsed": "..."}`: a small set of broad, lowercase topical tags describing what the document is about, so the knowledge base can categorise and filter documents. Tags are restricted to lowercase ascii letters, digits, spaces, and hyphens (e.g. `machine learning`, `covid-19`); anything else the model returns is dropped. The result is capped at 5 tags and de-duplicated regardless of what the model returns, and the prompt steers it toward common, reusable terms rather than document-specific phrasing so the same topic lands on the same tag across documents. A document with no clear topic yields an empty list. Callers may pass `{"objectKey": "...", "knownTags": [...]}` to bias the model toward reusing existing labels, which keeps the vocabulary from fragmenting into one-off tags; those are validated against the same allowlist before they reach the prompt.
 

--- a/services/genai/app/extract.py
+++ b/services/genai/app/extract.py
@@ -7,6 +7,11 @@ from pydantic import BaseModel, Field
 
 from app.llm import get_llm, get_model_name
 
+# Cap applied when the caller doesn't ask for a specific number. Long documents
+# otherwise yield a sprawling list that's noisy to render and scan in the
+# document view. Callers pass their own limit on the /genai/extract request.
+DEFAULT_MAX_ENTITIES = 20
+
 
 class _Entity(BaseModel):
     name: str = Field(description="The exact name or value of the entity as it appears in the text")
@@ -25,19 +30,34 @@ _PROMPT = ChatPromptTemplate.from_messages(
     [
         (
             "system",
-            "You are a named-entity recognition system. Extract all significant entities from the provided text. "
+            "You are a named-entity recognition system. Extract the most significant entities from the provided text. "
             "Identify PERSON (named individuals), DATE (dates, years, time expressions), "
             "TOPIC (key subjects, themes, concepts), and ORGANIZATION (companies, institutions, groups). "
             "Assign a confidence score based on how clearly the entity is identified in the text. "
-            "Avoid duplicates. Return only entities that are genuinely present in the text.",
+            "Avoid duplicates. Return only entities that are genuinely present in the text. "
+            "Return at most {max_entities} entities; when the text has more, keep the ones you are most confident about.",
         ),
         ("human", "{content}"),
     ]
 )
 
 
-def extract_entities(content: str) -> tuple[list[dict], str]:
+def _select_top_entities(entities: list[_Entity], limit: int) -> list[_Entity]:
+    """Keep the highest-confidence entities, up to the limit.
+
+    The prompt already asks for a bounded list, but we enforce the cap here so a
+    model that ignores the instruction can't flood the document view. The sort is
+    stable, so entities sharing a confidence keep the model's original order.
+    """
+    ranked = sorted(entities, key=lambda e: e.confidence, reverse=True)
+    return ranked[:limit]
+
+
+def extract_entities(content: str, max_entities: int = DEFAULT_MAX_ENTITIES) -> tuple[list[dict], str]:
     """Extract named entities from document content.
+
+    Returns at most ``max_entities`` entities, keeping the ones the model is most
+    confident about.
 
     Returns:
         (entities, model_name) where entities is a list of dicts with name, type, confidence.
@@ -45,6 +65,6 @@ def extract_entities(content: str) -> tuple[list[dict], str]:
     llm = get_llm()
     structured_llm = llm.with_structured_output(_ExtractionResult)
     chain = _PROMPT | structured_llm
-    result: _ExtractionResult = chain.invoke({"content": content})  # ty:ignore[invalid-assignment]
-    entities = [e.model_dump() for e in result.entities]
+    result: _ExtractionResult = chain.invoke({"content": content, "max_entities": max_entities})  # ty:ignore[invalid-assignment]
+    entities = [e.model_dump() for e in _select_top_entities(result.entities, max_entities)]
     return entities, get_model_name()

--- a/services/genai/app/main.py
+++ b/services/genai/app/main.py
@@ -6,7 +6,7 @@ from prometheus_fastapi_instrumentator import Instrumentator
 from pydantic import BaseModel, Field, field_validator
 
 from app.embeddings import chunk_text, embed_chunks, get_embedding_model_name
-from app.extract import extract_entities
+from app.extract import DEFAULT_MAX_ENTITIES, extract_entities
 from app.qa import answer_question
 from app.search import search_documents
 from app.storage import ObjectNotFoundError, UnsupportedFileError, fetch_text
@@ -15,7 +15,7 @@ from app.tag import generate_tags
 from app.vectorstore import close_client, delete_document, index_chunks
 
 SERVICE_NAME = "alexandria-genai"
-SERVICE_VERSION = "2.2.0"
+SERVICE_VERSION = "2.3.0"
 
 
 @asynccontextmanager
@@ -71,6 +71,7 @@ class GenAiExtractedEntity(BaseModel):
 
 class GenAiExtractRequest(BaseModel):
     objectKey: str
+    maxEntities: int = Field(default=DEFAULT_MAX_ENTITIES, ge=1, le=100)
 
 
 class GenAiExtractResponse(BaseModel):
@@ -197,7 +198,7 @@ def summarize_document(request: GenAiSummarizeRequest) -> GenAiSummarizeResponse
 def extract(request: GenAiExtractRequest) -> GenAiExtractResponse:
     """Extract named entities from the document stored under the given object key."""
     content = _load_document(request.objectKey)
-    entities, model = extract_entities(content)
+    entities, model = extract_entities(content, request.maxEntities)
     return GenAiExtractResponse(
         entities=[GenAiExtractedEntity(**e) for e in entities],
         modelUsed=model,

--- a/services/genai/tests/test_extract.py
+++ b/services/genai/tests/test_extract.py
@@ -18,6 +18,23 @@ def _fake_extraction_result():
     )
 
 
+def _extract_with(result, max_entities=None):
+    """Run extract_entities against a fake structured LLM returning ``result``."""
+    fake_structured_llm = RunnableLambda(lambda _: result)
+    mock_llm = MagicMock()
+    mock_llm.with_structured_output.return_value = fake_structured_llm
+
+    with (
+        patch("app.extract.get_llm", return_value=mock_llm),
+        patch("app.extract.get_model_name", return_value="test-model"),
+    ):
+        from app.extract import extract_entities
+
+        if max_entities is None:
+            return extract_entities("some document text")
+        return extract_entities("some document text", max_entities)
+
+
 def test_extract_returns_entities_and_model_name():
     fake_result = _fake_extraction_result()
     fake_structured_llm = RunnableLambda(lambda _: fake_result)
@@ -71,3 +88,48 @@ def test_extract_returns_empty_list_for_no_entities():
         entities, _ = extract_entities("The quick brown fox.")
 
     assert entities == []
+
+
+def _many_entities(count):
+    """Build ``count`` distinct entities with descending confidence (1.0, 0.99, ...)."""
+    from app.extract import _Entity, _ExtractionResult
+
+    entities = [_Entity(name=f"entity-{i}", type="TOPIC", confidence=round(1.0 - i / 1000, 3)) for i in range(count)]
+    return _ExtractionResult(entities=entities)
+
+
+def test_extract_caps_at_default_limit():
+    from app.extract import DEFAULT_MAX_ENTITIES
+
+    entities, _ = _extract_with(_many_entities(DEFAULT_MAX_ENTITIES + 15))
+
+    assert len(entities) == DEFAULT_MAX_ENTITIES
+
+
+def test_extract_respects_requested_limit():
+    entities, _ = _extract_with(_many_entities(10), max_entities=3)
+
+    assert len(entities) == 3
+    assert [e["name"] for e in entities] == ["entity-0", "entity-1", "entity-2"]
+
+
+def test_extract_keeps_highest_confidence_entities():
+    from app.extract import _Entity, _ExtractionResult
+
+    result = _ExtractionResult(
+        entities=[
+            _Entity(name="low", type="TOPIC", confidence=0.20),
+            _Entity(name="high", type="PERSON", confidence=0.95),
+            _Entity(name="mid", type="DATE", confidence=0.60),
+        ]
+    )
+
+    entities, _ = _extract_with(result, max_entities=2)
+
+    assert [e["name"] for e in entities] == ["high", "mid"]
+
+
+def test_extract_under_limit_returns_all():
+    entities, _ = _extract_with(_many_entities(4), max_entities=20)
+
+    assert len(entities) == 4

--- a/services/genai/tests/test_main.py
+++ b/services/genai/tests/test_main.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from fastapi.testclient import TestClient
 
+from app.extract import DEFAULT_MAX_ENTITIES
 from app.main import SERVICE_NAME, SERVICE_VERSION, app
 from app.storage import ObjectNotFoundError, UnsupportedFileError
 
@@ -162,6 +163,34 @@ def test_extract_returns_404_for_missing_object():
 def test_extract_rejects_missing_object_key():
     response = client.post("/genai/extract", json={})
     assert response.status_code == 422
+
+
+def test_extract_forwards_max_entities_to_extractor():
+    with (
+        patch("app.main.fetch_text", return_value="some text"),
+        patch("app.main.extract_entities", return_value=([], "test-model")) as mock_extract,
+    ):
+        response = client.post("/genai/extract", json={"objectKey": "k", "maxEntities": 5})
+
+    assert response.status_code == 200
+    assert mock_extract.call_args.args[1] == 5
+
+
+def test_extract_defaults_max_entities_when_omitted():
+    with (
+        patch("app.main.fetch_text", return_value="some text"),
+        patch("app.main.extract_entities", return_value=([], "test-model")) as mock_extract,
+    ):
+        response = client.post("/genai/extract", json={"objectKey": "k"})
+
+    assert response.status_code == 200
+    assert mock_extract.call_args.args[1] == DEFAULT_MAX_ENTITIES
+
+
+def test_extract_rejects_out_of_range_max_entities():
+    for bad in (0, 101):
+        response = client.post("/genai/extract", json={"objectKey": "k", "maxEntities": bad})
+        assert response.status_code == 422
 
 
 # --- tag ---

--- a/services/spring/knowledgebase-service/src/main/java/com/alexandria/knowledgebase/config/OpenApiConfig.java
+++ b/services/spring/knowledgebase-service/src/main/java/com/alexandria/knowledgebase/config/OpenApiConfig.java
@@ -19,7 +19,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @OpenAPIDefinition(
         info = @Info(
-                title = "Alexandria KnowledgeBase Service API", version = "2.2.0", description = "Document management, tagging, and text search. Owns the documents/tags/search-queries tables and calls the GenAI service for summarization and entity extraction.", license = @License(name = "MIT", identifier = "MIT")
+                title = "Alexandria KnowledgeBase Service API", version = "2.3.0", description = "Document management, tagging, and text search. Owns the documents/tags/search-queries tables and calls the GenAI service for summarization and entity extraction.", license = @License(name = "MIT", identifier = "MIT")
         ), servers = @Server(url = "/", description = "Current server")
 )
 @SecurityScheme(

--- a/services/spring/qa-service/src/main/java/com/alexandria/qa/config/OpenApiConfig.java
+++ b/services/spring/qa-service/src/main/java/com/alexandria/qa/config/OpenApiConfig.java
@@ -19,7 +19,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @OpenAPIDefinition(
         info = @Info(
-                title = "Alexandria QA Service API", version = "2.2.0", description = "Question answering over a user's documents. Fetches document keys from knowledgebase-service and delegates answer generation to the GenAI service.", license = @License(name = "MIT", identifier = "MIT")
+                title = "Alexandria QA Service API", version = "2.3.0", description = "Question answering over a user's documents. Fetches document keys from knowledgebase-service and delegates answer generation to the GenAI service.", license = @License(name = "MIT", identifier = "MIT")
         ), servers = @Server(url = "/", description = "Current server")
 )
 @SecurityScheme(

--- a/services/spring/user-service/src/main/java/com/alexandria/user/config/OpenApiConfig.java
+++ b/services/spring/user-service/src/main/java/com/alexandria/user/config/OpenApiConfig.java
@@ -19,7 +19,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @OpenAPIDefinition(
         info = @Info(
-                title = "Alexandria User Service API", version = "2.2.0", description = "User account management. Owns the users table; exposes internal fan-out endpoints consumed by knowledgebase-service and qa-service.", license = @License(name = "MIT", identifier = "MIT")
+                title = "Alexandria User Service API", version = "2.3.0", description = "User account management. Owns the users table; exposes internal fan-out endpoints consumed by knowledgebase-service and qa-service.", license = @License(name = "MIT", identifier = "MIT")
         ), servers = @Server(url = "/", description = "Current server")
 )
 @SecurityScheme(


### PR DESCRIPTION
## What does this PR do?

Caps the number of entities `/genai/extract` returns so long documents stop producing an unscannable list in the document view. The cap is a request field, `maxEntities` (1-100, default 20); the service keeps the highest-confidence entities up to that limit. Closes #262.

Design notes:

- The limit lives on the request, not an env var, so a caller can ask for a different number per document without redeploying.
- Enforcement is deterministic: even if the model ignores the "at most N" prompt hint, `_select_top_entities` sorts by confidence and trims, so the bound always holds (same defensive pattern as the tag cap).
- Additive, backwards-compatible field (has a default), so this is a minor version bump. Since the project versions all services together, GenAI and the three Spring services all go 2.2.0 -> 2.3.0, which carries through to the merged `api/openapi.yaml`.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] CI / infra

## Definition of Done

- [ ] CI is green
- [x] If the API changed: `api/openapi.yaml` is updated and lint passes
- [ ] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [x] Tests added or updated for the changed behaviour
- [x] Docs updated where it matters (README, ADRs, comments)

## Notes for the reviewer


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional `maxEntities` setting to entity extraction requests.
  * Extraction now returns up to 20 entities by default, configurable from 1 to 100.
  * Results prioritize entities with the highest confidence scores.

* **Documentation**
  * Updated extraction guidance and API schemas to describe the new limit.

* **Chores**
  * Updated API service version metadata to 2.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->