### PR TITLE
Monitoring: scrape Weaviate and expose per-service version metric

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -373,6 +373,7 @@ services:
       ENABLE_MODULES: ""
       DISABLE_TELEMETRY: "true"
       CLUSTER_HOSTNAME: "node1"
+      PROMETHEUS_MONITORING_ENABLED: "true"
     restart: unless-stopped
     networks:
       - alexandria

--- a/infra/grafana/dashboards/overview.json
+++ b/infra/grafana/dashboards/overview.json
@@ -224,6 +224,35 @@
 			],
 			"title": "Traefik web entrypoint requests by status code",
 			"type": "timeseries"
+		},
+		{
+			"datasource": { "type": "prometheus", "uid": "prometheus" },
+			"fieldConfig": { "defaults": { "custom": { "align": "auto", "filterable": false } }, "overrides": [] },
+			"gridPos": { "h": 6, "w": 24, "x": 0, "y": 29 },
+			"id": 7,
+			"options": { "cellHeight": "sm", "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false }, "showHeader": true },
+			"pluginVersion": "11.6.7",
+			"targets": [
+				{
+					"datasource": { "type": "prometheus", "uid": "prometheus" },
+					"expr": "application_version",
+					"format": "table",
+					"instant": true,
+					"refId": "A"
+				}
+			],
+			"title": "Running service versions",
+			"transformations": [
+				{
+					"id": "organize",
+					"options": {
+						"excludeByName": { "Time": true, "Value": true, "__name__": true, "instance": true, "service": true, "application": true },
+						"indexByName": { "job": 0, "version": 1 },
+						"renameByName": { "job": "Service", "version": "Version" }
+					}
+				}
+			],
+			"type": "table"
 		}
 	],
 	"preload": false,

--- a/infra/grafana/dashboards/weaviate.json
+++ b/infra/grafana/dashboards/weaviate.json
@@ -1,0 +1,292 @@
+{
+	"annotations": {
+		"list": [
+			{
+				"builtIn": 1,
+				"datasource": { "type": "grafana", "uid": "-- Grafana --" },
+				"enable": true,
+				"hide": true,
+				"iconColor": "rgba(0, 211, 255, 1)",
+				"name": "Annotations & Alerts",
+				"type": "dashboard"
+			}
+		]
+	},
+	"editable": true,
+	"fiscalYearStartMonth": 0,
+	"graphTooltip": 1,
+	"links": [],
+	"panels": [
+		{
+			"datasource": { "type": "prometheus", "uid": "prometheus" },
+			"fieldConfig": {
+				"defaults": {
+					"mappings": [
+						{ "options": { "0": { "color": "red", "text": "DOWN" } }, "type": "value" },
+						{ "options": { "1": { "color": "green", "text": "UP" } }, "type": "value" }
+					],
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{ "color": "red", "value": null },
+							{ "color": "green", "value": 1 }
+						]
+					}
+				},
+				"overrides": []
+			},
+			"gridPos": { "h": 5, "w": 8, "x": 0, "y": 0 },
+			"id": 1,
+			"options": {
+				"colorMode": "background",
+				"graphMode": "none",
+				"justifyMode": "auto",
+				"orientation": "horizontal",
+				"reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+				"textMode": "value_and_name"
+			},
+			"pluginVersion": "11.6.7",
+			"targets": [
+				{
+					"datasource": { "type": "prometheus", "uid": "prometheus" },
+					"expr": "up{job=\"weaviate\"}",
+					"legendFormat": "weaviate",
+					"refId": "A"
+				}
+			],
+			"title": "Weaviate health",
+			"type": "stat"
+		},
+		{
+			"datasource": { "type": "prometheus", "uid": "prometheus" },
+			"fieldConfig": {
+				"defaults": { "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] }, "unit": "short" },
+				"overrides": []
+			},
+			"gridPos": { "h": 5, "w": 8, "x": 8, "y": 0 },
+			"id": 2,
+			"options": {
+				"colorMode": "value",
+				"graphMode": "area",
+				"justifyMode": "auto",
+				"orientation": "horizontal",
+				"reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+				"textMode": "value"
+			},
+			"pluginVersion": "11.6.7",
+			"targets": [
+				{
+					"datasource": { "type": "prometheus", "uid": "prometheus" },
+					"expr": "sum(weaviate_schema_collections{job=\"weaviate\"})",
+					"legendFormat": "collections",
+					"refId": "A"
+				}
+			],
+			"title": "Schema collections",
+			"type": "stat"
+		},
+		{
+			"datasource": { "type": "prometheus", "uid": "prometheus" },
+			"fieldConfig": { "defaults": { "custom": { "align": "auto", "filterable": false } }, "overrides": [] },
+			"gridPos": { "h": 5, "w": 8, "x": 16, "y": 0 },
+			"id": 3,
+			"options": { "cellHeight": "sm", "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false }, "showHeader": true },
+			"pluginVersion": "11.6.7",
+			"targets": [
+				{
+					"datasource": { "type": "prometheus", "uid": "prometheus" },
+					"expr": "weaviate_build_info{job=\"weaviate\"}",
+					"format": "table",
+					"instant": true,
+					"refId": "A"
+				}
+			],
+			"title": "Weaviate build",
+			"transformations": [
+				{
+					"id": "organize",
+					"options": {
+						"excludeByName": { "Time": true, "Value": true, "__name__": true, "instance": true, "job": true, "branch": true, "goarch": true, "goos": true, "revision": true, "tags": true },
+						"indexByName": { "version": 0, "goversion": 1 },
+						"renameByName": { "version": "Version", "goversion": "Go" }
+					}
+				}
+			],
+			"type": "table"
+		},
+		{
+			"datasource": { "type": "prometheus", "uid": "prometheus" },
+			"fieldConfig": {
+				"defaults": {
+					"color": { "mode": "palette-classic" },
+					"custom": { "axisLabel": "req/s", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "showPoints": "never" },
+					"unit": "reqps"
+				},
+				"overrides": []
+			},
+			"gridPos": { "h": 8, "w": 12, "x": 0, "y": 5 },
+			"id": 4,
+			"options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+			"targets": [
+				{
+					"datasource": { "type": "prometheus", "uid": "prometheus" },
+					"expr": "sum by (status_code) (rate(weaviate_http_request_duration_seconds_count{job=\"weaviate\"}[5m]))",
+					"legendFormat": "{{status_code}}",
+					"refId": "A"
+				}
+			],
+			"title": "HTTP request rate by status",
+			"type": "timeseries"
+		},
+		{
+			"datasource": { "type": "prometheus", "uid": "prometheus" },
+			"fieldConfig": {
+				"defaults": {
+					"color": { "mode": "palette-classic" },
+					"custom": { "axisLabel": "seconds", "drawStyle": "line", "fillOpacity": 0, "lineWidth": 1, "showPoints": "never" },
+					"unit": "s"
+				},
+				"overrides": []
+			},
+			"gridPos": { "h": 8, "w": 12, "x": 12, "y": 5 },
+			"id": 5,
+			"options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+			"targets": [
+				{
+					"datasource": { "type": "prometheus", "uid": "prometheus" },
+					"expr": "histogram_quantile(0.50, sum by (le) (rate(weaviate_http_request_duration_seconds_bucket{job=\"weaviate\"}[5m])))",
+					"legendFormat": "p50",
+					"refId": "A"
+				},
+				{
+					"datasource": { "type": "prometheus", "uid": "prometheus" },
+					"expr": "histogram_quantile(0.95, sum by (le) (rate(weaviate_http_request_duration_seconds_bucket{job=\"weaviate\"}[5m])))",
+					"legendFormat": "p95",
+					"refId": "B"
+				}
+			],
+			"title": "HTTP request latency",
+			"type": "timeseries"
+		},
+		{
+			"datasource": { "type": "prometheus", "uid": "prometheus" },
+			"fieldConfig": {
+				"defaults": {
+					"color": { "mode": "palette-classic" },
+					"custom": { "axisLabel": "req/s", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "showPoints": "never" },
+					"unit": "reqps"
+				},
+				"overrides": []
+			},
+			"gridPos": { "h": 8, "w": 12, "x": 0, "y": 13 },
+			"id": 6,
+			"options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+			"targets": [
+				{
+					"datasource": { "type": "prometheus", "uid": "prometheus" },
+					"expr": "sum by (method) (rate(weaviate_grpc_server_request_duration_seconds_count{job=\"weaviate\"}[5m]))",
+					"legendFormat": "{{method}}",
+					"refId": "A"
+				}
+			],
+			"title": "gRPC request rate by method",
+			"type": "timeseries"
+		},
+		{
+			"datasource": { "type": "prometheus", "uid": "prometheus" },
+			"fieldConfig": {
+				"defaults": {
+					"color": { "mode": "palette-classic" },
+					"custom": { "axisLabel": "bytes", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "showPoints": "never" },
+					"unit": "bytes"
+				},
+				"overrides": []
+			},
+			"gridPos": { "h": 8, "w": 12, "x": 12, "y": 13 },
+			"id": 7,
+			"options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+			"targets": [
+				{
+					"datasource": { "type": "prometheus", "uid": "prometheus" },
+					"expr": "process_resident_memory_bytes{job=\"weaviate\"}",
+					"legendFormat": "resident",
+					"refId": "A"
+				},
+				{
+					"datasource": { "type": "prometheus", "uid": "prometheus" },
+					"expr": "go_memstats_heap_inuse_bytes{job=\"weaviate\"}",
+					"legendFormat": "heap in use",
+					"refId": "B"
+				}
+			],
+			"title": "Process memory",
+			"type": "timeseries"
+		},
+		{
+			"datasource": { "type": "prometheus", "uid": "prometheus" },
+			"fieldConfig": {
+				"defaults": {
+					"color": { "mode": "palette-classic" },
+					"custom": { "axisLabel": "count", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "showPoints": "never" },
+					"unit": "short"
+				},
+				"overrides": []
+			},
+			"gridPos": { "h": 8, "w": 12, "x": 0, "y": 21 },
+			"id": 8,
+			"options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+			"targets": [
+				{
+					"datasource": { "type": "prometheus", "uid": "prometheus" },
+					"expr": "go_goroutines{job=\"weaviate\"}",
+					"legendFormat": "goroutines",
+					"refId": "A"
+				}
+			],
+			"title": "Goroutines",
+			"type": "timeseries"
+		},
+		{
+			"datasource": { "type": "prometheus", "uid": "prometheus" },
+			"fieldConfig": {
+				"defaults": {
+					"color": { "mode": "palette-classic" },
+					"custom": { "axisLabel": "requests", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "showPoints": "never" },
+					"unit": "short"
+				},
+				"overrides": []
+			},
+			"gridPos": { "h": 8, "w": 12, "x": 12, "y": 21 },
+			"id": 9,
+			"options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+			"targets": [
+				{
+					"datasource": { "type": "prometheus", "uid": "prometheus" },
+					"expr": "sum(weaviate_http_requests_inflight{job=\"weaviate\"})",
+					"legendFormat": "http",
+					"refId": "A"
+				},
+				{
+					"datasource": { "type": "prometheus", "uid": "prometheus" },
+					"expr": "sum(weaviate_grpc_server_requests_inflight{job=\"weaviate\"})",
+					"legendFormat": "grpc",
+					"refId": "B"
+				}
+			],
+			"title": "In-flight requests",
+			"type": "timeseries"
+		}
+	],
+	"preload": false,
+	"refresh": "30s",
+	"schemaVersion": 39,
+	"tags": ["alexandria", "weaviate", "genai"],
+	"templating": { "list": [] },
+	"time": { "from": "now-30m", "to": "now" },
+	"timepicker": {},
+	"timezone": "browser",
+	"title": "Alexandria Weaviate",
+	"uid": "alexandria-weaviate",
+	"version": 1,
+	"weekStart": ""
+}

--- a/infra/k8s/alexandria/Chart.yaml
+++ b/infra/k8s/alexandria/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 
 version: 2.0.0
 
-appVersion: "1.16.0"
+appVersion: "5.0.0"
 dependencies:
   - name: keycloak
     version: 0.21.9

--- a/infra/k8s/alexandria/templates/prometheus-config.yaml
+++ b/infra/k8s/alexandria/templates/prometheus-config.yaml
@@ -52,6 +52,10 @@ data:
         static_configs:
           - targets: ["{{ .Release.Name }}-seaweedfs-volume.{{ .Release.Namespace }}:9327"]
 
+      - job_name: weaviate
+        static_configs:
+          - targets: ["{{ include "alexandria.fullname" . }}-weaviate.{{ .Release.Namespace }}:2112"]
+
   alert.rules.yml: |
     groups:
       - name: alexandria

--- a/infra/k8s/alexandria/templates/weaviate-deployment.yaml
+++ b/infra/k8s/alexandria/templates/weaviate-deployment.yaml
@@ -48,6 +48,9 @@ spec:
             - name: grpc
               containerPort: 50051
               protocol: TCP
+            - name: metrics
+              containerPort: 2112
+              protocol: TCP
           env:
             # ENABLE_MODULES is empty because embeddings come from the genai
             # service, not a Weaviate-side vectorizer. Anonymous
@@ -65,6 +68,8 @@ spec:
               value: "true"
             - name: CLUSTER_HOSTNAME
               value: {{ include "alexandria.fullname" . }}-weaviate
+            - name: PROMETHEUS_MONITORING_ENABLED
+              value: "true"
           volumeMounts:
             - name: data
               mountPath: /var/lib/weaviate

--- a/infra/k8s/alexandria/templates/weaviate-service.yaml
+++ b/infra/k8s/alexandria/templates/weaviate-service.yaml
@@ -20,3 +20,7 @@ spec:
       port: 50051
       targetPort: grpc
       protocol: TCP
+    - name: metrics
+      port: 2112
+      targetPort: metrics
+      protocol: TCP

--- a/infra/prometheus/prometheus.yml
+++ b/infra/prometheus/prometheus.yml
@@ -44,3 +44,8 @@ scrape_configs:
   - job_name: s3-storage
     static_configs:
       - targets: ["s3-storage:9091"]
+
+  # Weaviate for the RAG pipeline
+  - job_name: weaviate
+    static_configs:
+      - targets: ["weaviate:2112"]

--- a/services/genai/app/main.py
+++ b/services/genai/app/main.py
@@ -2,6 +2,7 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import PlainTextResponse
+from prometheus_client import Gauge
 from prometheus_fastapi_instrumentator import Instrumentator
 from pydantic import BaseModel, Field, field_validator
 
@@ -49,6 +50,13 @@ Instrumentator(should_group_untemplated=True).instrument(app).expose(
     include_in_schema=False,
     tags=["metrics"],
 )
+
+# Constant info gauge so Grafana can show which version is running, matching the
+# Spring services' application_version metric (value is always 1, version in a
+# label). The name avoids an _info suffix on purpose: Micrometer strips it on the
+# Spring side, so the two exporters would otherwise disagree on the series name.
+_application_version = Gauge("application_version", "Running application build info", ["application", "version"])
+_application_version.labels(application=SERVICE_NAME, version=SERVICE_VERSION).set(1)
 
 
 # --- request / response models ---

--- a/services/genai/pyproject.toml
+++ b/services/genai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "alexandria-genai"
-version = "2.2.0"
+version = "5.0.0"
 description = "GenAI microservice for Alexandria"
 requires-python = "~=3.14.0"
 dependencies = [

--- a/services/genai/tests/test_main.py
+++ b/services/genai/tests/test_main.py
@@ -65,6 +65,11 @@ def test_metrics_endpoint_records_http_requests():
     assert 'handler="/genai/health"' in body
 
 
+def test_metrics_endpoint_exposes_version_info():
+    body = client.get("/genai/metrics").text
+    assert f'application_version{{application="{SERVICE_NAME}",version="{SERVICE_VERSION}"}} 1.0' in body
+
+
 # --- summarize ---
 
 

--- a/services/genai/uv.lock
+++ b/services/genai/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.14.*"
 
 [[package]]
 name = "alexandria-genai"
-version = "2.2.0"
+version = "5.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/services/spring/build.gradle
+++ b/services/spring/build.gradle
@@ -22,7 +22,7 @@ subprojects {
 	apply plugin: 'com.github.spotbugs'
 
 	group = 'com.alexandria'
-	version = '2.0.0'
+	version = '5.0.0'
 
 	spotbugs {
 		toolVersion = '4.10.3'
@@ -93,6 +93,13 @@ subprojects {
 
 	tasks.named('test') {
 		useJUnitPlatform()
+	}
+}
+
+// For the version tag.
+configure(subprojects.findAll { it.name.endsWith('-service') }) {
+	springBoot {
+		buildInfo()
 	}
 }
 

--- a/services/spring/common/src/main/java/com/alexandria/common/metrics/ApplicationInfoMetricsAutoConfiguration.java
+++ b/services/spring/common/src/main/java/com/alexandria/common/metrics/ApplicationInfoMetricsAutoConfiguration.java
@@ -1,0 +1,21 @@
+package com.alexandria.common.metrics;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.info.BuildProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.env.Environment;
+
+@AutoConfiguration
+public class ApplicationInfoMetricsAutoConfiguration {
+
+    @Bean
+    public MeterBinder applicationInfoMetric(Environment environment, ObjectProvider<BuildProperties> buildProperties) {
+        String application = environment.getProperty("spring.application.name", "unknown");
+        BuildProperties build = buildProperties.getIfAvailable();
+        String version = build != null ? build.getVersion() : "unknown";
+        return registry -> Gauge.builder("application_version", () -> 1).description("Running application build info; the value is always 1, the version is carried as a label").tag("application", application).tag("version", version).register(registry);
+    }
+}

--- a/services/spring/common/src/main/java/com/alexandria/common/metrics/ApplicationInfoMetricsAutoConfiguration.java
+++ b/services/spring/common/src/main/java/com/alexandria/common/metrics/ApplicationInfoMetricsAutoConfiguration.java
@@ -15,7 +15,7 @@ public class ApplicationInfoMetricsAutoConfiguration {
     public MeterBinder applicationInfoMetric(Environment environment, ObjectProvider<BuildProperties> buildProperties) {
         String application = environment.getProperty("spring.application.name", "unknown");
         BuildProperties build = buildProperties.getIfAvailable();
-        String version = build != null ? build.getVersion() : "unknown";
+        String version = build != null && build.getVersion() != null ? build.getVersion() : "unknown";
         return registry -> Gauge.builder("application_version", () -> 1).description("Running application build info; the value is always 1, the version is carried as a label").tag("application", application).tag("version", version).register(registry);
     }
 }

--- a/services/spring/common/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/services/spring/common/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.alexandria.common.metrics.ApplicationInfoMetricsAutoConfiguration


### PR DESCRIPTION
## What does this PR do?

Two monitoring gaps in one branch.

Closes #285: Weaviate wasn't scraped by Prometheus, so a vector-store outage was invisible and `ServiceDown` couldn't fire for it. Turned on Weaviate's Prometheus endpoint (`PROMETHEUS_MONITORING_ENABLED`, metrics on `:2112`) and added a `weaviate` scrape job to both the compose and k8s Prometheus configs. In k8s that meant exposing port 2112 on the deployment and service too. `ServiceDown` already alerts on `up == 0` for every job, so it now covers Weaviate with no rule change. Added an "Alexandria Weaviate" Grafana dashboard (health, object count, request rate by status, object op latency, memory, goroutines).

Closes #286: no service exposed its running version to Prometheus, so you couldn't tell from a dashboard which release was live. Added an `application_version` gauge (value 1, version carried as a label) to every service: Spring via a shared auto-config in the `common` module that reads Spring Boot's build-info, GenAI via a labelled `prometheus_client` gauge. The overview dashboard now has a "Running service versions" table. Note on the name: it deliberately isn't `application_info`; Micrometer strips a reserved `_info` suffix on the Spring side, so the two exporters would otherwise land on different series names.

While wiring up the version metric I noticed the version numbers had drifted, so (as agreed) I lined them up to 5.0.0, which is what every OpenAPI spec and the GenAI runtime already report:

- Spring Gradle `version` 2.0.0 -> 5.0.0
- GenAI `pyproject.toml` 2.2.0 -> 5.0.0
- Helm `Chart.yaml` `appVersion` 1.16.0 -> 5.0.0 (chart `version` left as-is, it's the chart's own semver)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [x] CI / infra

## Definition of Done

- [x] CI is green
- [ ] If the API changed: `api/openapi.yaml` is updated and lint passes (no API change)
- [x] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [x] Tests added or updated for the changed behaviour
- [x] Docs updated where it matters (README, ADRs, comments)

## Notes for the reviewer

- The Spring metric is wired through a real Spring Boot auto-config (`common/src/main/resources/META-INF/spring/...AutoConfiguration.imports`), so all three services pick it up without touching each one. Enabled `springBoot { buildInfo() }` only for the `*-service` modules; `common` stays a plain jar.
- Both services expose the same metric name/labels (`application_version{application, version}`), so the overview table is a single query across Spring + GenAI. Verified against the running stack: all four targets (user/knowledgebase/qa/genai) report 5.0.0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Prometheus monitoring for Weaviate, including health, traffic, latency, memory, and request metrics.
  * Added Grafana dashboards for Weaviate operations and running service versions.
  * Added application version metrics for service build visibility.
  * Enabled monitoring across Docker Compose and Kubernetes deployments.

* **Improvements**
  * Updated application and chart versions to 5.0.0.
  * Added automatic collection of service build information for supported Spring services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->