### PR TITLE
feat(client): implement React Router

### DIFF
--- a/services/client/Dockerfile
+++ b/services/client/Dockerfile
@@ -12,6 +12,7 @@ RUN npm run build
 
 FROM nginxinc/nginx-unprivileged:stable-alpine@sha256:b3f2436575bd5be7386518084d842dac414ab4962712afa31e99e0942a56e3b2
 COPY --from=build /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \

--- a/services/client/README.md
+++ b/services/client/README.md
@@ -72,3 +72,4 @@ Notes
 - The dev Dockerfile starts Vite with --host 0.0.0.0 so the dev server is reachable from the host when running in a container.
 - The production image is based on `nginxinc/nginx-unprivileged` and serves the built files on port 8080 inside the container (Traefik in docker-compose routes to it via the internal network, no host port published by default).
 - When starting the development server, `--build --renew-anon-volumes` has to be specified.
+- The TypeScript types of `useQuery` calls (via `openapi-react-query`) are verified by the pre-commit hook, which runs `tsc --noEmit` before every commit.

--- a/services/client/nginx.conf
+++ b/services/client/nginx.conf
@@ -1,0 +1,10 @@
+server {
+    listen 8080;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/services/client/package-lock.json
+++ b/services/client/package-lock.json
@@ -15,7 +15,8 @@
         "react": "~19.2.7",
         "react-dom": "~19.2.7",
         "react-markdown": "~10.1.0",
-        "react-oidc-context": "~3.3.1"
+        "react-oidc-context": "~3.3.1",
+        "react-router": "^8.2.0"
       },
       "devDependencies": {
         "@eslint/js": "~10.0.1",
@@ -1620,6 +1621,12 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
@@ -3622,6 +3629,27 @@
       "peerDependencies": {
         "oidc-client-ts": "^3.1.0",
         "react": ">=16.14.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.2.0.tgz",
+      "integrity": "sha512-uP1LgGNHyilL1u+ZkecQk74DJOKOb6q4NLNYLRJcD/fjoogftNb5/Rj/07o/QBFsY/5MbAKPm1peTCQuVPv9cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie-es": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=22.22.0"
+      },
+      "peerDependencies": {
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/readdirp": {

--- a/services/client/package-lock.json
+++ b/services/client/package-lock.json
@@ -16,7 +16,7 @@
         "react-dom": "~19.2.7",
         "react-markdown": "~10.1.0",
         "react-oidc-context": "~3.3.1",
-        "react-router": "^8.2.0"
+        "react-router": "~8.2.0"
       },
       "devDependencies": {
         "@eslint/js": "~10.0.1",

--- a/services/client/package.json
+++ b/services/client/package.json
@@ -22,7 +22,7 @@
     "react-dom": "~19.2.7",
     "react-markdown": "~10.1.0",
     "react-oidc-context": "~3.3.1",
-    "react-router": "^8.2.0"
+    "react-router": "~8.2.0"
   },
   "devDependencies": {
     "@eslint/js": "~10.0.1",

--- a/services/client/package.json
+++ b/services/client/package.json
@@ -21,7 +21,8 @@
     "react": "~19.2.7",
     "react-dom": "~19.2.7",
     "react-markdown": "~10.1.0",
-    "react-oidc-context": "~3.3.1"
+    "react-oidc-context": "~3.3.1",
+    "react-router": "^8.2.0"
   },
   "devDependencies": {
     "@eslint/js": "~10.0.1",

--- a/services/client/src/App.tsx
+++ b/services/client/src/App.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { Routes, Route, useLocation } from "react-router";
+import React, { useEffect } from "react";
+import { Routes, Route } from "react-router";
 import { useAuth } from "react-oidc-context";
 import LoginPage from "./components/LoginPage";
 import MainView from "./components/MainView";
@@ -8,12 +8,16 @@ import QAPanel from "./components/QAPanel";
 
 function AuthGuard({ children }: { children: React.ReactNode }) {
   const auth = useAuth();
-  const location = useLocation();
-  if (auth.isLoading) return null;
-  if (!auth.isAuthenticated) {
-    void auth.signinRedirect({ state: { returnTo: location.pathname } });
-    return null;
-  }
+
+  useEffect(() => {
+    if (!auth.isLoading && !auth.isAuthenticated) {
+      auth.signinRedirect({
+        redirect_uri: window.location.href,
+      });
+    }
+  }, [auth, auth.isLoading, auth.isAuthenticated]);
+
+  if (auth.isLoading || !auth.isAuthenticated) return null;
   return <>{children}</>;
 }
 

--- a/services/client/src/App.tsx
+++ b/services/client/src/App.tsx
@@ -1,59 +1,33 @@
 import React from "react";
+import { Routes, Route, Navigate } from "react-router";
 import { useAuth } from "react-oidc-context";
+import LoginPage from "./components/LoginPage";
 import MainView from "./components/MainView";
+import DocumentDetail from "./components/DocumentDetail";
+import QAPanel from "./components/QAPanel";
+
+function AuthGuard({ children }: { children: React.ReactNode }) {
+  const auth = useAuth();
+  if (auth.isLoading) return null;
+  if (!auth.isAuthenticated) return <Navigate to="/" replace />;
+  return <>{children}</>;
+}
 
 export default function App() {
-  const auth = useAuth();
-
-  if (auth.isLoading) {
-    return (
-      <div className="app">
-        <div className="login-view">
-          <p>Loading...</p>
-        </div>
-      </div>
-    );
-  }
-
-  if (auth.error) {
-    return (
-      <div className="app">
-        <div className="login-view">
-          <h1>Alexandria</h1>
-          <p className="login-error">
-            Authentication error: {auth.error.message}
-          </p>
-          <button
-            className="login-button"
-            onClick={() => auth.signinRedirect()}
-          >
-            Try again
-          </button>
-        </div>
-      </div>
-    );
-  }
-
-  if (!auth.isAuthenticated) {
-    return (
-      <div className="app">
-        <div className="login-view">
-          <h1>Alexandria — Document Summarization</h1>
-          <p>
-            Alexandria helps users upload documents and get concise summaries,
-            extracted tags, and searchable knowledge — so reading a 40-page
-            report is no longer necessary.
-          </p>
-          <button
-            className="login-button"
-            onClick={() => auth.signinRedirect()}
-          >
-            Login
-          </button>
-        </div>
-      </div>
-    );
-  }
-
-  return <MainView />;
+  return (
+    <Routes>
+      <Route path="/" element={<LoginPage />} />
+      <Route
+        element={
+          <AuthGuard>
+            <MainView />
+          </AuthGuard>
+        }
+      >
+        <Route path="ask" element={<QAPanel />} />
+        <Route path="documents" element={<DocumentDetail />} />
+        <Route path="documents/:id" element={<DocumentDetail />} />
+      </Route>
+    </Routes>
+  );
 }

--- a/services/client/src/App.tsx
+++ b/services/client/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import { Routes, Route } from "react-router";
+import { Routes, Route, Navigate } from "react-router";
 import { useAuth } from "react-oidc-context";
 import LoginPage from "./components/LoginPage";
 import MainView from "./components/MainView";
@@ -17,7 +17,7 @@ function AuthGuard({ children }: { children: React.ReactNode }) {
     }
   }, [auth, auth.isLoading, auth.isAuthenticated]);
 
-  if (auth.isLoading || !auth.isAuthenticated) return null;
+  if (auth.isLoading || !auth.isAuthenticated) return <h2>Redirecting...</h2>;
   return <>{children}</>;
 }
 
@@ -36,6 +36,7 @@ export default function App() {
         <Route path="documents" element={<DocumentDetail />} />
         <Route path="documents/:id" element={<DocumentDetail />} />
       </Route>
+      <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>
   );
 }

--- a/services/client/src/App.tsx
+++ b/services/client/src/App.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Routes, Route, Navigate } from "react-router";
+import { Routes, Route, useLocation } from "react-router";
 import { useAuth } from "react-oidc-context";
 import LoginPage from "./components/LoginPage";
 import MainView from "./components/MainView";
@@ -8,8 +8,12 @@ import QAPanel from "./components/QAPanel";
 
 function AuthGuard({ children }: { children: React.ReactNode }) {
   const auth = useAuth();
+  const location = useLocation();
   if (auth.isLoading) return null;
-  if (!auth.isAuthenticated) return <Navigate to="/" replace />;
+  if (!auth.isAuthenticated) {
+    void auth.signinRedirect({ state: { returnTo: location.pathname } });
+    return null;
+  }
   return <>{children}</>;
 }
 

--- a/services/client/src/components/DocumentDetail.tsx
+++ b/services/client/src/components/DocumentDetail.tsx
@@ -1,11 +1,8 @@
 import React, { useEffect, useState } from "react";
 import ReactMarkdown from "react-markdown";
+import { useParams } from "react-router";
 import $api from "../api/client";
 import { formatDateTime } from "../utils/format";
-
-interface Props {
-  documentId: string | null;
-}
 
 const ENTITY_TYPE_LABELS: Record<string, string> = {
   PERSON: "Person",
@@ -21,7 +18,8 @@ function formatBytes(bytes?: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-export default function DocumentDetail({ documentId }: Props) {
+export default function DocumentDetail() {
+  const { id: documentId = null } = useParams<{ id: string }>();
   const {
     data: document,
     isLoading,

--- a/services/client/src/components/DocumentTree.tsx
+++ b/services/client/src/components/DocumentTree.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useNavigate, useParams } from "react-router";
+import { Link, useNavigate, useParams } from "react-router";
 import UploadDocument from "./UploadDocument";
 import type { components } from "../api/schema";
 import { formatDate } from "../utils/format";
@@ -18,14 +18,10 @@ export default function DocumentTree({ documents, isLoading, error }: Props) {
   const errorMessage =
     error instanceof Error ? error.message : error ? String(error) : "";
 
-  function handleSelect(id: string) {
-    void navigate(`/documents/${id}`);
-  }
-
   return (
     <nav className="document-tree" aria-label="Document list">
       <h2 className="tree-heading">Documents</h2>
-      <UploadDocument onUploaded={handleSelect} />
+      <UploadDocument onUploaded={(id) => void navigate(`/documents/${id}`)} />
       {isLoading && <p className="tree-status">Loading…</p>}
       {!!error && (
         <p
@@ -54,16 +50,14 @@ export default function DocumentTree({ documents, isLoading, error }: Props) {
               <li
                 key={id}
                 className={`tree-item${selectedId === id ? " tree-item--active" : ""}`}
-                onClick={() => handleSelect(id)}
-                role="button"
-                tabIndex={0}
-                onKeyDown={(e) => e.key === "Enter" && handleSelect(id)}
                 aria-current={selectedId === id ? "true" : undefined}
               >
-                <span className="tree-item__name">{doc.fileName}</span>
-                <span className="tree-item__date">
-                  {formatDate(doc.createdAt)}
-                </span>
+                <Link to={`/documents/${id}`} className="tree-item__link">
+                  <span className="tree-item__name">{doc.fileName}</span>
+                  <span className="tree-item__date">
+                    {formatDate(doc.createdAt)}
+                  </span>
+                </Link>
               </li>
             );
           })}

--- a/services/client/src/components/DocumentTree.tsx
+++ b/services/client/src/components/DocumentTree.tsx
@@ -50,9 +50,8 @@ export default function DocumentTree({ documents, isLoading, error }: Props) {
               <li
                 key={id}
                 className={`tree-item${selectedId === id ? " tree-item--active" : ""}`}
-                aria-current={selectedId === id ? "true" : undefined}
               >
-                <Link to={`/documents/${id}`} className="tree-item__link">
+                <Link to={`/documents/${id}`} className="tree-item__link" aria-current={selectedId === id ? "true" : undefined}>
                   <span className="tree-item__name">{doc.fileName}</span>
                   <span className="tree-item__date">
                     {formatDate(doc.createdAt)}

--- a/services/client/src/components/DocumentTree.tsx
+++ b/services/client/src/components/DocumentTree.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useNavigate, useParams } from "react-router";
 import UploadDocument from "./UploadDocument";
 import type { components } from "../api/schema";
 import { formatDate } from "../utils/format";
@@ -6,27 +7,25 @@ import { formatDate } from "../utils/format";
 type Document = components["schemas"]["Document"];
 
 interface Props {
-  selectedId: string | null;
-  onSelect: (id: string) => void;
   documents: Document[] | undefined;
   isLoading: boolean;
   error: unknown;
 }
 
-export default function DocumentTree({
-  selectedId,
-  onSelect,
-  documents,
-  isLoading,
-  error,
-}: Props) {
+export default function DocumentTree({ documents, isLoading, error }: Props) {
+  const navigate = useNavigate();
+  const { id: selectedId } = useParams<{ id: string }>();
   const errorMessage =
     error instanceof Error ? error.message : error ? String(error) : "";
+
+  function handleSelect(id: string) {
+    void navigate(`/documents/${id}`);
+  }
 
   return (
     <nav className="document-tree" aria-label="Document list">
       <h2 className="tree-heading">Documents</h2>
-      <UploadDocument onUploaded={onSelect} />
+      <UploadDocument onUploaded={handleSelect} />
       {isLoading && <p className="tree-status">Loading…</p>}
       {!!error && (
         <p
@@ -55,10 +54,10 @@ export default function DocumentTree({
               <li
                 key={id}
                 className={`tree-item${selectedId === id ? " tree-item--active" : ""}`}
-                onClick={() => onSelect(id)}
+                onClick={() => handleSelect(id)}
                 role="button"
                 tabIndex={0}
-                onKeyDown={(e) => e.key === "Enter" && onSelect(id)}
+                onKeyDown={(e) => e.key === "Enter" && handleSelect(id)}
                 aria-current={selectedId === id ? "true" : undefined}
               >
                 <span className="tree-item__name">{doc.fileName}</span>

--- a/services/client/src/components/LoginPage.tsx
+++ b/services/client/src/components/LoginPage.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { Navigate } from "react-router";
+import { useAuth } from "react-oidc-context";
+
+export default function LoginPage() {
+  const auth = useAuth();
+
+  if (auth.isAuthenticated) {
+    return <Navigate to="/ask" replace />;
+  }
+
+  if (auth.isLoading) {
+    return (
+      <div className="app">
+        <div className="login-view">
+          <p>Loading...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (auth.error) {
+    return (
+      <div className="app">
+        <div className="login-view">
+          <h1>Alexandria</h1>
+          <p className="login-error">
+            Authentication error: {auth.error.message}
+          </p>
+          <button
+            className="login-button"
+            onClick={() => auth.signinRedirect()}
+          >
+            Try again
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="app">
+      <div className="login-view">
+        <h1>Alexandria — Document Summarization</h1>
+        <p>
+          Alexandria helps users upload documents and get concise summaries,
+          extracted tags, and searchable knowledge — so reading a 40-page
+          report is no longer necessary.
+        </p>
+        <button
+          className="login-button"
+          onClick={() => auth.signinRedirect()}
+        >
+          Login
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/services/client/src/components/MainView.tsx
+++ b/services/client/src/components/MainView.tsx
@@ -1,18 +1,11 @@
-import React, { useState } from "react";
+import React from "react";
+import { NavLink, Outlet } from "react-router";
 import { useAuth } from "react-oidc-context";
 import DocumentTree from "./DocumentTree";
-import DocumentDetail from "./DocumentDetail";
 import $api from "../api/client";
-import QAPanel from "./QAPanel";
-
-type AppTab = "documents" | "qa";
 
 export default function MainView() {
   const auth = useAuth();
-  const [selectedDocumentId, setSelectedDocumentId] = useState<string | null>(
-    null,
-  );
-  const [activeTab, setActiveTab] = useState<AppTab>("qa");
 
   const {
     data: documents,
@@ -20,31 +13,31 @@ export default function MainView() {
     error: documentsError,
   } = $api.useQuery("get", "/api/v1/knowledgebase/documents");
 
-  function handleSelectDocument(id: string) {
-    setSelectedDocumentId(id);
-    setActiveTab("documents");
-  }
-
   return (
     <div className="app">
       <header className="app-header">
         <div className="app-header-top">
           <h1>Alexandria</h1>
           <nav className="app-header-nav">
-            <button
-              className={`app-tab${activeTab === "qa" ? " app-tab--active" : ""}`}
-              onClick={() => setActiveTab("qa")}
+            <NavLink
+              to="/ask"
+              className={({ isActive }) =>
+                `app-tab${isActive ? " app-tab--active" : ""}`
+              }
             >
               <span className="app-tab__label">Ask</span>
               <span className="app-tab__sizer">Ask</span>
-            </button>
-            <button
-              className={`app-tab${activeTab === "documents" ? " app-tab--active" : ""}`}
-              onClick={() => setActiveTab("documents")}
+            </NavLink>
+            <NavLink
+              to="/documents"
+              end={false}
+              className={({ isActive }) =>
+                `app-tab${isActive ? " app-tab--active" : ""}`
+              }
             >
               <span className="app-tab__label">Documents</span>
               <span className="app-tab__sizer">Documents</span>
-            </button>
+            </NavLink>
           </nav>
           <div className="user-info">
             <span className="user-name">
@@ -58,30 +51,12 @@ export default function MainView() {
       </header>
       <div className="app-body">
         <DocumentTree
-          selectedId={selectedDocumentId}
-          onSelect={handleSelectDocument}
           documents={documents}
           isLoading={documentsLoading}
           error={documentsError}
         />
         <main className="app-main">
-          <div
-            id="tab-panel-documents"
-            className="app-tab-content"
-            hidden={activeTab !== "documents"}
-          >
-            <DocumentDetail documentId={selectedDocumentId} />
-          </div>
-          <div
-            id="tab-panel-qa"
-            className="app-tab-content"
-            hidden={activeTab !== "qa"}
-          >
-            <QAPanel
-              documents={documents ?? []}
-              onSelectDocument={handleSelectDocument}
-            />
-          </div>
+          <Outlet />
         </main>
       </div>
     </div>

--- a/services/client/src/components/MainView.tsx
+++ b/services/client/src/components/MainView.tsx
@@ -30,7 +30,6 @@ export default function MainView() {
             </NavLink>
             <NavLink
               to="/documents"
-              end={false}
               className={({ isActive }) =>
                 `app-tab${isActive ? " app-tab--active" : ""}`
               }

--- a/services/client/src/components/QAPanel.tsx
+++ b/services/client/src/components/QAPanel.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
+import { Link } from "react-router";
 import $api from "../api/client";
 import type { components } from "../api/schema";
 import { useQueryClient } from "@tanstack/react-query";
@@ -7,11 +8,6 @@ import { formatDateTime } from "../utils/format";
 
 type QAInteraction = components["schemas"]["QAInteraction"];
 type Document = components["schemas"]["Document"];
-
-interface Props {
-  documents: Document[];
-  onSelectDocument: (documentId: string) => void;
-}
 
 /**
  * Maps a fetch error to a user-facing message. Extracting the error code and
@@ -49,11 +45,16 @@ function findDocumentByKey(
   return documents.find((doc) => doc.objectKey === key);
 }
 
-export default function QAPanel({ documents, onSelectDocument }: Props) {
+export default function QAPanel() {
   const queryClient = useQueryClient();
   const [question, setQuestion] = useState("");
   const [interactions, setInteractions] = useState<QAInteraction[]>([]);
   const historyLoaded = useRef(false);
+
+  const { data: documents = [] } = $api.useQuery(
+    "get",
+    "/api/v1/knowledgebase/documents",
+  );
 
   const {
     data: historyData,
@@ -203,14 +204,13 @@ export default function QAPanel({ documents, onSelectDocument }: Props) {
                         className="qa-source-item"
                       >
                         {docId ? (
-                          <button
-                            type="button"
+                          <Link
+                            to={`/documents/${docId}`}
                             className="qa-source-link"
-                            onClick={() => onSelectDocument(docId)}
                             title={citation.snippet ?? key}
                           >
                             {name}
-                          </button>
+                          </Link>
                         ) : (
                           <span
                             className="qa-source-link qa-source-link--unresolved"

--- a/services/client/src/main.tsx
+++ b/services/client/src/main.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
+import { BrowserRouter } from "react-router";
 import { AuthProvider } from "react-oidc-context";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import App from "./App";
@@ -37,9 +38,11 @@ if (!rootElement) throw new Error("Root element not found");
 
 const root = createRoot(rootElement);
 root.render(
-  <QueryClientProvider client={queryClient}>
-    <AuthProvider {...authConfig}>
-      <App />
-    </AuthProvider>
-  </QueryClientProvider>,
+  <BrowserRouter>
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider {...authConfig}>
+        <App />
+      </AuthProvider>
+    </QueryClientProvider>
+  </BrowserRouter>,
 );

--- a/services/client/src/main.tsx
+++ b/services/client/src/main.tsx
@@ -23,9 +23,13 @@ const queryClient = new QueryClient({
 
 const authConfig = {
   ...oidcConfig,
-  onSigninCallback: () => {
-    // Remove OIDC query params from URL after successful login.
-    window.history.replaceState({}, document.title, window.location.pathname);
+  onSigninCallback: (user: unknown) => {
+    // After login, restore the deep-link path saved in the OIDC state, or
+    // fall back to /ask.
+    const returnTo =
+      (user as { state?: { returnTo?: string } } | null)?.state?.returnTo ??
+      "/ask";
+    window.history.replaceState({}, document.title, returnTo);
     queryClient.invalidateQueries();
   },
   onSignoutCallback: () => {

--- a/services/client/src/main.tsx
+++ b/services/client/src/main.tsx
@@ -23,13 +23,8 @@ const queryClient = new QueryClient({
 
 const authConfig = {
   ...oidcConfig,
-  onSigninCallback: (user: unknown) => {
-    // After login, restore the deep-link path saved in the OIDC state, or
-    // fall back to /ask.
-    const returnTo =
-      (user as { state?: { returnTo?: string } } | null)?.state?.returnTo ??
-      "/ask";
-    window.history.replaceState({}, document.title, returnTo);
+  onSigninCallback: () => {
+    window.history.replaceState({}, document.title, window.location.pathname);
     queryClient.invalidateQueries();
   },
   onSignoutCallback: () => {

--- a/services/client/src/styles/_layout.scss
+++ b/services/client/src/styles/_layout.scss
@@ -61,6 +61,7 @@ body {
     background: none;
     border: none;
     cursor: pointer;
+    text-decoration: none;
     transition: color 0.12s;
 
     // Both spans sit in the same grid cell so the button is always as wide

--- a/services/client/src/styles/_sidebar.scss
+++ b/services/client/src/styles/_sidebar.scss
@@ -66,6 +66,14 @@
         border-left-color: $color-primary;
     }
 
+    &__link {
+        display: flex;
+        flex-direction: column;
+        gap: 0.15rem;
+        text-decoration: none;
+        color: inherit;
+    }
+
     &__name {
         font-size: 0.9rem;
         font-weight: 500;

--- a/services/client/tests/app.spec.ts
+++ b/services/client/tests/app.spec.ts
@@ -19,7 +19,7 @@ test.describe("Alexandria client", () => {
       },
       { key: storageKey, value: JSON.stringify(oidcUser) },
     );
-    await page.goto("/");
+    await page.goto("/ask");
   });
 
   test.describe("Page metadata", () => {
@@ -267,7 +267,7 @@ test.describe("Alexandria client", () => {
         },
       );
 
-      await page.goto("/");
+      await page.goto("/ask");
 
       // No documents yet — tree list should be absent or status shown
       await expect(page.locator(".tree-item")).toHaveCount(0, {
@@ -327,6 +327,7 @@ test.describe("Alexandria client", () => {
     test("shows a placeholder when no document is selected", async ({
       page,
     }) => {
+      await page.goto("/documents");
       const main = page.locator("main.app-main");
       await expect(main).toBeVisible();
       await expect(main).toContainText(
@@ -381,7 +382,7 @@ test.describe("Alexandria client", () => {
           }),
       );
 
-      await page.goto("/");
+      await page.goto("/ask");
 
       // The document item should appear in the tree
       const docItem = page.locator(".tree-item").first();
@@ -441,7 +442,7 @@ test.describe("Alexandria client", () => {
           }),
       );
 
-      await page.goto("/");
+      await page.goto("/ask");
 
       const docItem = page.locator(".tree-item").first();
       await expect(docItem).toBeVisible({ timeout: 5000 });
@@ -470,7 +471,7 @@ test.describe("Alexandria client", () => {
     });
 
     test("Ask tab is active by default on load", async ({ page }) => {
-      await page.goto("/");
+      await page.goto("/ask");
 
       // Scope to the header nav to avoid matching the .qa-submit "Ask" button
       const askTab = page
@@ -485,7 +486,7 @@ test.describe("Alexandria client", () => {
     });
 
     test("Q&A panel renders input and submit button", async ({ page }) => {
-      await page.goto("/");
+      await page.goto("/ask");
 
       const input = page.locator(".qa-input");
       await expect(input).toBeVisible();
@@ -496,7 +497,7 @@ test.describe("Alexandria client", () => {
     });
 
     test("shows empty state when there is no history", async ({ page }) => {
-      await page.goto("/");
+      await page.goto("/ask");
 
       const empty = page.locator(".qa-empty");
       await expect(empty).toBeVisible({ timeout: 5000 });
@@ -521,7 +522,7 @@ test.describe("Alexandria client", () => {
         }),
       );
 
-      await page.goto("/");
+      await page.goto("/ask");
 
       await page.locator(".qa-input").fill("What is the main topic?");
       await page.locator(".qa-submit").click();
@@ -552,7 +553,7 @@ test.describe("Alexandria client", () => {
         });
       });
 
-      await page.goto("/");
+      await page.goto("/ask");
       await page.locator(".qa-input").fill("Slow question?");
       await page.locator(".qa-submit").click();
 
@@ -577,7 +578,7 @@ test.describe("Alexandria client", () => {
         }),
       );
 
-      await page.goto("/");
+      await page.goto("/ask");
       await page.locator(".qa-input").fill("When was it published?");
       await page.locator(".qa-submit").click();
 
@@ -635,7 +636,7 @@ test.describe("Alexandria client", () => {
         }),
       );
 
-      await page.goto("/");
+      await page.goto("/ask");
       await page.locator(".qa-input").fill("What does the report say?");
       await page.locator(".qa-submit").click();
 
@@ -678,7 +679,7 @@ test.describe("Alexandria client", () => {
         }),
       );
 
-      await page.goto("/");
+      await page.goto("/ask");
       await page.locator(".qa-input").fill("What is this?");
       await page.locator(".qa-submit").click();
 
@@ -687,7 +688,7 @@ test.describe("Alexandria client", () => {
       await expect(sourceLink).toHaveText("mystery.pdf");
     });
 
-    test("clicking a resolved source switches to Documents tab and selects the document", async ({
+    test("clicking a resolved source navigates to the document detail route", async ({
       page,
     }) => {
       const docId = "00000000-0000-0000-0000-000000000011";
@@ -754,7 +755,7 @@ test.describe("Alexandria client", () => {
         }),
       );
 
-      await page.goto("/");
+      await page.goto("/ask");
       await page.locator(".qa-input").fill("What is in the guide?");
       await page.locator(".qa-submit").click();
 
@@ -762,8 +763,10 @@ test.describe("Alexandria client", () => {
       await expect(sourceLink).toBeVisible({ timeout: 5000 });
       await sourceLink.click();
 
-      // Documents tab should now be active
-      const documentsTab = page.getByRole("button", { name: "Documents" });
+      // Documents tab link should now be active
+      const documentsTab = page
+        .locator(".app-header-nav .app-tab")
+        .filter({ hasText: "Documents" });
       await expect(documentsTab).toHaveClass(/app-tab--active/, {
         timeout: 3000,
       });
@@ -796,7 +799,7 @@ test.describe("Alexandria client", () => {
         }),
       );
 
-      await page.goto("/");
+      await page.goto("/ask");
 
       const interaction = page.locator(".qa-interaction").first();
       await expect(interaction).toBeVisible({ timeout: 5000 });
@@ -813,7 +816,7 @@ test.describe("Alexandria client", () => {
         route.fulfill({ status: 500, body: "Internal Server Error" }),
       );
 
-      await page.goto("/");
+      await page.goto("/ask");
       await page.locator(".qa-input").fill("This will fail.");
       await page.locator(".qa-submit").click();
 
@@ -833,7 +836,7 @@ test.describe("Alexandria client", () => {
         route.fulfill({ status: 401, body: "Unauthorized" }),
       );
 
-      await page.goto("/");
+      await page.goto("/ask");
       await page.locator(".qa-input").fill("Auth check question.");
       await page.locator(".qa-submit").click();
 
@@ -842,10 +845,8 @@ test.describe("Alexandria client", () => {
       await expect(error).toHaveText("Authentication error. Retrying login...");
     });
 
-    test("Documents tab button switches back to document view", async ({
-      page,
-    }) => {
-      await page.goto("/");
+    test("Documents tab link switches to document view", async ({ page }) => {
+      await page.goto("/ask");
 
       // Scope to the header nav to avoid matching the .qa-submit "Ask" button
       const askTab = page
@@ -907,7 +908,7 @@ test.describe("Alexandria client", () => {
         }
       });
 
-      await page.goto("/");
+      await page.goto("/ask");
 
       // Both interactions should be visible
       await expect(page.locator(".qa-interaction")).toHaveCount(2, {


### PR DESCRIPTION
## What does this PR do?

Replaces the in-memory tab state in `MainView` with React Router. The app now has real URLs:

- `/`: login / loading / error page
- `/ask`: Q&A panel (default after login)
- `/documents`: document detail (empty state)
- `/documents/:id`: document detail for a specific document

Tab links are `<NavLink>` elements. Components read their context from the URL (`useParams`, `useNavigate`) instead of receiving callbacks as props. An `AuthGuard` layout route redirects unauthenticated users to `/`. A custom `nginx.conf` adds `try_files` so deep routes are served correctly.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / cleanup
- [ ] Docs
- [ ] CI / infra

## Definition of Done

- [ ] CI is green
- [ ] If the API changed: `api/openapi.yaml` is updated and lint passes
- [x] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [x] Tests added or updated for the changed behaviour
- [x] Docs updated where it matters (README, ADRs, comments)

## Notes for the reviewer

`nginx.conf` is new — required for the SPA to work on direct navigation or page refresh to any route other than `/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Implemented route-driven navigation for Ask, Documents, and document detail pages.
  - Added an authentication-gated login flow with loading, error, and redirect handling.
  - Document selection and resolved-source actions now open the corresponding document route.
  - Updated the web server configuration to support SPA-friendly refreshes.
- **Bug Fixes**
  - Removed unwanted text underlines in navigation/tab styling.
- **Documentation**
  - Noted that a pre-commit hook validates TypeScript types for query usage.
- **Tests**
  - Updated Playwright navigation/setup to start from the current routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->