### PR TITLE
Perf: Port compose resource sizing to the k8s services

### DIFF
--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -88,6 +88,51 @@ kubectl -n alexandria get svc
 kubectl -n alexandria get ingress
 ```
 
+## Resource sizing
+
+Every pod carries CPU and memory requests/limits (set in `values.yaml`) tuned to
+fit the stud cluster ResourceQuota `default-h2d5c`, which caps the alexandria
+namespace at 3250m CPU and 5144Mi memory. The quota caps limits, not requests,
+so the low-request/high-limit burst trick doesn't buy us anything here.
+
+CPU is the binding resource, so limits are tiered by how hard each service leans
+on it at startup:
+
+| Tier           | Services                          | CPU limit |
+| -------------- | --------------------------------- | --------- |
+| Slow-boot JVMs | user, knowledgebase, qa, keycloak | 550m      |
+| Mid            | genai, weaviate                   | 150m      |
+| Low            | client, postgres                  | 75-100m   |
+
+The three Spring services and Keycloak are slow-booting JVMs and get the most:
+throttled at ~200-300m, user-service took roughly 76s to boot, versus ~9s once
+it had real CPU. seaweedfs runs as four pods (master/volume/filer/s3) and is
+sized as one group at ~375m total rather than matched pod-for-pod. That lands
+the namespace at ~3150m CPU and ~5056Mi memory, just under the quota.
+
+Memory has room to spare, so the Spring services get a little extra heap
+headroom, while Keycloak and postgres keep more memory than their CPU tier
+suggests: starving the auth server or the shared DB of memory risks OOM for no
+real gain when memory isn't the binding quota.
+
+### Recreate strategy on the Spring deployments
+
+user-service, knowledgebase-service and qa-service use `strategy: Recreate`
+instead of the default rolling update. With a rolling update the surge pod runs
+next to the old one for a moment and doubles that service's (now much larger) CPU
+limit, which pushes the namespace past the 3250m quota and wedges the
+`helm upgrade`. Recreate kills the old pod before starting the new one.
+
+These are single-replica services, so this trades a few seconds of downtime per
+upgrade for a reliable rollout. That's fine here: the cluster is a student
+deployment with no availability SLA, and upgrades run on merge to main rather
+than under live load. If one of these services ever needs zero-downtime
+upgrades, raise the quota (or lower the CPU limits) and switch back to a rolling
+update with a capped `maxSurge`.
+
+genai keeps a rolling update but adds a `startupProbe` (12 x 5s, up to 60s of
+grace) so liveness and readiness don't trip while it boots (~10s).
+
 # Kubernetes Troubleshooting
 
 ### Spring or Keycloak fail postgres password authentication after a reinstall

--- a/infra/k8s/alexandria/templates/genai-deployment.yaml
+++ b/infra/k8s/alexandria/templates/genai-deployment.yaml
@@ -64,6 +64,13 @@ spec:
               mountPath: /tmp
           resources:
             {{- toYaml .Values.genai.resources | nindent 12 }}
+          startupProbe:
+            httpGet:
+              path: /genai/health
+              port: http
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 12
           livenessProbe:
             httpGet:
               path: /genai/health

--- a/infra/k8s/alexandria/templates/knowledgebase-service-deployment.yaml
+++ b/infra/k8s/alexandria/templates/knowledgebase-service-deployment.yaml
@@ -9,6 +9,10 @@ metadata:
     app.kubernetes.io/component: backend
 spec:
   replicas: {{ .Values.replicaCount }}
+  # Recreate, not rolling: a surge pod would briefly double this service's CPU
+  # limit and blow the namespace ResourceQuota, wedging the upgrade.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "alexandria.selectorLabels" . | nindent 6 }}

--- a/infra/k8s/alexandria/templates/qa-service-deployment.yaml
+++ b/infra/k8s/alexandria/templates/qa-service-deployment.yaml
@@ -9,6 +9,10 @@ metadata:
     app.kubernetes.io/component: backend
 spec:
   replicas: {{ .Values.replicaCount }}
+  # Recreate, not rolling: a surge pod would briefly double this service's CPU
+  # limit and blow the namespace ResourceQuota, wedging the upgrade.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "alexandria.selectorLabels" . | nindent 6 }}

--- a/infra/k8s/alexandria/templates/user-service-deployment.yaml
+++ b/infra/k8s/alexandria/templates/user-service-deployment.yaml
@@ -9,6 +9,10 @@ metadata:
     app.kubernetes.io/component: backend
 spec:
   replicas: {{ .Values.replicaCount }}
+  # Recreate, not rolling: a surge pod would briefly double this service's CPU
+  # limit and blow the namespace ResourceQuota, wedging the upgrade.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "alexandria.selectorLabels" . | nindent 6 }}

--- a/infra/k8s/alexandria/values.yaml
+++ b/infra/k8s/alexandria/values.yaml
@@ -27,8 +27,16 @@ spring:
     rolesClaim: "roles"
 
 # Resource limits are sized to stay under the stud cluster ResourceQuota
-# `default-h2d5c` (3250m CPU / 5144Mi memory in the alexandria namespace).
-# Prometheus + Grafana live in alexandria-monitoring with its own 750m/1000Mi
+# `default-h2d5c` (3250m CPU / 5144Mi in the alexandria namespace). The quota
+# caps limits, not requests. CPU is the binding resource, so limits are tiered
+# by how hard each service leans on it at startup: the three Spring services and
+# keycloak are slow-booting JVMs and get the most, genai and weaviate sit in the
+# middle, client/postgres/seaweedfs get the least. seaweedfs runs as four pods
+# (master/volume/filer/s3) and is sized as one group. Memory has room to spare,
+# so the Spring services get a little extra heap headroom while keycloak and
+# postgres keep more memory than their CPU tier suggests, since starving the auth
+# server or the shared DB of memory risks OOM. Totals: CPU ~3150m, memory ~5056Mi.
+# Prometheus + Grafana run in alexandria-monitoring with its own 750m/1000Mi
 # quota, sized independently below.
 userService:
   resources:
@@ -36,8 +44,8 @@ userService:
       cpu: 100m
       memory: 192Mi
     limits:
-      cpu: 200m
-      memory: 384Mi
+      cpu: 550m
+      memory: 448Mi
 
 knowledgebaseService:
   resources:
@@ -45,8 +53,8 @@ knowledgebaseService:
       cpu: 150m
       memory: 256Mi
     limits:
-      cpu: 300m
-      memory: 512Mi
+      cpu: 550m
+      memory: 576Mi
 
 qaService:
   resources:
@@ -54,8 +62,8 @@ qaService:
       cpu: 100m
       memory: 192Mi
     limits:
-      cpu: 200m
-      memory: 384Mi
+      cpu: 550m
+      memory: 448Mi
 
 client:
   resources:
@@ -63,7 +71,7 @@ client:
       cpu: 50m
       memory: 64Mi
     limits:
-      cpu: 100m
+      cpu: 75m
       memory: 128Mi
 
 genai:
@@ -84,10 +92,10 @@ genai:
   baseUrl: "http://alexandria-genai:8000"
   resources:
     requests:
-      cpu: 250m
+      cpu: 100m
       memory: 256Mi
     limits:
-      cpu: 500m
+      cpu: 150m
       memory: 512Mi
 
 weaviate:
@@ -104,7 +112,7 @@ weaviate:
       cpu: 100m
       memory: 192Mi
     limits:
-      cpu: 200m
+      cpu: 150m
       memory: 384Mi
 
 ingress:
@@ -183,7 +191,7 @@ keycloak:
       cpu: 250m
       memory: 512Mi
     limits:
-      cpu: 500m
+      cpu: 550m
       memory: 1024Mi
   initContainers:
     copyQuarkusLib:
@@ -226,10 +234,10 @@ postgres-db:
   resources:
     requests:
       memory: "384Mi"
-      cpu: "250m"
+      cpu: "75m"
     limits:
       memory: "768Mi"
-      cpu: "500m"
+      cpu: "100m"
 
 s3:
   # endpoint: override to use external S3 (e.g. AWS). Leave empty to auto-derive from release name.
@@ -254,7 +262,7 @@ seaweedfs:
         cpu: 50m
         memory: 64Mi
       limits:
-        cpu: 100m
+        cpu: 75m
         memory: 128Mi
   volume:
     enabled: true
@@ -271,7 +279,7 @@ seaweedfs:
         cpu: 50m
         memory: 128Mi
       limits:
-        cpu: 200m
+        cpu: 150m
         memory: 256Mi
   filer:
     enabled: true
@@ -285,7 +293,7 @@ seaweedfs:
         cpu: 50m
         memory: 64Mi
       limits:
-        cpu: 100m
+        cpu: 75m
         memory: 128Mi
   s3:
     enabled: true
@@ -311,5 +319,5 @@ seaweedfs:
         cpu: 50m
         memory: 64Mi
       limits:
-        cpu: 100m
+        cpu: 75m
         memory: 128Mi

--- a/infra/k8s/alexandria/values.yaml
+++ b/infra/k8s/alexandria/values.yaml
@@ -27,17 +27,10 @@ spring:
     rolesClaim: "roles"
 
 # Resource limits are sized to stay under the stud cluster ResourceQuota
-# `default-h2d5c` (3250m CPU / 5144Mi in the alexandria namespace). The quota
-# caps limits, not requests. CPU is the binding resource, so limits are tiered
-# by how hard each service leans on it at startup: the three Spring services and
-# keycloak are slow-booting JVMs and get the most, genai and weaviate sit in the
-# middle, client/postgres/seaweedfs get the least. seaweedfs runs as four pods
-# (master/volume/filer/s3) and is sized as one group. Memory has room to spare,
-# so the Spring services get a little extra heap headroom while keycloak and
-# postgres keep more memory than their CPU tier suggests, since starving the auth
-# server or the shared DB of memory risks OOM. Totals: CPU ~3150m, memory ~5056Mi.
-# Prometheus + Grafana run in alexandria-monitoring with its own 750m/1000Mi
-# quota, sized independently below.
+# `default-h2d5c` (3250m CPU / 5144Mi in the alexandria namespace). Prometheus +
+# Grafana run in alexandria-monitoring with its own 750m/1000Mi quota, sized
+# independently below. See the "Resource sizing" section in infra/k8s/README.md
+# for the per-service rationale.
 userService:
   resources:
     requests:


### PR DESCRIPTION
## What does this PR do?

Ports the resource sizing from #298 (the compose startup-speed PR) into the Helm chart. On compose the win was giving the JVM services a lot more CPU: user-service booted in ~76s at 0.25 CPU vs ~8.7s at 2.0. Our k8s Spring services sit at 200-300m limits, the same throttled regime, so they boot just as slowly on the cluster.

We can't copy compose's numbers directly. Compose asks for ~9.75 CPU across these services; the alexandria namespace ResourceQuota (`default-h2d5c`) caps `limitsCpu` at 3250m (and it caps limits, not requests, so the low-request/high-limit burst trick doesn't help). So I kept compose's per-service proportions and scaled them to fit, roughly a third of each compose value.

### CPU limits (compose value -> k8s limit)

| Service                | compose | k8s before | k8s now    |
| ---------------------- | ------- | ---------- | ---------- |
| user-service           | 2.0     | 200m       | 550m       |
| knowledgebase-service  | 2.0     | 300m       | 550m       |
| qa-service             | 2.0     | 200m       | 550m       |
| keycloak               | 2.0     | 500m       | 550m       |
| genai                  | 0.5     | 500m       | 150m       |
| weaviate               | 0.5     | 200m       | 150m       |
| client                 | 0.25    | 100m       | 75m        |
| postgres               | 0.25    | 500m       | 100m       |
| seaweedfs (s3-storage) | 0.25    | 500m total | 375m total |

The four top-tier services (the three Spring JVMs plus keycloak) land at 550m, the 0.5 tier at 150m, the 0.25 tier at 75-100m. That matches compose's shape: spring and keycloak highest, genai/weaviate mid, client/postgres/storage low. genai and postgres had their CPU requests lowered too so the request still sits under the new limit.

seaweedfs is the one thing that doesn't map cleanly: compose runs it as a single s3-storage container, the chart splits it into master/volume/filer/s3. I sized that group at 375m total rather than trying to match a single 0.25 container pod-for-pod.

New CPU total is ~3150m of 3250m.

### Memory

Compose's memory (~3456Mi across these services) already fits under the 5144Mi cap, so memory didn't need scaling. I gave the three Spring services a small bump for JVM heap room (user/qa 384 -> 448Mi, knowledgebase 512 -> 576Mi). keycloak and postgres keep their current higher k8s memory rather than dropping to compose levels, since cutting DB/auth memory risks OOM for no real gain when memory isn't the binding quota. New memory total ~5056Mi.

### Two supporting changes

- The three Spring deployments now use `strategy: Recreate`. With a rolling update the surge pod briefly runs next to the old one and doubles that service's (now much larger) CPU limit, which would push us over the 3250m quota and wedge the `helm upgrade`. Recreate kills the old pod first. These are single-replica services, so it's a short restart, not a real availability change.
- Added a `startupProbe` to genai (12 x 5s = up to 60s of grace), mirroring the compose `start_period` bump from 5s to 30s. The app takes ~10s to boot and the probe holds off liveness/readiness until it's actually up.

### What did not need porting

Most of #298 was compose-only or already true in k8s:

- Spring `depends_on: keycloak` healthy -> started: k8s Spring pods only wait on postgres (init container), never keycloak.
- Dropping `depends_on: genai` on kb/qa: no such wait exists in k8s.
- keycloak on postgres with a dedicated `keycloak` db: already how the chart runs it.
- traefik healthcheck timeouts: no traefik in k8s, we use the nginx ingress.
- playwright e2e `depends_on`: no e2e runner in the cluster.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [x] CI / infra

## Definition of Done

- [ ] CI is green
- [x] If the API changed: not applicable, no API change
- [x] If a service was added or restructured: not applicable, chart-only resource change
- [x] Tests added or updated for the changed behaviour: not applicable
- [x] Docs updated where it matters: the sizing rationale is in the values.yaml comment

## Notes for the reviewer


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GenAI startup validation to prevent traffic from reaching the service before it is ready.
  * Updated service rollout behavior to avoid temporary resource spikes that could block upgrades.

* **Performance**
  * Adjusted CPU resource allocations across platform services to better align with available capacity.
  * Increased CPU allocation for the authentication service to support its workload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->