### PR TITLE
Test: Raise GenAI coverage to 100% and run integration tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -436,9 +436,14 @@ jobs:
         working-directory: services/genai
         run: uv run ruff check .
 
-      - name: Run Tests
-        working-directory: services/genai
-        run: uv run pytest
+      # Run the full suite (unit + Weaviate integration tests) against a
+      # throwaway Weaviate via the compose test profile.
+      - name: Run Tests With Test Weaviate
+        run: docker compose run --rm genai-test
+
+      - name: Tear Down Test Weaviate
+        if: always()
+        run: docker compose --profile test down -v
 
       - name: Upload Coverage Report
         if: always()

--- a/services/genai/tests/test_embeddings.py
+++ b/services/genai/tests/test_embeddings.py
@@ -148,6 +148,11 @@ def test_get_embedding_model_name_per_provider():
         assert get_embedding_model_name() == "custom-embed"
 
 
+def test_get_embedding_model_name_unknown_provider_returns_unknown():
+    with patch.dict(os.environ, {"EMBEDDING_PROVIDER": "bogus"}):
+        assert get_embedding_model_name() == "unknown"
+
+
 # --- embedding with a mocked client ---
 
 

--- a/services/genai/tests/test_env.py
+++ b/services/genai/tests/test_env.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
-from app.env import int_env
+from app.env import float_env, int_env
 
 
 def test_int_env_returns_default_when_unset():
@@ -39,3 +39,36 @@ def test_int_env_rejects_below_minimum():
 def test_int_env_allows_zero_when_minimum_is_zero():
     with patch.dict(os.environ, {"SOME_INT": "0"}):
         assert int_env("SOME_INT", 7, minimum=0) == 0
+
+
+def test_float_env_returns_default_when_unset():
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("SOME_FLOAT", None)
+        assert float_env("SOME_FLOAT", 1.5, minimum=0.0) == 1.5
+
+
+def test_float_env_returns_default_when_empty():
+    with patch.dict(os.environ, {"SOME_FLOAT": ""}):
+        assert float_env("SOME_FLOAT", 1.5, minimum=0.0) == 1.5
+
+
+def test_float_env_parses_valid_value():
+    with patch.dict(os.environ, {"SOME_FLOAT": "12.5"}):
+        assert float_env("SOME_FLOAT", 1.5, minimum=0.0) == 12.5
+
+
+def test_float_env_rejects_non_number():
+    with patch.dict(os.environ, {"SOME_FLOAT": "abc"}):
+        with pytest.raises(RuntimeError, match="must be a number"):
+            float_env("SOME_FLOAT", 1.5, minimum=0.0)
+
+
+def test_float_env_rejects_below_minimum():
+    with patch.dict(os.environ, {"SOME_FLOAT": "-1.0"}):
+        with pytest.raises(RuntimeError, match="must be >= 0"):
+            float_env("SOME_FLOAT", 1.5, minimum=0.0)
+
+
+def test_float_env_allows_zero_when_minimum_is_zero():
+    with patch.dict(os.environ, {"SOME_FLOAT": "0"}):
+        assert float_env("SOME_FLOAT", 1.5, minimum=0.0) == 0.0

--- a/services/genai/tests/test_errors.py
+++ b/services/genai/tests/test_errors.py
@@ -1,0 +1,31 @@
+"""Unit tests for the OpenAPI error-response rewiring.
+
+The end-to-end behaviour is covered via the app in test_main.py; this exercises
+the schema walker directly on a hand-built spec so the branch that skips
+non-operation path-item entries (parameters, summary, an op without responses)
+is covered without needing a route that produces one.
+"""
+
+from app.errors import _ERROR_CONTENT, _rewire_error_responses
+
+
+def test_rewire_skips_non_operation_entries_and_rewires_real_responses():
+    schema = {
+        "paths": {
+            "/x": {
+                "parameters": [{"name": "q"}],
+                "summary": "shared summary",
+                "get": {"operationId": "getX"},
+                "post": {"responses": {"404": {"description": "nf"}}, "tags": ["ai"]},
+            }
+        }
+    }
+
+    _rewire_error_responses(schema)
+
+    post_responses = schema["paths"]["/x"]["post"]["responses"]
+    assert post_responses["404"]["content"] == _ERROR_CONTENT
+    # the "ai" tag pulls in the provider-error contract
+    assert {"500", "502", "504"} <= set(post_responses)
+    # the responseless operation and the parameters/summary entries are left alone
+    assert "responses" not in schema["paths"]["/x"]["get"]

--- a/services/genai/tests/test_llm.py
+++ b/services/genai/tests/test_llm.py
@@ -1,10 +1,122 @@
-"""Unit tests for LLM result helpers (model name resolution and parsing)."""
+"""Unit tests for the LLM factory and result helpers.
+
+The provider factory tests patch the LangChain client classes so no client is
+ever constructed and no network or API key is touched; we only assert the
+service passes the right config through.
+"""
+
+import os
+from unittest.mock import patch
 
 import pytest
 from langchain_core.messages import AIMessage
 
 from app.errors import ProviderError
-from app.llm import model_name_from_result, require_parsed
+from app.llm import (
+    get_llm,
+    get_model_name,
+    get_provider,
+    model_name_from_result,
+    require_parsed,
+)
+
+# --- provider selection ---
+
+
+def test_get_provider_defaults_to_logos():
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("LLM_PROVIDER", None)
+        assert get_provider() == "logos"
+
+
+def test_get_provider_is_case_insensitive():
+    with patch.dict(os.environ, {"LLM_PROVIDER": "OpenAI"}):
+        assert get_provider() == "openai"
+
+
+# --- get_llm factory ---
+
+
+def test_get_llm_logos_uses_logos_defaults():
+    with patch("langchain_openai.ChatOpenAI") as mock_chat, patch.dict(os.environ, {"LLM_PROVIDER": "logos"}, clear=False):
+        for var in ("LLM_BASE_URL", "LLM_MODEL", "LLM_TIMEOUT_SECONDS", "LLM_MAX_RETRIES"):
+            os.environ.pop(var, None)
+        get_llm()
+
+    kwargs = mock_chat.call_args.kwargs
+    assert kwargs["base_url"] == "https://logos.aet.cit.tum.de/v1"
+    assert kwargs["model"] == "openai/gpt-oss-120b"
+    assert kwargs["timeout"] == 60.0
+    assert kwargs["max_retries"] == 2
+
+
+def test_get_llm_openai_uses_openai_defaults():
+    with patch("langchain_openai.ChatOpenAI") as mock_chat, patch.dict(os.environ, {"LLM_PROVIDER": "openai"}, clear=False):
+        for var in ("LLM_BASE_URL", "LLM_MODEL"):
+            os.environ.pop(var, None)
+        get_llm()
+
+    kwargs = mock_chat.call_args.kwargs
+    assert kwargs["base_url"] == "https://api.openai.com/v1"
+    assert kwargs["model"] == "gpt-4o-mini"
+
+
+def test_get_llm_openai_compatible_reads_key_lazily():
+    # api_key is a callable so a rotated key is picked up per call, not frozen at
+    # construction; resolve it inside the patched env to prove it reads live.
+    with patch("langchain_openai.ChatOpenAI") as mock_chat, patch.dict(os.environ, {"LLM_PROVIDER": "logos", "LLM_API_KEY": "lg-secret"}):
+        get_llm()
+        api_key = mock_chat.call_args.kwargs["api_key"]
+        assert callable(api_key)
+        assert api_key() == "lg-secret"
+
+
+def test_get_llm_honours_timeout_and_retry_overrides():
+    env = {"LLM_PROVIDER": "logos", "LLM_TIMEOUT_SECONDS": "12.5", "LLM_MAX_RETRIES": "5"}
+    with patch("langchain_openai.ChatOpenAI") as mock_chat, patch.dict(os.environ, env):
+        get_llm()
+
+    kwargs = mock_chat.call_args.kwargs
+    assert kwargs["timeout"] == 12.5
+    assert kwargs["max_retries"] == 5
+
+
+def test_get_llm_ollama_uses_ollama_defaults():
+    with patch("langchain_ollama.ChatOllama") as mock_ollama, patch.dict(os.environ, {"LLM_PROVIDER": "ollama"}, clear=False):
+        for var in ("LLM_MODEL", "OLLAMA_BASE_URL"):
+            os.environ.pop(var, None)
+        get_llm()
+
+    kwargs = mock_ollama.call_args.kwargs
+    assert kwargs["base_url"] == "http://localhost:11434"
+    assert kwargs["model"] == "llama3.2"
+
+
+def test_get_llm_rejects_unknown_provider():
+    with patch.dict(os.environ, {"LLM_PROVIDER": "bogus"}):
+        with pytest.raises(ValueError, match="bogus"):
+            get_llm()
+
+
+# --- get_model_name ---
+
+
+def test_get_model_name_per_provider_defaults():
+    with patch.dict(os.environ, {"LLM_PROVIDER": "logos"}, clear=False):
+        os.environ.pop("LLM_MODEL", None)
+        assert get_model_name() == "openai/gpt-oss-120b"
+
+    with patch.dict(os.environ, {"LLM_PROVIDER": "openai"}, clear=False):
+        os.environ.pop("LLM_MODEL", None)
+        assert get_model_name() == "gpt-4o-mini"
+
+    with patch.dict(os.environ, {"LLM_PROVIDER": "ollama", "LLM_MODEL": "llama3.1"}):
+        assert get_model_name() == "llama3.1"
+
+
+def test_get_model_name_unknown_provider_returns_unknown():
+    with patch.dict(os.environ, {"LLM_PROVIDER": "bogus"}):
+        assert get_model_name() == "unknown"
 
 
 def test_model_name_read_from_plain_message_metadata():

--- a/services/genai/tests/test_main.py
+++ b/services/genai/tests/test_main.py
@@ -13,6 +13,17 @@ from app.storage import ObjectNotFoundError, UnsupportedFileError
 client = TestClient(app)
 
 
+# --- lifespan ---
+
+
+def test_lifespan_closes_weaviate_client_on_shutdown():
+    with patch("app.main.close_client") as mock_close:
+        with TestClient(app):
+            pass
+
+    mock_close.assert_called_once()
+
+
 # --- health / hello ---
 
 

--- a/services/genai/tests/test_qa.py
+++ b/services/genai/tests/test_qa.py
@@ -195,3 +195,21 @@ def test_answer_is_stripped():
         result = answer_question("q", ["doc-1"])
 
     assert result.answer == "spaced answer"
+
+
+def test_citation_snippet_is_truncated_at_word_boundary_for_long_chunk():
+    from app.qa import _SNIPPET_MAX_CHARS
+
+    long_text = "word " * 200
+    with (
+        patch("app.qa.embed_query", return_value=[0.1]),
+        patch("app.qa.search", return_value=[_hit("doc-1", 0, long_text)]),
+        patch("app.qa.get_llm", return_value=_structured_llm("answer", [1])),
+        patch("app.qa.get_model_name", return_value="m"),
+    ):
+        result = answer_question("q", ["doc-1"])
+
+    snippet = result.citations[0].snippet
+    assert snippet.endswith("...")
+    assert len(snippet) <= _SNIPPET_MAX_CHARS + len("...")
+    assert not snippet[:-3].endswith(" ")

--- a/services/genai/tests/test_search.py
+++ b/services/genai/tests/test_search.py
@@ -42,6 +42,17 @@ def test_score_is_similarity_derived_from_distance():
     assert results[0]["score"] == 0.75
 
 
+def test_score_is_zero_when_distance_is_missing():
+    with (
+        patch("app.search.embed_query", return_value=[0.0]),
+        patch("app.search.search_grouped", return_value=[_hit("doc-1", 0, "x", None)]),
+        patch("app.search.get_embedding_model_name", return_value="m"),
+    ):
+        results, _ = search_documents("q", ["doc-1"], limit=5)
+
+    assert results[0]["score"] == 0.0
+
+
 def test_score_clamps_to_zero_for_very_distant_chunks():
     with (
         patch("app.search.embed_query", return_value=[0.0]),

--- a/services/genai/tests/test_vectorstore_unit.py
+++ b/services/genai/tests/test_vectorstore_unit.py
@@ -1,0 +1,236 @@
+"""Unit tests for the Weaviate vector store with a mocked client.
+
+These complement tests/test_vectorstore.py, which exercises the real thing and
+skips without a running Weaviate. Here the client is mocked so the wiring around
+it (connection params, collection setup, insert/delete/search shaping) runs in
+CI without any live instance. No network, no gRPC.
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from weaviate.exceptions import UnexpectedStatusCodeError
+from weaviate.util import generate_uuid5
+
+from app import vectorstore
+from app.embeddings import Chunk
+
+
+def _client_and_collection() -> tuple[MagicMock, MagicMock]:
+    """A mock client whose collections.get(...) always yields the same collection."""
+    client = MagicMock()
+    collection = client.collections.get.return_value
+    return client, collection
+
+
+def _status_error() -> UnexpectedStatusCodeError:
+    response = httpx.Response(status_code=500, request=httpx.Request("POST", "http://weaviate/v1/schema"))
+    return UnexpectedStatusCodeError("create failed", response)
+
+
+# --- connection params ---
+
+
+def test_connection_params_defaults_to_in_network_weaviate():
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("WEAVIATE_URL", None)
+        os.environ.pop("WEAVIATE_GRPC_PORT", None)
+        params = vectorstore._connection_params()
+
+    assert params == {
+        "http_host": "weaviate",
+        "http_port": 8080,
+        "http_secure": False,
+        "grpc_host": "weaviate",
+        "grpc_port": 50051,
+        "grpc_secure": False,
+    }
+
+
+def test_connection_params_uses_https_port_and_secure_for_https_url():
+    with patch.dict(os.environ, {"WEAVIATE_URL": "https://vec.example.com"}, clear=False):
+        os.environ.pop("WEAVIATE_GRPC_PORT", None)
+        params = vectorstore._connection_params()
+
+    assert params["http_host"] == "vec.example.com"
+    assert params["http_port"] == 443
+    assert params["http_secure"] is True
+    assert params["grpc_secure"] is True
+
+
+def test_connection_params_honours_explicit_ports():
+    with patch.dict(os.environ, {"WEAVIATE_URL": "http://host:9999", "WEAVIATE_GRPC_PORT": "50052"}):
+        params = vectorstore._connection_params()
+
+    assert params["http_port"] == 9999
+    assert params["grpc_port"] == 50052
+
+
+# --- collection setup ---
+
+
+def test_ensure_collection_is_noop_when_it_already_exists():
+    client = MagicMock()
+    client.collections.exists.return_value = True
+
+    vectorstore._ensure_collection(client)
+
+    client.collections.create.assert_not_called()
+
+
+def test_ensure_collection_creates_it_when_absent():
+    client = MagicMock()
+    client.collections.exists.return_value = False
+
+    vectorstore._ensure_collection(client)
+
+    client.collections.create.assert_called_once()
+    assert client.collections.create.call_args.kwargs["name"] == vectorstore.COLLECTION_NAME
+
+
+def test_ensure_collection_swallows_create_race_when_now_present():
+    # First exists() says no, create loses the race and 500s, second exists() says yes.
+    client = MagicMock()
+    client.collections.exists.side_effect = [False, True]
+    client.collections.create.side_effect = _status_error()
+
+    vectorstore._ensure_collection(client)  # must not raise
+
+
+def test_ensure_collection_reraises_when_create_fails_for_real():
+    client = MagicMock()
+    client.collections.exists.side_effect = [False, False]
+    client.collections.create.side_effect = _status_error()
+
+    with pytest.raises(UnexpectedStatusCodeError):
+        vectorstore._ensure_collection(client)
+
+
+# --- chunk ids ---
+
+
+def test_chunk_uuid_is_deterministic_and_matches_weaviate_scheme():
+    assert vectorstore._chunk_uuid("doc", 0) == generate_uuid5("doc:0")
+
+
+def test_chunk_uuid_differs_per_chunk_index():
+    assert vectorstore._chunk_uuid("doc", 0) != vectorstore._chunk_uuid("doc", 1)
+
+
+# --- indexing ---
+
+
+def test_index_chunks_writes_one_object_per_chunk_after_clearing_old():
+    client, collection = _client_and_collection()
+    collection.data.insert_many.return_value.has_errors = False
+    chunks = [Chunk("doc", 0, "alpha"), Chunk("doc", 1, "beta")]
+
+    with patch("app.vectorstore._client", return_value=client):
+        written = vectorstore.index_chunks("doc", chunks, [[0.1], [0.2]])
+
+    assert written == 2
+    collection.data.delete_many.assert_called_once()  # stale chunks cleared first
+    objects = collection.data.insert_many.call_args.args[0]
+    assert [o.properties["chunk_index"] for o in objects] == [0, 1]
+    assert objects[0].uuid == generate_uuid5("doc:0")
+
+
+def test_index_chunks_with_no_chunks_clears_and_returns_zero():
+    client, collection = _client_and_collection()
+
+    with patch("app.vectorstore._client", return_value=client):
+        assert vectorstore.index_chunks("doc", [], []) == 0
+
+    collection.data.delete_many.assert_called_once()
+    collection.data.insert_many.assert_not_called()
+
+
+def test_index_chunks_raises_when_weaviate_reports_insert_errors():
+    client, collection = _client_and_collection()
+    result = collection.data.insert_many.return_value
+    result.has_errors = True
+    result.errors = {0: "boom"}
+
+    with patch("app.vectorstore._client", return_value=client):
+        with pytest.raises(RuntimeError, match="failed to index"):
+            vectorstore.index_chunks("doc", [Chunk("doc", 0, "a")], [[0.1]])
+
+
+def test_index_chunks_rejects_length_mismatch_before_touching_weaviate():
+    with patch("app.vectorstore._client", side_effect=AssertionError("must not touch weaviate")):
+        with pytest.raises(ValueError, match="length mismatch"):
+            vectorstore.index_chunks("doc", [Chunk("doc", 0, "a")], [[0.1], [0.2]])
+
+
+# --- deletion ---
+
+
+def test_delete_document_returns_successful_count():
+    client, collection = _client_and_collection()
+    collection.data.delete_many.return_value.successful = 3
+
+    with patch("app.vectorstore._client", return_value=client):
+        assert vectorstore.delete_document("doc") == 3
+
+
+# --- search ---
+
+
+def test_search_maps_objects_to_result_dicts():
+    obj = MagicMock()
+    obj.properties = {"text": "hello", "object_key": "doc", "chunk_index": 2}
+    obj.metadata.distance = 0.15
+    client, collection = _client_and_collection()
+    collection.query.near_vector.return_value.objects = [obj]
+
+    with patch("app.vectorstore._client", return_value=client):
+        hits = vectorstore.search([0.1, 0.2], ["doc"], 5)
+
+    assert hits == [{"text": "hello", "object_key": "doc", "chunk_index": 2, "distance": 0.15}]
+
+
+def test_search_grouped_returns_one_result_per_group_and_skips_empty_groups():
+    best = MagicMock()
+    best.properties = {"text": "closest", "chunk_index": 1}
+    best.metadata.distance = 0.2
+    group = MagicMock()
+    group.objects = [best]
+    group.name = "doc-1"
+    empty = MagicMock()
+    empty.objects = []
+    empty.name = "doc-2"
+
+    client, collection = _client_and_collection()
+    collection.query.near_vector.return_value.groups = {"doc-1": group, "doc-2": empty}
+
+    with patch("app.vectorstore._client", return_value=client):
+        results = vectorstore.search_grouped([0.1], ["doc-1", "doc-2"], 5)
+
+    assert results == [{"text": "closest", "object_key": "doc-1", "chunk_index": 1, "distance": 0.2}]
+
+
+# --- client lifecycle ---
+
+
+def test_close_client_is_noop_when_nothing_cached():
+    vectorstore._client.cache_clear()
+
+    vectorstore.close_client()  # must not construct or close anything
+
+
+def test_close_client_closes_and_clears_the_cached_client():
+    fake = MagicMock()
+    with patch("app.vectorstore.weaviate.connect_to_custom", return_value=fake), patch("app.vectorstore._ensure_collection"):
+        vectorstore._client.cache_clear()
+        try:
+            vectorstore._client()  # populate the cache
+            assert vectorstore._client.cache_info().currsize == 1
+
+            vectorstore.close_client()
+
+            fake.close.assert_called_once()
+            assert vectorstore._client.cache_info().currsize == 0
+        finally:
+            vectorstore._client.cache_clear()


### PR DESCRIPTION
## What does this PR do?

The GenAI service was sitting at 87% line coverage, so this fills the gaps. Most
of the untested code was the two hardest-to-reach modules: the Weaviate
`vectorstore` (only exercised by integration tests that skip without a live
Weaviate) and the `llm` provider factory. This gets the service to 100%.

New/extended tests:

- `test_vectorstore_unit.py` (new): unit tests for the vector store with a mocked
  Weaviate client, so the connection-param parsing, collection setup (including
  the create-race path), chunk id generation, and the index/delete/search/
  search_grouped/close wiring all run in CI without a live instance. These
  complement the existing integration tests rather than replacing them.
- `test_llm.py`: cover `get_llm` for logos/openai/ollama plus the unknown-provider
  error, lazy API-key resolution, timeout/retry overrides, and `get_model_name`.
- `test_env.py`: cover `float_env` (was completely untested).
- `test_errors.py` (new): cover the OpenAPI response-rewiring branch that skips
  non-operation path-item entries.
- small gaps in `test_qa.py` (long-snippet truncation), `test_search.py` (missing
  distance -> zero score), `test_embeddings.py` (unknown provider), and
  `test_main.py` (lifespan shutdown closes the Weaviate client).

Second change: CI now runs the GenAI integration tests. The `build-genai` job ran
`uv run pytest` straight on the runner, where there is no Weaviate, so the
`test_vectorstore.py` integration tests silently skipped. It now runs the suite
through the existing `genai-test` compose profile against a throwaway
`weaviate-test` container, so those tests actually execute. Coverage.xml still
lands in `services/genai` via the bind mount and feeds the coverage badge.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [x] CI / infra
- [x] Tests

## Definition of Done

- [ ] CI is green
- [ ] If the API changed: `api/openapi.yaml` is updated and lint passes (no API change)
- [x] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose run --rm genai-test` passes)
- [x] Tests added or updated for the changed behaviour
- [x] Docs updated where it matters (no doc change needed)

## Notes for the reviewer

Run it locally with `docker compose run --rm genai-test` -- 186 passed, 100%
coverage. The plain `uv run pytest` on the runner still works too, it just skips
the 4 Weaviate integration tests (that's the point of the CI change).

The vectorstore unit tests mock the client, so they check our wiring and result
shaping, not Weaviate's real behaviour; the integration tests still cover the
round-trip against a real instance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated test execution using isolated integration-test environments.
  * Ensured temporary test services are cleaned up after test runs.
  * Added coverage for safer handling of unknown providers, missing search distances, citation truncation, environment values, and application shutdown.

* **Tests**
  * Expanded validation of language-model configuration, error responses, vector search, indexing, deletion, and client lifecycle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->