### PR TITLE
Chore: Re-enable Azure Deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -857,11 +857,6 @@ jobs:
 
   # ---------------------------------------------------------------------
   # Deploy to Azure VM
-  #
-  # Currently disabled: Our Azure for Students credit expired and the VM is gone.
-  # Everything below is kept intact. To re-enable, set the repo variable
-  # DEPLOY_AZURE to 'true' and make sure the AZURE_PUBLIC_IP / AZURE_USER vars
-  # and the AZURE_PRIVATE_KEY secret are set again.
   # ---------------------------------------------------------------------
   deploy:
     name: Deploy to Azure VM

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ All services are accessed through Traefik as the reverse proxy. See [`docs/traef
 
 ### Infrastructure & Deployment
 
-- **Azure VM (Terraform + Ansible)**: _Currently disabled_ since our Azure for Students credit expired. The config is kept under [`infra/azure/README.md`](infra/azure/README.md) and can be brought back later again.
+- **Azure VM (Terraform + Ansible)**: Provisioning details live under [`infra/azure/README.md`](infra/azure/README.md).
 - **Kubernetes (Helm)**: Cluster deployment and troubleshooting details live under [`infra/k8s/README.md`](infra/k8s/README.md).
 
 ### Git Repository


### PR DESCRIPTION
## What does this PR do?

Re-enable the Azure deployment with a new account after it was disabled in #271.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [X] CI / infra

## Definition of Done

- [x] CI is green
- [ ] If the API changed: `api/openapi.yaml` is updated and lint passes
- [ ] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [ ] Tests added or updated for the changed behaviour
- [X] Docs updated where it matters (README, ADRs, comments)

## Notes for the reviewer

<!-- Anything they should look at first, gotchas, screenshots, ... -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Azure VM deployment documentation to remove outdated disabled-status messaging.
  * Clarified where Azure provisioning details can be found.
  * Removed obsolete CI configuration comments without changing deployment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->