### PR TITLE
Feat: Add autoscaling, NetworkPolicies, and Prometheus docs to Helm char

### DIFF
--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -107,17 +107,17 @@ When a service's autoscaling is enabled the HPA owns the replica count, so the s
 kubectl -n alexandria get hpa
 ```
 
-### Rationale on Static Scrape Config
+## Rationale on Static Scrape Config
 
 We run our own Prometheus and Grafana as plain deployments and feed Prometheus a static scrape config from a ConfigMap (`templates/prometheus-config.yaml`), rather than using the Prometheus operator with ServiceMonitor/PodMonitor and PrometheusRule CRDs.
 
-The operator isn't installed on the stud cluster and the CRDs aren't available, thus ServiceMonitors would need us to bring up and manage the whole operator stack. For a fixed, small set of services that only changes when we add a service, a hand-written scrape config is simpler, needs no extra cluster components, and keeps the k8s setup close to the docker-compose one.
+The `monitoring.coreos.com` CRDs exist on the stud cluster, but that operator and its Prometheus are cluster-owned. We don't control its scrape scope, alerting, or Grafana and shouldn't rely on shared infrastructure for our project's monitoring. Running our own Prometheus + Grafana with a self-contained static scrape config keeps monitoring fully owned by the chart, needs no coordination with the cluster operator, and mirrors the docker-compose setup. For a fixed, small set of services that only changes when we add a service, a hand-written scrape config is also simpler than wiring ServiceMonitors into our own operator install.
 
 The scrape targets differ slightly from the compose setup on purpose: compose runs an all-in-one SeaweedFS container and Traefik, while the chart splits SeaweedFS into `seaweedfs-s3` and `seaweedfs-volume` (different metrics port) and fronts traffic with the ingress instead of Traefik. The alert rules are kept in sync with `infra/prometheus/alert.rules.yml`.
 
 ## NetworkPolicies
 
-The chart ships default-deny-ingress together with explicit allow policies (`templates/networkpolicies.yaml`) so each service only accepts traffic from the components that actually call it. The Spring services and client accept from the ingress, knowledgebase/qa from the other Spring services, GenAI from knowledgebase/qa, Weaviate only from GenAI, SeaweedFS S3 from GenAI/knowledgebase, Postgres from the Spring services and Keycloak. The SeaweedFS master/volume/filer/s3 pods are also allowed to talk to each other, since the subchart ships no policies of its own. Every pod allows traffic from the monitoring namespace, so Prometheus can still scrape. Outgoing traffic (egress) is not limited.
+The chart ships default-deny-ingress together with explicit allow policies (`templates/networkpolicies.yaml`) so each service only accepts traffic from the components that actually call it. Client, GenAi, Spring microservices and Keycloak accept traffic from the ingress (see `allowFromAnywhere` below), knowledgebase/qa from the other Spring services, GenAI from knowledgebase/qa, Weaviate only from GenAI, SeaweedFS S3 from GenAI/knowledgebase, Postgres from the Spring services and Keycloak. The SeaweedFS master/volume/filer/s3 pods are also allowed to talk to each other, since the subchart ships no policies of its own. Every pod allows traffic from the monitoring namespace, so Prometheus can still scrape. Outgoing traffic (egress) is not limited.
 
 The implemented NetworkPolicies are off by default for two reasons:
 1. They only actually enforce on a CNI that implements NetworkPolicy
@@ -131,6 +131,26 @@ helm upgrade alexandria infra/k8s/alexandria \
   -f infra/k8s/alexandria/values-secrets.yaml \
   --set networkPolicy.enabled=true
 ```
+
+### Ingress controller allow-rule (`allowFromAnywhere`)
+
+Client, GenAi, Spring microservices and Keycloak's `/auth` are reached through the cluster's ingress controller. To scope an allow-rule to that controller a NetworkPolicy needs the controller's namespace or pod labels, but on the shared stud cluster the controller runs in a namespace we have no permissions to inspect, and guessing the namespace wrong silently 504s all external traffic. Confirmed empirically: enabling a namespace/label-scoped rule with a guessed selector took the site down with a gateway timeout.
+
+Because those services are already publicly reachable through the ingress anyway, the default `networkPolicy.ingressController.allowFromAnywhere: true` makes their ingress allow-rule accept traffic from any source instead of trying to name the controller. This does not widen their real exposure: it only affects the front-door services that the ingress already exposes. The internal tier (Postgres, Weaviate, GenAI, SeaweedFS, and the Spring `/internal` endpoints) stays locked down by default-deny and its own scoped, in-namespace allow-rules regardless of this flag.
+
+If one knows the controller's namespace or pod labels, it should be scoped tightly instead by putting the following in a values file (example for a stock ingress-nginx):
+
+```yaml
+networkPolicy:
+  enabled: true
+  ingressController:
+    allowFromAnywhere: false
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: ingress-nginx
+```
+
+With `allowFromAnywhere: false` the render fails fast if both selectors are left empty, so the default-deny can't be silently defeated.
 
 # Kubernetes Troubleshooting
 

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -115,6 +115,23 @@ The operator isn't installed on the stud cluster and the CRDs aren't available, 
 
 The scrape targets differ slightly from the compose setup on purpose: compose runs an all-in-one SeaweedFS container and Traefik, while the chart splits SeaweedFS into `seaweedfs-s3` and `seaweedfs-volume` (different metrics port) and fronts traffic with the ingress instead of Traefik. The alert rules are kept in sync with `infra/prometheus/alert.rules.yml`.
 
+## NetworkPolicies
+
+The chart ships default-deny-ingress together with explicit allow policies (`templates/networkpolicies.yaml`) so each service only accepts traffic from the components that actually call it. The Spring services and client accept from the ingress, knowledgebase/qa from the other Spring services, GenAI from knowledgebase/qa, Weaviate only from GenAI, SeaweedFS S3 from GenAI/knowledgebase, Postgres from the Spring services and Keycloak. Every pod allows traffic from the monitoring namespace, so Prometheus can still scrape. Outgoing traffic (egress) is not limited.
+
+The implemented NetworkPolicies are off by default for two reasons:
+1. They only actually enforce on a CNI that implements NetworkPolicy
+2. A wrong rule can cut off live traffic
+
+To enable them:
+
+```bash
+helm upgrade alexandria infra/k8s/alexandria \
+  --namespace alexandria \
+  -f infra/k8s/alexandria/values-secrets.yaml \
+  --set networkPolicy.enabled=true
+```
+
 # Kubernetes Troubleshooting
 
 ### Spring or Keycloak fail postgres password authentication after a reinstall

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -88,6 +88,25 @@ kubectl -n alexandria get svc
 kubectl -n alexandria get ingress
 ```
 
+## Autoscaling
+
+The stateless services (user-service, knowledgebase-service, qa-service, client, genai) can scale on CPU via a HorizontalPodAutoscaler. It's off by default so a install stays inside the small stud cluster resource quota. To enable it per service:
+
+```bash
+helm upgrade alexandria infra/k8s/alexandria \
+  --namespace alexandria \
+  -f infra/k8s/alexandria/values-secrets.yaml \
+  --set userService.autoscaling.enabled=true \
+  --set knowledgebaseService.autoscaling.enabled=true \
+  --set qaService.autoscaling.enabled=true
+```
+
+When a service's autoscaling is enabled the HPA owns the replica count, so the static `replicaCount` is dropped from that deployment. Min/Max and the CPU target are defined under each `autoscaling` block in `values.yaml`. The maxReplicas defaults are deliberately low to keep the summed CPU and memory requests under the namespace resource quota. This needs the metrics server to be running in the cluster. Check scaling with:
+
+```bash
+kubectl -n alexandria get hpa
+```
+
 # Kubernetes Troubleshooting
 
 ### Spring or Keycloak fail postgres password authentication after a reinstall

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -90,7 +90,7 @@ kubectl -n alexandria get ingress
 
 ## Autoscaling
 
-The stateless services (user-service, knowledgebase-service, qa-service, client, genai) can scale on CPU via a HorizontalPodAutoscaler. It's off by default so a install stays inside the small stud cluster resource quota. To enable it per service:
+The stateless services (user-service, knowledgebase-service, qa-service, client, genai) can scale on CPU via a HorizontalPodAutoscaler. It's off by default so an install stays inside the small stud cluster resource quota. To enable it per service:
 
 ```bash
 helm upgrade alexandria infra/k8s/alexandria \
@@ -117,7 +117,7 @@ The scrape targets differ slightly from the compose setup on purpose: compose ru
 
 ## NetworkPolicies
 
-The chart ships default-deny-ingress together with explicit allow policies (`templates/networkpolicies.yaml`) so each service only accepts traffic from the components that actually call it. The Spring services and client accept from the ingress, knowledgebase/qa from the other Spring services, GenAI from knowledgebase/qa, Weaviate only from GenAI, SeaweedFS S3 from GenAI/knowledgebase, Postgres from the Spring services and Keycloak. Every pod allows traffic from the monitoring namespace, so Prometheus can still scrape. Outgoing traffic (egress) is not limited.
+The chart ships default-deny-ingress together with explicit allow policies (`templates/networkpolicies.yaml`) so each service only accepts traffic from the components that actually call it. The Spring services and client accept from the ingress, knowledgebase/qa from the other Spring services, GenAI from knowledgebase/qa, Weaviate only from GenAI, SeaweedFS S3 from GenAI/knowledgebase, Postgres from the Spring services and Keycloak. The SeaweedFS master/volume/filer/s3 pods are also allowed to talk to each other, since the subchart ships no policies of its own. Every pod allows traffic from the monitoring namespace, so Prometheus can still scrape. Outgoing traffic (egress) is not limited.
 
 The implemented NetworkPolicies are off by default for two reasons:
 1. They only actually enforce on a CNI that implements NetworkPolicy

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -107,6 +107,14 @@ When a service's autoscaling is enabled the HPA owns the replica count, so the s
 kubectl -n alexandria get hpa
 ```
 
+### Rationale on Static Scrape Config
+
+We run our own Prometheus and Grafana as plain deployments and feed Prometheus a static scrape config from a ConfigMap (`templates/prometheus-config.yaml`), rather than using the Prometheus operator with ServiceMonitor/PodMonitor and PrometheusRule CRDs.
+
+The operator isn't installed on the stud cluster and the CRDs aren't available, thus ServiceMonitors would need us to bring up and manage the whole operator stack. For a fixed, small set of services that only changes when we add a service, a hand-written scrape config is simpler, needs no extra cluster components, and keeps the k8s setup close to the docker-compose one.
+
+The scrape targets differ slightly from the compose setup on purpose: compose runs an all-in-one SeaweedFS container and Traefik, while the chart splits SeaweedFS into `seaweedfs-s3` and `seaweedfs-volume` (different metrics port) and fronts traffic with the ingress instead of Traefik. The alert rules are kept in sync with `infra/prometheus/alert.rules.yml`.
+
 # Kubernetes Troubleshooting
 
 ### Spring or Keycloak fail postgres password authentication after a reinstall

--- a/infra/k8s/alexandria/templates/_helpers.tpl
+++ b/infra/k8s/alexandria/templates/_helpers.tpl
@@ -52,3 +52,15 @@ http://{{ .Release.Name }}-seaweedfs-s3:{{ .Values.seaweedfs.s3.port }}
 {{- define "alexandria.monitoringNamespace" -}}
 {{- default (printf "%s-monitoring" .Release.Namespace) .Values.monitoring.namespace }}
 {{- end }}
+
+{{- define "alexandria.ingressControllerPeer" -}}
+-
+  {{- with .namespaceSelector }}
+  namespaceSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .podSelector }}
+  podSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/infra/k8s/alexandria/templates/client-deployment.yaml
+++ b/infra/k8s/alexandria/templates/client-deployment.yaml
@@ -7,7 +7,9 @@ metadata:
     app: client
     app.kubernetes.io/component: frontend
 spec:
+  {{- if not .Values.client.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "alexandria.selectorLabels" . | nindent 6 }}

--- a/infra/k8s/alexandria/templates/genai-deployment.yaml
+++ b/infra/k8s/alexandria/templates/genai-deployment.yaml
@@ -7,7 +7,9 @@ metadata:
     app: genai
     app.kubernetes.io/component: ai-service
 spec:
+  {{- if not .Values.genai.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "alexandria.selectorLabels" . | nindent 6 }}

--- a/infra/k8s/alexandria/templates/hpa.yaml
+++ b/infra/k8s/alexandria/templates/hpa.yaml
@@ -1,0 +1,34 @@
+{{- $services := list
+  (dict "name" "user-service" "cfg" .Values.userService.autoscaling)
+  (dict "name" "knowledgebase-service" "cfg" .Values.knowledgebaseService.autoscaling)
+  (dict "name" "qa-service" "cfg" .Values.qaService.autoscaling)
+  (dict "name" "client" "cfg" .Values.client.autoscaling)
+  (dict "name" "genai" "cfg" .Values.genai.autoscaling)
+}}
+{{- range $services }}
+{{- if .cfg.enabled }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "alexandria.fullname" $ }}-{{ .name }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "alexandria.labels" $ | nindent 4 }}
+    app: {{ .name }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "alexandria.fullname" $ }}-{{ .name }}
+  minReplicas: {{ .cfg.minReplicas }}
+  maxReplicas: {{ .cfg.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .cfg.targetCPUUtilizationPercentage }}
+{{- end }}
+{{- end }}

--- a/infra/k8s/alexandria/templates/knowledgebase-service-deployment.yaml
+++ b/infra/k8s/alexandria/templates/knowledgebase-service-deployment.yaml
@@ -8,7 +8,9 @@ metadata:
     app: knowledgebase-service
     app.kubernetes.io/component: backend
 spec:
+  {{- if not .Values.knowledgebaseService.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "alexandria.selectorLabels" . | nindent 6 }}

--- a/infra/k8s/alexandria/templates/networkpolicies.yaml
+++ b/infra/k8s/alexandria/templates/networkpolicies.yaml
@@ -1,0 +1,244 @@
+{{- if .Values.networkPolicy.enabled }}
+{{- $ns := .Release.Namespace }}
+{{- $monitoringNs := include "alexandria.monitoringNamespace" . }}
+{{- $ic := .Values.networkPolicy.ingressController }}
+---
+# Default-deny: nothing in the namespace accepts ingress unless a policy below
+# explicitly allows it.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "alexandria.fullname" . }}-default-deny-ingress
+  namespace: {{ $ns }}
+  labels:
+    {{- include "alexandria.labels" . | nindent 4 }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+# Prometheus lives in its own namespace and scrapes every pod's metrics port,
+# so allow ingress from the monitoring namespace to all pods here.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "alexandria.fullname" . }}-allow-monitoring
+  namespace: {{ $ns }}
+  labels:
+    {{- include "alexandria.labels" . | nindent 4 }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ $monitoringNs }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "alexandria.fullname" . }}-allow-ingress-controller
+  namespace: {{ $ns }}
+  labels:
+    {{- include "alexandria.labels" . | nindent 4 }}
+spec:
+  policyTypes:
+    - Ingress
+  podSelector:
+    matchExpressions:
+      - key: app
+        operator: In
+        values: ["client", "user-service", "knowledgebase-service", "qa-service", "genai"]
+  ingress:
+    - from:
+        - namespaceSelector:
+            {{- toYaml $ic.namespaceSelector | nindent 12 }}
+          podSelector:
+            {{- toYaml $ic.podSelector | nindent 12 }}
+---
+# user-service and qa-service call knowledgebase-service /internal endpoints
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "alexandria.fullname" . }}-allow-knowledgebase-internal
+  namespace: {{ $ns }}
+  labels:
+    {{- include "alexandria.labels" . | nindent 4 }}
+spec:
+  policyTypes:
+    - Ingress
+  podSelector:
+    matchLabels:
+      app: knowledgebase-service
+  ingress:
+    - from:
+        - podSelector:
+            matchExpressions:
+              - key: app
+                operator: In
+                values: ["user-service", "qa-service"]
+      ports:
+        - protocol: TCP
+          port: 8080
+---
+# user-service calls qa-service /internal endpoints
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "alexandria.fullname" . }}-allow-qa-internal
+  namespace: {{ $ns }}
+  labels:
+    {{- include "alexandria.labels" . | nindent 4 }}
+spec:
+  policyTypes:
+    - Ingress
+  podSelector:
+    matchLabels:
+      app: qa-service
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: user-service
+      ports:
+        - protocol: TCP
+          port: 8080
+---
+# knowledgebase-service and qa-service call the GenAI service
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "alexandria.fullname" . }}-allow-genai
+  namespace: {{ $ns }}
+  labels:
+    {{- include "alexandria.labels" . | nindent 4 }}
+spec:
+  policyTypes:
+    - Ingress
+  podSelector:
+    matchLabels:
+      app: genai
+  ingress:
+    - from:
+        - podSelector:
+            matchExpressions:
+              - key: app
+                operator: In
+                values: ["knowledgebase-service", "qa-service"]
+      ports:
+        - protocol: TCP
+          port: 8000
+---
+# only the GenAI service calls Weaviate
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "alexandria.fullname" . }}-allow-weaviate
+  namespace: {{ $ns }}
+  labels:
+    {{- include "alexandria.labels" . | nindent 4 }}
+spec:
+  policyTypes:
+    - Ingress
+  podSelector:
+    matchLabels:
+      app: weaviate
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: genai
+      ports:
+        - protocol: TCP
+          port: 8080
+        - protocol: TCP
+          port: {{ .Values.weaviate.grpcPort | default 50051 }}
+---
+# SeaweedFS S3 is reached by the GenAI and knowledgebase services for object
+# storage
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "alexandria.fullname" . }}-allow-seaweedfs-s3
+  namespace: {{ $ns }}
+  labels:
+    {{- include "alexandria.labels" . | nindent 4 }}
+spec:
+  policyTypes:
+    - Ingress
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: seaweedfs
+      app.kubernetes.io/component: s3
+  ingress:
+    - from:
+        - podSelector:
+            matchExpressions:
+              - key: app
+                operator: In
+                values: ["genai", "knowledgebase-service"]
+      ports:
+        - protocol: TCP
+          port: {{ .Values.seaweedfs.s3.port | default 8333 }}
+---
+# Postgres is reached by the three Spring services and by Keycloak
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "alexandria.fullname" . }}-allow-postgres
+  namespace: {{ $ns }}
+  labels:
+    {{- include "alexandria.labels" . | nindent 4 }}
+spec:
+  policyTypes:
+    - Ingress
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: postgres-db
+  ingress:
+    - from:
+        - podSelector:
+            matchExpressions:
+              - key: app
+                operator: In
+                values: ["user-service", "knowledgebase-service", "qa-service"]
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: keycloak
+      ports:
+        - protocol: TCP
+          port: 5432
+---
+# The Spring services and the client authenticate against Keycloak, and the
+# client redirects users to it, so allow both in-namespace services and the
+# ingress controller
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "alexandria.fullname" . }}-allow-keycloak
+  namespace: {{ $ns }}
+  labels:
+    {{- include "alexandria.labels" . | nindent 4 }}
+spec:
+  policyTypes:
+    - Ingress
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: keycloak
+  ingress:
+    - from:
+        - podSelector:
+            matchExpressions:
+              - key: app
+                operator: In
+                values: ["user-service", "knowledgebase-service", "qa-service", "client"]
+        - namespaceSelector:
+            {{- toYaml $ic.namespaceSelector | nindent 12 }}
+          podSelector:
+            {{- toYaml $ic.podSelector | nindent 12 }}
+      ports:
+        - protocol: TCP
+          port: 8080
+{{- end }}

--- a/infra/k8s/alexandria/templates/networkpolicies.yaml
+++ b/infra/k8s/alexandria/templates/networkpolicies.yaml
@@ -183,6 +183,25 @@ spec:
         - protocol: TCP
           port: {{ .Values.seaweedfs.s3.port | default 8333 }}
 ---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "alexandria.fullname" . }}-allow-seaweedfs-internal
+  namespace: {{ $ns }}
+  labels:
+    {{- include "alexandria.labels" . | nindent 4 }}
+spec:
+  policyTypes:
+    - Ingress
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: seaweedfs
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: seaweedfs
+---
 # Postgres is reached by the three Spring services and by Keycloak
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/infra/k8s/alexandria/templates/networkpolicies.yaml
+++ b/infra/k8s/alexandria/templates/networkpolicies.yaml
@@ -2,6 +2,9 @@
 {{- $ns := .Release.Namespace }}
 {{- $monitoringNs := include "alexandria.monitoringNamespace" . }}
 {{- $ic := .Values.networkPolicy.ingressController }}
+{{- if and (not $ic.allowFromAnywhere) (empty $ic.namespaceSelector) (empty $ic.podSelector) }}
+{{- fail "networkPolicy.enabled=true with ingressController.allowFromAnywhere=false requires ingressController.namespaceSelector and/or podSelector to be set; leaving both empty selects every pod in the cluster and silently defeats the default-deny. Either set allowFromAnywhere=true, or set the selectors to match your ingress controller (e.g. namespaceSelector.matchLabels.kubernetes.io/metadata.name: ingress-nginx)." }}
+{{- end }}
 ---
 # Default-deny: nothing in the namespace accepts ingress unless a policy below
 # explicitly allows it.
@@ -52,11 +55,14 @@ spec:
         operator: In
         values: ["client", "user-service", "knowledgebase-service", "qa-service", "genai"]
   ingress:
+    {{- if $ic.allowFromAnywhere }}
+    # Controller identity is unknown on the shared cluster, so allow all sources
+    # to the already-public web tier. Internal services stay locked down below.
+    - {}
+    {{- else }}
     - from:
-        - namespaceSelector:
-            {{- toYaml $ic.namespaceSelector | nindent 12 }}
-          podSelector:
-            {{- toYaml $ic.podSelector | nindent 12 }}
+        {{- include "alexandria.ingressControllerPeer" $ic | nindent 8 }}
+    {{- end }}
 ---
 # user-service and qa-service call knowledgebase-service /internal endpoints
 apiVersion: networking.k8s.io/v1
@@ -253,11 +259,18 @@ spec:
               - key: app
                 operator: In
                 values: ["user-service", "knowledgebase-service", "qa-service", "client"]
-        - namespaceSelector:
-            {{- toYaml $ic.namespaceSelector | nindent 12 }}
-          podSelector:
-            {{- toYaml $ic.podSelector | nindent 12 }}
+        {{- if not $ic.allowFromAnywhere }}
+        {{- include "alexandria.ingressControllerPeer" $ic | nindent 8 }}
+        {{- end }}
       ports:
         - protocol: TCP
           port: 8080
+    {{- if $ic.allowFromAnywhere }}
+    # Keycloak's /auth is reached by external users through the ingress; the
+    # controller can't be selected here, so allow the public auth port from
+    # any source (it is already exposed via the ingress).
+    - ports:
+        - protocol: TCP
+          port: 8080
+    {{- end }}
 {{- end }}

--- a/infra/k8s/alexandria/templates/prometheus-config.yaml
+++ b/infra/k8s/alexandria/templates/prometheus-config.yaml
@@ -80,18 +80,30 @@ data:
             annotations:
               summary: "{{`{{ $labels.job }}`}} 5xx error rate above 5%"
               description: "More than 5% of {{`{{ $labels.job }}`}} requests have failed with a 5xx status over the last 5 minutes."
-          - alert: GenAiSlowResponses
+          - alert: GenAiSlowModelCalls
             expr: |
               histogram_quantile(
                 0.95,
-                sum(rate(http_request_duration_seconds_bucket{job="genai"}[5m])) by (le)
-              ) > 2
+                sum(rate(genai_model_request_duration_seconds_bucket[5m])) by (le, operation)
+              ) > 30
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              summary: "GenAI {{`{{ $labels.operation }}`}} p95 model latency above 30s"
+              description: "The 95th percentile of GenAI {{`{{ $labels.operation }}`}} model-call latency has been above 30 seconds for 10 minutes."
+          - alert: GenAiModelErrors
+            expr: |
+              sum by (operation) (rate(genai_model_requests_total{status=~"error|timeout"}[5m]))
+                /
+              sum by (operation) (rate(genai_model_requests_total[5m]))
+                > 0.10
             for: 5m
             labels:
               severity: warning
             annotations:
-              summary: "GenAI p95 latency above 2s"
-              description: "The 95th percentile of GenAI request latency has been above 2 seconds for 5 minutes."
+              summary: "GenAI {{`{{ $labels.operation }}`}} failure rate above 10%"
+              description: "More than 10% of GenAI {{`{{ $labels.operation }}`}} calls have failed (provider error or timeout) over the last 5 minutes."
           - alert: S3StorageLowDiskSpace
             expr: |
               sum(SeaweedFS_volumeServer_resource{type="avail"})

--- a/infra/k8s/alexandria/templates/qa-service-deployment.yaml
+++ b/infra/k8s/alexandria/templates/qa-service-deployment.yaml
@@ -8,7 +8,9 @@ metadata:
     app: qa-service
     app.kubernetes.io/component: backend
 spec:
+  {{- if not .Values.qaService.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "alexandria.selectorLabels" . | nindent 6 }}

--- a/infra/k8s/alexandria/templates/user-service-deployment.yaml
+++ b/infra/k8s/alexandria/templates/user-service-deployment.yaml
@@ -8,7 +8,9 @@ metadata:
     app: user-service
     app.kubernetes.io/component: backend
 spec:
+  {{- if not .Values.userService.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "alexandria.selectorLabels" . | nindent 6 }}

--- a/infra/k8s/alexandria/values.yaml
+++ b/infra/k8s/alexandria/values.yaml
@@ -124,9 +124,16 @@ ingress:
   className: nginx
   host: alexandria.stud.k8s.aet.cit.tum.de
 
+# NetworkPolicies: default-deny ingress with explicit allow rules.
+#  Off by default.
+networkPolicy:
+  enabled: false
+  ingressController:
+    namespaceSelector: {}
+    podSelector: {}
+
 # Self-hosted Prometheus and Grafana mirroring the docker-compose setup.
-# They live in their own namespace (per "Monitoring Best Practices in Kubernetes"
-# §1). Neither is exposed through the ingress — port-forward to reach them:
+# They live in their own namespace. Neither is exposed, port-forward to reach them:
 #   kubectl -n alexandria-monitoring port-forward svc/alexandria-prometheus 9090:9090
 #   kubectl -n alexandria-monitoring port-forward svc/alexandria-grafana 3000:3000
 monitoring:

--- a/infra/k8s/alexandria/values.yaml
+++ b/infra/k8s/alexandria/values.yaml
@@ -125,10 +125,14 @@ ingress:
   host: alexandria.stud.k8s.aet.cit.tum.de
 
 # NetworkPolicies: default-deny ingress with explicit allow rules.
-#  Off by default.
+# Off by default.
+#
+# Set allowFromAnywhere: false and fill in ingressController selectors if
+# you know your controller's namespace/pod labels and want to scope it tightly.
 networkPolicy:
   enabled: false
   ingressController:
+    allowFromAnywhere: true
     namespaceSelector: {}
     podSelector: {}
 

--- a/infra/k8s/alexandria/values.yaml
+++ b/infra/k8s/alexandria/values.yaml
@@ -30,6 +30,7 @@ spring:
 # `default-h2d5c` (3250m CPU / 5144Mi memory in the alexandria namespace).
 # Prometheus + Grafana live in alexandria-monitoring with its own 750m/1000Mi
 # quota, sized independently below.
+# Autoscaling is off by default.
 userService:
   resources:
     requests:
@@ -38,6 +39,11 @@ userService:
     limits:
       cpu: 200m
       memory: 384Mi
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 3
+    targetCPUUtilizationPercentage: 75
 
 knowledgebaseService:
   resources:
@@ -47,6 +53,11 @@ knowledgebaseService:
     limits:
       cpu: 300m
       memory: 512Mi
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 3
+    targetCPUUtilizationPercentage: 75
 
 qaService:
   resources:
@@ -56,6 +67,11 @@ qaService:
     limits:
       cpu: 200m
       memory: 384Mi
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 3
+    targetCPUUtilizationPercentage: 75
 
 client:
   resources:
@@ -65,6 +81,11 @@ client:
     limits:
       cpu: 100m
       memory: 128Mi
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 80
 
 genai:
   baseUrl: "http://alexandria-genai:8000"
@@ -75,6 +96,11 @@ genai:
     limits:
       cpu: 500m
       memory: 512Mi
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 75
 
 weaviate:
   url: ""


### PR DESCRIPTION
## What does this PR do?

This PR addresses the main helm issues still open. Closes #282, closes #283 and closes #284.
- Regarding #282: Adds autoscaling to all stateless services: spring microservices, genai, client. Gated by `autoscaling.enabled`, disabled by default.
- Regarding #283: Added default-deny ingress, default-allow egress as NetworkPolicy. Gated by `networkPolicy.enabled`, disabled by default.
- Reagrding #284: Changed scrape configs to be more closely aligned between `docker-compose` setup and helm deployment. Complete sync not possible because of different integration of `traefik` and `s3-storage`. Added a small note to the README on why we keep our static scrape config, TL;DR: Missing permissions.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [x] CI / infra

## Definition of Done

- [x] CI is green
- [ ] If the API changed: `api/openapi.yaml` is updated and lint passes
- [ ] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [ ] Tests added or updated for the changed behaviour
- [x] Docs updated where it matters (README, ADRs, comments)

## Notes for the reviewer

<!-- Anything they should look at first, gotchas, screenshots, ... -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional per-service CPU autoscaling with configurable replica limits.
  * Added optional network policies with default-deny ingress and explicit service access rules.
  * Added Kubernetes deployment guidance for autoscaling, networking, and monitoring configuration.

* **Monitoring**
  * Replaced the GenAI latency alert with alerts for slow model calls and elevated model-call failure rates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->