### PR TITLE
CI: Publish API docs to GitHub Pages via Redoc

### DIFF
--- a/.github/workflows/deploy-api-docs.yml
+++ b/.github/workflows/deploy-api-docs.yml
@@ -1,0 +1,65 @@
+# Publish the merged OpenAPI spec as a Redoc site on GitHub Pages.
+#
+# api/openapi.yaml is the single source of truth, so that's what gets
+# rendered. Runs on pushes to main that touch the spec (plus manual
+# dispatch). Nothing is committed: the HTML is built fresh each run and
+# handed straight to the Pages deployment.
+
+name: Deploy API Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "api/openapi.yaml"
+      - ".github/workflows/deploy-api-docs.yml"
+  workflow_dispatch:
+
+# Only checkout needs anything here; the deploy job asks for the rest itself.
+permissions:
+  contents: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build Redoc HTML
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      - name: Build Docs
+        run: |
+          mkdir -p site
+          npx --yes @redocly/cli@2.38.0 build-docs api/openapi.yaml \
+            --output site/index.html \
+            --title "Alexandria API Reference"
+
+      - name: Upload Pages Artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: site
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write # to publish the Pages deployment
+      id-token: write # to prove the deployment came from this workflow
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/deploy-api-docs.yml
+++ b/.github/workflows/deploy-api-docs.yml
@@ -52,6 +52,7 @@ jobs:
   deploy:
     name: Deploy to GitHub Pages
     needs: build
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       pages: write # to publish the Pages deployment

--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ Alexandria consists of three main subsystems orchestrated via Docker Compose and
 
 ## Setup
 
+### API Documentation
+
+The REST API is documented from `api/openapi.yaml`, our single source of truth. A Redoc render is published to GitHub Pages whenever the spec changes on main:
+
+https://aet-devops26.github.io/team-bnd/
+
+The per-service Swagger UIs are also available locally through Traefik (see the routes below).
+
 ### Traefik Reverse Proxy
 
 All services are accessed through Traefik as the reverse proxy. See [`docs/traefik.md`](docs/traefik.md) for architecture, routing, and configuration details.


### PR DESCRIPTION
## What does this PR do?

Adds a GitHub Pages deployment for our API docs, ticking the "doc automation: OpenAPI docs published with Redoc to GH Pages" item from #219.

A new `Deploy API Docs` workflow renders the merged `api/openapi.yaml` (our single source of truth) into a standalone Redoc HTML page with `@redocly/cli build-docs`, then publishes it via `actions/upload-pages-artifact` + `actions/deploy-pages`. It runs on pushes to main that touch the spec, plus manual dispatch. Nothing generated is committed, the HTML is built fresh each run.

README gets a short API Documentation section pointing at the published site.

One-time setup needed before this works: enable Pages in repo Settings with source "GitHub Actions". Once that's done and this lands on main, the docs go live at https://aet-devops26.github.io/team-bnd/

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [x] CI / infra

## Definition of Done

- [x] CI is green
- [x] If the API changed: `api/openapi.yaml` is updated and lint passes (spec unchanged here, only rendered)
- [ ] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [ ] Tests added or updated for the changed behaviour
- [x] Docs updated where it matters (README, ADRs, comments)

## Notes for the reviewer

- Pages must be enabled once in Settings (source: GitHub Actions), otherwise the deploy job errors out.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated publishing of API documentation to GitHub Pages.
  * API documentation updates are generated when the API specification changes, with manual publishing also available.

* **Documentation**
  * Added setup guidance linking to the API specification and published documentation.
  * Documented how to access service-specific Swagger UIs locally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->