### PR TITLE
Perf: Speed up docker compose startup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -280,6 +280,8 @@ services:
       - alexandria
     volumes:
       - ./infra/oidc/realm.json:/opt/keycloak/data/import/realm.json:ro
+      # Persisted realm survives restarts, so edits to realm.json are not
+      # re-imported until this volume is removed (docker compose down -v).
       - keycloak_data:/opt/keycloak/data
     deploy:
       resources:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -267,7 +267,10 @@ services:
       KC_BOOTSTRAP_ADMIN_USERNAME: ${KC_BOOTSTRAP_ADMIN_USERNAME:-admin}
       KC_BOOTSTRAP_ADMIN_PASSWORD: ${KC_BOOTSTRAP_ADMIN_PASSWORD:-localkcpassword}
       KC_HEALTH_ENABLED: "true"
-      KC_DB: dev-file
+      KC_DB: postgres
+      KC_DB_URL: jdbc:postgresql://postgres-db:${POSTGRES_PORT:-5432}/keycloak
+      KC_DB_USERNAME: ${POSTGRES_USER:-admin}
+      KC_DB_PASSWORD: ${POSTGRES_PASSWORD:-localpgpassword}
       KC_HTTP_PORT: 8180
       KC_HOSTNAME: http://localhost/auth
       KC_PROXY_HEADERS: xforwarded
@@ -279,10 +282,12 @@ services:
     networks:
       - alexandria
     volumes:
+      # The realm persists in the keycloak postgres db, so edits to realm.json are
+      # not re-imported until the postgres data is wiped (docker compose down -v).
       - ./infra/oidc/realm.json:/opt/keycloak/data/import/realm.json:ro
-      # Persisted realm survives restarts, so edits to realm.json are not
-      # re-imported until this volume is removed (docker compose down -v).
-      - keycloak_data:/opt/keycloak/data
+    depends_on:
+      postgres-db:
+        condition: service_healthy
     deploy:
       resources:
         limits:
@@ -318,6 +323,7 @@ services:
       - alexandria
     volumes:
       - pgdata:/var/lib/postgresql/data
+      - ./infra/postgres/init:/docker-entrypoint-initdb.d:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-admin} -d ${POSTGRES_DB:-alexandria} -p ${POSTGRES_PORT:-5432}"]
       interval: 10s
@@ -577,4 +583,3 @@ volumes:
   prometheus_data:
   grafana_data:
   weaviate_data:
-  keycloak_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -267,6 +267,7 @@ services:
       KC_BOOTSTRAP_ADMIN_USERNAME: ${KC_BOOTSTRAP_ADMIN_USERNAME:-admin}
       KC_BOOTSTRAP_ADMIN_PASSWORD: ${KC_BOOTSTRAP_ADMIN_PASSWORD:-localkcpassword}
       KC_HEALTH_ENABLED: "true"
+      KC_DB: dev-file
       KC_HTTP_PORT: 8180
       KC_HOSTNAME: http://localhost/auth
       KC_PROXY_HEADERS: xforwarded
@@ -279,6 +280,7 @@ services:
       - alexandria
     volumes:
       - ./infra/oidc/realm.json:/opt/keycloak/data/import/realm.json:ro
+      - keycloak_data:/opt/keycloak/data
     deploy:
       resources:
         limits:
@@ -553,6 +555,15 @@ services:
     profiles:
       - e2e
     command: '/bin/sh -c "npx -y playwright@1.61.1 run-server --port 3000 --host 0.0.0.0"'
+    depends_on:
+      client:
+        condition: service_healthy
+      traefik:
+        condition: service_healthy
+      keycloak:
+        condition: service_healthy
+      genai:
+        condition: service_healthy
 
 networks:
   alexandria:
@@ -564,3 +575,4 @@ volumes:
   prometheus_data:
   grafana_data:
   weaviate_data:
+  keycloak_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,7 +80,7 @@ services:
     deploy:
       resources:
         limits:
-          cpus: "0.25"
+          cpus: "2.0"
           memory: 384M
     labels:
       - "traefik.enable=true"
@@ -98,7 +98,7 @@ services:
       postgres-db:
         condition: service_healthy
       keycloak:
-        condition: service_healthy
+        condition: service_started
 
   knowledgebase-service:
     image: ghcr.io/aet-devops26/team-bnd/knowledgebase-service:latest
@@ -135,7 +135,7 @@ services:
     deploy:
       resources:
         limits:
-          cpus: "0.50"
+          cpus: "2.0"
           memory: 512M
     labels:
       - "traefik.enable=true"
@@ -155,9 +155,7 @@ services:
       postgres-db:
         condition: service_healthy
       keycloak:
-        condition: service_healthy
-      genai:
-        condition: service_healthy
+        condition: service_started
 
   qa-service:
     image: ghcr.io/aet-devops26/team-bnd/qa-service:latest
@@ -190,7 +188,7 @@ services:
     deploy:
       resources:
         limits:
-          cpus: "0.25"
+          cpus: "2.0"
           memory: 384M
     labels:
       - "traefik.enable=true"
@@ -208,9 +206,7 @@ services:
       postgres-db:
         condition: service_healthy
       keycloak:
-        condition: service_healthy
-      genai:
-        condition: service_healthy
+        condition: service_started
 
   genai:
     image: ghcr.io/aet-devops26/team-bnd/genai:latest
@@ -255,7 +251,7 @@ services:
       interval: 30s
       timeout: 3s
       retries: 3
-      start_period: 5s
+      start_period: 30s
     depends_on:
       s3-storage:
         condition: service_healthy
@@ -286,7 +282,7 @@ services:
     deploy:
       resources:
         limits:
-          cpus: "0.50"
+          cpus: "2.0"
           memory: 512M
     labels:
       - "traefik.enable=true"
@@ -472,9 +468,9 @@ services:
     healthcheck:
       test: ["CMD", "traefik", "healthcheck", "--ping"]
       interval: 30s
-      timeout: 3s
+      timeout: 10s
       retries: 3
-      start_period: 5s
+      start_period: 20s
 
   prometheus:
     image: prom/prometheus:v3.12.0

--- a/infra/postgres/init/create-keycloak-db.sql
+++ b/infra/postgres/init/create-keycloak-db.sql
@@ -1,0 +1,3 @@
+-- Keycloak stores its realm and users in a dedicated database on the shared
+-- Postgres instance, mirroring the k8s/Helm setup. Runs only on first init.
+CREATE DATABASE keycloak;


### PR DESCRIPTION
## What does this PR do?

Cuts a cold `docker compose up` from ~234s to ~44s for a usable stack (~48s until every container reports healthy), and makes Keycloak restarts ~10s faster on top of that. Closes #265.

Everything below is measured on a clean `docker compose down -v` + `docker compose up -d` on the pull path (images already local, no build), on a 12-thread host.

### Where the time was going

Original container-start timeline: infra at t=0, the three Spring services only at t=127s, client at t=229s. So ~127s was pure waiting, then the Spring boots, then client.

Two root causes:

1. The Spring services were gated on `keycloak: service_healthy`, but they do not need Keycloak at boot. I ran user-service with Keycloak stopped and it reaches `Started` cleanly, no OIDC/JWKS errors (the JWKS is fetched lazily on the first token check). Keycloak takes ~127s to go healthy at its old 0.5 CPU (about half is the `start-dev` re-augmentation that runs every boot, the rest is Quarkus start plus realm import), so that gate was dead wait.

2. The `cpus` caps were throttling JVM startup. user-service, host idle, memory unlimited:

   | cpus | boot  |
   | ---- | ----- |
   | 0.25 | 76.5s |
   | 0.5  | 35.4s |
   | 1.0  | 16.6s |
   | 1.5  | 11.7s |
   | 2.0  | 8.7s  |
   | 3.0  | 7.3s  |
   | 4.0  | 8.4s  |

   2.0 is the knee: 1.0 is ~2x slower, and past 2.0 it flattens (3.0 saves ~1.4s, 4.0 is noise). That is why the JVM services went to 2.0 and not 1.0.

I also checked whether the memory cap was the throttle, since those sweeps had no memory limit. It is not. user-service at 2.0 CPU, varying memory: 384m 8.5s, 512m 8.5s, 768m 8.3s, 1024m 8.5s, unlimited 8.8s. Flat, so the Spring memory limits are left untouched.

### Changes

- CPU caps: user/knowledgebase/qa/keycloak all to 2.0 (from 0.25/0.5/0.25/0.5). Memory unchanged.
- Spring services `depends_on: keycloak` from `service_healthy` to `service_started`.
- Dropped the `depends_on: genai` on knowledgebase and qa. They call GenAI lazily at runtime (wrapped in try/catch per the Spring README), and I verified both boot to readiness UP with GenAI unreachable (knowledgebase 10.4s, qa 8.6s). This lets all three Spring services start at postgres-healthy (~11s) instead of waiting for the genai container.
- genai healthcheck `start_period` 5s to 30s. Its app takes ~10s to boot, and during `start_period` probes run every `start_interval` (5s default), so a 5s window dropped it onto the 30s `interval` cadence and it got marked healthy ~30s late. knowledgebase/qa used to gate on it, so that was on the critical path.
- traefik healthcheck `timeout` 3s to 10s, `start_period` 5s to 20s. The `traefik healthcheck --ping` CLI spawns a full traefik binary (~2s idle, more under the boot CPU burst) and was getting SIGKILLed by the 3s timeout, so it only passed on a later 30s-interval probe. Traefik routes fine the whole time, this just fixes its self-probe.
- Keycloak persistence: `KC_DB=dev-file` plus a `keycloak_data` volume on `/opt/keycloak/data`. Dev mode defaults to in-memory H2, so every boot rebuilt the schema (~14s of Liquibase) and re-imported the realm. With a file-backed H2 that survives restarts, subsequent boots skip both. The volume is mounted at `/opt/keycloak/data` rather than the H2 subdir because that path exists in the image owned by the keycloak user; a fresh volume on the subdir is root-owned and H2 fails with an access-denied.
- playwright (e2e profile) now has a `depends_on` on client, traefik, keycloak and genai (all `service_healthy`), so the e2e runner waits for the app to actually be up. client already gates on the three Spring services, so that covers them too.

`start_period` does not make a service boot faster, it is only the grace window before a failing probe counts. The real levers were the `depends_on` gating and the CPU caps.

### After

Timeline now: infra at t=0, all three Spring services plus genai at ~11s, client (usable stack) healthy ~44s, keycloak last to report healthy at ~48s. `docker compose up -d` returns in ~38s.

Keycloak boot-to-healthy, full stack: 41.4s on a fresh volume, 31.3s once the volume is warm (schema init and realm import both skipped). That gain lands on restarts and `down`/`up` (anything that keeps the volume), not on a `down -v`, which wipes it and pays the first-boot cost again.

I did try bumping keycloak CPU higher (3.0 gets it healthy at ~42.5s, 4.0 no better), but keycloak is off the client critical path so that only shifts the last green by ~4s without making the app usable any sooner, so it stays at 2.0 like the others.

Remaining floor: three JVMs booting at once contend (3 Spring in parallel at 2.0 boot in 13-16s vs 8.7s solo). That is physical-core/JIT contention, not something the caps or memory fix.

### Changed after review

The Keycloak persistence above originally used a file-backed H2 (`KC_DB=dev-file` + a `keycloak_data` volume). It now uses the existing Postgres instead, with a dedicated `keycloak` database, which matches how the k8s/Helm chart already runs Keycloak. Concretely:

- `infra/postgres/init/create-keycloak-db.sql` creates the `keycloak` database on first init (runs only on an empty data dir, so an existing volume needs a `down -v`).
- keycloak uses `KC_DB=postgres` pointing at that database and now `depends_on` postgres-db being healthy.
- The H2 `dev-file` config and the `keycloak_data` volume are gone; the realm now lives in the `keycloak` Postgres database, so the same "edit realm.json, need `down -v` to re-import" caveat applies to the Postgres data.

Same persistence behaviour: fresh boot ~39s to healthy with the realm imported, restart ~32s with schema init and realm import both skipped.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [x] CI / infra

## Definition of Done

- [ ] CI is green
- [x] If the API changed: not applicable, no API change
- [x] If a service was added or restructured: docker compose still comes up cleanly, verified with repeated down -v / up cycles
- [x] Tests added or updated: not applicable, compose-only change
- [x] Docs updated where it matters: rationale is in this PR

## Notes for the reviewer

- The CPU caps are local-compose only; the k8s manifests keep their own limits, so prod sizing is untouched.
- `KC_DB=dev-file` keeps Keycloak in dev mode, just file-backed instead of in-memory. A `down -v` still resets it, same as the other data volumes.
- Not done here, would need a custom image: I prototyped the docs' optimized path (`kc.sh build` + `start --optimized`), which drops the per-boot augmentation and gets Keycloak ready in the ~20s range, but it means rebuilding the Keycloak image and switching it to production mode. Happy to do it as a follow-up if we want Keycloak faster still.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added persistent storage for Keycloak data.
  - End-to-end tests now wait for required services to be healthy before starting.

- **Bug Fixes**
  - Improved service startup reliability by adjusting dependency and health-check behavior.
  - Increased runtime resources for several services.
  - Extended startup grace periods for GenAI and Traefik to accommodate slower initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->