### PR TITLE
Infra: Recreate for Spring deployments and genai startup probe

### DIFF
--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -107,6 +107,19 @@ When a service's autoscaling is enabled the HPA owns the replica count, so the s
 kubectl -n alexandria get hpa
 ```
 
+## Rollout strategy
+
+The three Spring deployments (user, knowledgebase, qa) use `strategy: Recreate`
+instead of the default rolling update while they run as a single replica (i.e.
+autoscaling disabled, as above). The alexandria namespace runs under a
+ResourceQuota that caps limits, and a rolling update briefly starts a second pod
+whose limits stack on top of the running one. That can trip the quota and leave
+`helm upgrade` wedged, which has happened to us before. Recreate stops the old
+pod first. The tradeoff is a few seconds of downtime per upgrade, fine for
+single-replica services on the student cluster (no availability SLA, upgrades
+run on merge to main). With autoscaling enabled the deployments keep the rolling
+update, since multiple replicas are expected there.
+
 ## Rationale on Static Scrape Config
 
 We run our own Prometheus and Grafana as plain deployments and feed Prometheus a static scrape config from a ConfigMap (`templates/prometheus-config.yaml`), rather than using the Prometheus operator with ServiceMonitor/PodMonitor and PrometheusRule CRDs.

--- a/infra/k8s/alexandria/templates/genai-deployment.yaml
+++ b/infra/k8s/alexandria/templates/genai-deployment.yaml
@@ -66,6 +66,13 @@ spec:
               mountPath: /tmp
           resources:
             {{- toYaml .Values.genai.resources | nindent 12 }}
+          startupProbe:
+            httpGet:
+              path: /genai/health
+              port: http
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 12
           livenessProbe:
             httpGet:
               path: /genai/health

--- a/infra/k8s/alexandria/templates/knowledgebase-service-deployment.yaml
+++ b/infra/k8s/alexandria/templates/knowledgebase-service-deployment.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   {{- if not .Values.knowledgebaseService.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: Recreate
   {{- end }}
   selector:
     matchLabels:

--- a/infra/k8s/alexandria/templates/qa-service-deployment.yaml
+++ b/infra/k8s/alexandria/templates/qa-service-deployment.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   {{- if not .Values.qaService.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: Recreate
   {{- end }}
   selector:
     matchLabels:

--- a/infra/k8s/alexandria/templates/user-service-deployment.yaml
+++ b/infra/k8s/alexandria/templates/user-service-deployment.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   {{- if not .Values.userService.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: Recreate
   {{- end }}
   selector:
     matchLabels:


### PR DESCRIPTION
## What does this PR do?

Two small robustness tweaks to the Alexandria Helm chart.

The three Spring deployments (user, knowledgebase, qa) now use `strategy: Recreate` instead of the default rolling update, but only while they run as a single replica (autoscaling disabled). The alexandria namespace sits under a ResourceQuota that caps limits, and a rolling update briefly starts a second pod whose limits stack on top of the running one. That can trip the quota and leave `helm upgrade` wedged, which has happened to us. Recreate stops the old pod before starting the new one. The strategy sits inside the same `autoscaling.enabled` guard as `replicas`, so once a service scales out on HPA it keeps the rolling update, where multiple replicas are expected anyway.

genai gets a `startupProbe` on `/genai/health` (12 x 5s, up to 60s of grace) so a slow boot doesn't get killed by the liveness check before the app is actually up.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [x] CI / infra

## Definition of Done

- [ ] CI is green
- [x] If the API changed: not applicable, no API change
- [x] If a service was added or restructured: not applicable, chart-only change
- [x] Tests added or updated for the changed behaviour: not applicable
- [x] Docs updated where it matters: added a "Rollout strategy" note to `infra/k8s/README.md`

## Notes for the reviewer

The Recreate trade-off is a few seconds of downtime per upgrade on the single-replica Spring services. That's on purpose, rationale is in the README note. If any of them ever needs zero-downtime upgrades, enabling its HPA already flips it back to a rolling update.
