### PR TITLE
Perf: Trim Spring services' JVM memory footprint

### DIFF
--- a/services/spring/Dockerfile
+++ b/services/spring/Dockerfile
@@ -42,7 +42,7 @@ RUN chown -R appuser:appgroup /app
 USER appuser
 
 # JVM settings tuned for a small resident footprint
-ENV JAVA_TOOL_OPTIONS="-XX:InitialRAMPercentage=5 -XX:MaxRAMPercentage=75 -XX:MaxHeapFreeRatio=25 -Xss512k -XX:TieredStopAtLevel=1 -XX:+ExitOnOutOfMemoryError"
+ENV JAVA_TOOL_OPTIONS="-XX:InitialRAMPercentage=5 -XX:MaxRAMPercentage=75 -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=25 -Xss512k -XX:TieredStopAtLevel=1 -XX:+ExitOnOutOfMemoryError"
 
 EXPOSE 8080
 

--- a/services/spring/Dockerfile
+++ b/services/spring/Dockerfile
@@ -41,8 +41,8 @@ RUN chown -R appuser:appgroup /app
 
 USER appuser
 
-# JVM settings
-ENV JAVA_TOOL_OPTIONS="-XX:MaxRAMPercentage=75 -XX:+ExitOnOutOfMemoryError"
+# JVM settings tuned for a small resident footprint
+ENV JAVA_TOOL_OPTIONS="-XX:InitialRAMPercentage=5 -XX:MaxRAMPercentage=75 -XX:MaxHeapFreeRatio=25 -Xss512k -XX:TieredStopAtLevel=1 -XX:+ExitOnOutOfMemoryError"
 
 EXPOSE 8080
 

--- a/services/spring/knowledgebase-service/src/main/resources/application.properties
+++ b/services/spring/knowledgebase-service/src/main/resources/application.properties
@@ -11,6 +11,12 @@ springdoc.swagger-ui.path=/knowledgebase-service/docs
 spring.datasource.url=jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}?currentSchema=knowledgebase_service
 spring.datasource.username=${POSTGRES_USER}
 spring.datasource.password=${POSTGRES_PASSWORD}
+# Trim the thread and connection pools to shrink the memory footprint. This is a
+# low-traffic service, so the Boot defaults (200 Tomcat threads, 10 DB
+# connections) reserve far more than we ever use.
+server.tomcat.threads.max=10
+server.tomcat.threads.min-spare=1
+spring.datasource.hikari.maximum-pool-size=3
 # Flyway owns the schema, Hibernate only verifies it matches entities
 spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.properties.hibernate.default_schema=knowledgebase_service

--- a/services/spring/qa-service/src/main/resources/application.properties
+++ b/services/spring/qa-service/src/main/resources/application.properties
@@ -11,6 +11,12 @@ springdoc.swagger-ui.path=/qa-service/docs
 spring.datasource.url=jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}?currentSchema=qa_service
 spring.datasource.username=${POSTGRES_USER}
 spring.datasource.password=${POSTGRES_PASSWORD}
+# Trim the thread and connection pools to shrink the memory footprint. This is a
+# low-traffic service, so the Boot defaults (200 Tomcat threads, 10 DB
+# connections) reserve far more than we ever use.
+server.tomcat.threads.max=10
+server.tomcat.threads.min-spare=1
+spring.datasource.hikari.maximum-pool-size=3
 # Flyway owns the schema, Hibernate only verifies it matches entities
 spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.properties.hibernate.default_schema=qa_service

--- a/services/spring/user-service/src/main/resources/application.properties
+++ b/services/spring/user-service/src/main/resources/application.properties
@@ -11,6 +11,12 @@ springdoc.swagger-ui.path=/user-service/docs
 spring.datasource.url=jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}?currentSchema=user_service
 spring.datasource.username=${POSTGRES_USER}
 spring.datasource.password=${POSTGRES_PASSWORD}
+# Trim the thread and connection pools to shrink the memory footprint. This is a
+# low-traffic service, so the Boot defaults (200 Tomcat threads, 10 DB
+# connections) reserve far more than we ever use.
+server.tomcat.threads.max=10
+server.tomcat.threads.min-spare=1
+spring.datasource.hikari.maximum-pool-size=3
 # Flyway owns the schema, Hibernate only verifies it matches entities
 spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.properties.hibernate.default_schema=user_service


### PR DESCRIPTION
## What does this PR do?

Trims the resident memory of the three Spring services by about 20 MiB each, with JVM and pool tuning only. No behaviour change, no experimental flags.

Where the memory actually goes (measured on a running user-service via the Actuator `jvm_memory_committed_bytes`): heap is only ~51 MiB, while Metaspace + Compressed Class Space is ~113 MiB and CodeCache ~8 MiB. Most of the footprint is class metadata, which no JVM flag shrinks, so this is only a modest win, not a big one.

What moves the number, in `services/spring/Dockerfile` (shared by all three services):

- `-XX:InitialRAMPercentage=5`: start the heap small and let it grow on demand instead of committing a big heap up front.
- `-XX:MaxHeapFreeRatio=25`: after a GC, shrink the heap back and hand the freed pages to the OS rather than holding them.
- `-XX:TieredStopAtLevel=1`: C1-only JIT keeps the code cache at ~8 MiB instead of ~25.
- `-Xss512k`: smaller stack per thread.

`-XX:MaxRAMPercentage=75` and `-XX:+ExitOnOutOfMemoryError` are unchanged.

And the pools, in each `application.properties`: Tomcat 200 -> 10 max threads (min-spare 1), Hikari 10 -> 3 connections. These are low-traffic services, the defaults reserve far more than we use, and fewer DB connections also eases postgres.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / cleanup
- [ ] Docs
- [ ] CI / infra

## Definition of Done

- [ ] CI is green
- [x] If the API changed: not applicable, no API change
- [x] If a service was added or restructured: not applicable, config-only change, compose still comes up
- [x] Tests added or updated for the changed behaviour: not applicable, no behaviour change
- [x] Docs updated where it matters: rationale is in the Dockerfile and properties comments

## Notes for the reviewer

- Roughly 20 MiB per service in `docker compose stats`. It's capped by metaspace (the classes Spring loads), which flags can't touch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced memory usage for Spring services by tuning JVM runtime settings.
  * Added limits for web server threads and database connection pools to improve resource efficiency, especially for low-traffic services.
* **Reliability**
  * Preserved existing health checks, ports, startup behavior, and service access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->