### PR TITLE
GenAI: add opt-in OpenTelemetry tracing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,6 +78,12 @@
 # WEAVIATE_URL=http://weaviate:8080
 # WEAVIATE_GRPC_PORT=50051
 
+# OpenTelemetry tracing (opt-in). Tracing stays off until an OTLP endpoint is set.
+# The docker-compose.tracing.yml overlay sets these to a local Jaeger for you, so
+# you only need them here to point at a different collector.
+# OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4318
+# OTEL_SERVICE_NAME=alexandria-genai
+
 
 # ----------------------------------------------------------------------------------
 # OpenID Connect

--- a/README.md
+++ b/README.md
@@ -104,3 +104,13 @@ Prometheus scrapes metrics from each Spring service (`/actuator/prometheus`, one
 - Prometheus: http://localhost/prometheus/
 
 Dashboards are provisioned automatically under the "Alexandria" folder: an overview (request rate, errors, latency across services), an aggregate Spring dashboard plus one per Spring service (JVM, GC, threads, DB pool), a GenAI dashboard (request rate, latency, process memory), and an object storage dashboard (S3 request rate and latency, in-flight requests, disk usage). Dashboard JSON and the Prometheus scrape and alert config live under [`infra/prometheus`](infra/prometheus) and [`infra/grafana`](infra/grafana).
+
+#### Tracing (opt-in)
+
+The GenAI service can emit OpenTelemetry traces so you can see where a request spends its time, the query embedding vs. the LLM call. It's off by default; bring it up with the tracing overlay, which adds a local Jaeger and points GenAI at it:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.tracing.yml up
+```
+
+Jaeger UI is then at http://localhost/jaeger/ (service `alexandria-genai`). Details are in [`services/genai/README.md`](services/genai/README.md#tracing).

--- a/docker-compose.tracing.yml
+++ b/docker-compose.tracing.yml
@@ -1,0 +1,40 @@
+# Opt-in tracing overlay. Adds a local Jaeger and points the GenAI service's
+# OTLP exporter at it. Not part of the default stack, bring it up explicitly:
+#
+#   docker compose -f docker-compose.yml -f docker-compose.tracing.yml up
+#
+# Then open http://localhost/jaeger/, pick the "alexandria-genai" service, and
+# hit an AI endpoint (summarize, ask, search) to generate traces. Each request
+# shows up with its model/embedding calls as child spans.
+
+services:
+  genai:
+    environment:
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://jaeger:4318}
+      OTEL_SERVICE_NAME: ${OTEL_SERVICE_NAME:-alexandria-genai}
+    depends_on:
+      jaeger:
+        condition: service_started
+
+  jaeger:
+    image: jaegertracing/all-in-one:1.62.0
+    container_name: jaeger
+    # kics-scan ignore-block
+    environment:
+      COLLECTOR_OTLP_ENABLED: "true"
+      # Serve the UI under /jaeger so Traefik can route it like the other tools.
+      QUERY_BASE_PATH: /jaeger
+    restart: unless-stopped
+    networks:
+      - alexandria
+    deploy:
+      resources:
+        limits:
+          cpus: "0.50"
+          memory: 512M
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.jaeger.rule=PathPrefix(`/jaeger`)"
+      - "traefik.http.routers.jaeger.entrypoints=web"
+      - "traefik.http.routers.jaeger.priority=10"
+      - "traefik.http.services.jaeger.loadbalancer.server.port=16686"

--- a/services/genai/README.md
+++ b/services/genai/README.md
@@ -67,6 +67,27 @@ The service also exposes the shared `application_version` gauge (same as the Spr
 
 The `model` label comes from the same provider response as `modelUsed`. The Grafana GenAI dashboard (`infra/grafana/dashboards/genai.json`) charts model call rate by model/provider, call outcomes, per-operation model latency, and truncations. The `GenAiSlowModelCalls` and `GenAiModelErrors` alerts (`infra/prometheus/alert.rules.yml`) fire per operation, so a slow or failing chat model isn't masked by fast embedding calls.
 
+## Tracing
+
+Metrics tell you _that_ `/genai/ask` is slow; a trace tells you _where_ the time went, the query embedding or the chat call. The service can export OpenTelemetry traces so each request shows up as a span tree: the FastAPI request span with the model and embedding calls nested underneath.
+
+Tracing is opt-in and off by default. It only activates when `OTEL_EXPORTER_OTLP_ENDPOINT` is set; otherwise the spans run on OpenTelemetry's no-op tracer and nothing is exported. The `docker-compose.tracing.yml` overlay wires it to a local Jaeger:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.tracing.yml up
+```
+
+Then open http://localhost/jaeger/, pick the `alexandria-genai` service, and exercise an AI endpoint (summarize, ask, search). The `/genai/health` and `/genai/metrics` endpoints are excluded so the constant probe and scrape traffic doesn't bury the real work.
+
+Instrumentation lives in `app/tracing.py` (setup and FastAPI instrumentation) and `app/model_calls.py` (one span per model/embedding call). The model spans carry OpenTelemetry GenAI attributes: `gen_ai.operation.name` (`chat`/`embedding`), `gen_ai.system` (the provider), `gen_ai.request.model`, `gen_ai.response.model`, plus a `genai.outcome` (`ok`/`error`/`timeout`) that mirrors the metric status label; failures also record the exception and set the span status to error.
+
+We deliberately stopped at request and model-call spans rather than pulling in a LangChain callback integration, which doesn't support langchain 1.x yet. The single `run_model_call` chokepoint already wraps every provider call, so that is where the span lives.
+
+| Variable                      | Default            | Description                                                  |
+| ----------------------------- | ------------------ | ------------------------------------------------------------ |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | _(unset)_          | OTLP HTTP collector base URL. When unset, tracing stays off. |
+| `OTEL_SERVICE_NAME`           | `alexandria-genai` | Service name shown in the trace UI.                          |
+
 ## LLM configuration
 
 The service is configured entirely via environment variables. Copy `.env.example` to `.env` and fill in your key.

--- a/services/genai/app/main.py
+++ b/services/genai/app/main.py
@@ -16,6 +16,7 @@ from app.search import search_documents
 from app.storage import ObjectNotFoundError, UnsupportedFileError, fetch_text
 from app.summarize import summarize
 from app.tag import generate_tags
+from app.tracing import setup_tracing
 from app.vectorstore import close_client, delete_document, index_chunks
 
 SERVICE_NAME = "alexandria-genai"
@@ -53,6 +54,9 @@ Instrumentator(should_group_untemplated=True).instrument(app).expose(
     include_in_schema=False,
     tags=["metrics"],
 )
+
+# Opt-in: only exports when OTEL_EXPORTER_OTLP_ENDPOINT is set (docker-compose.tracing.yml), else a no-op.
+setup_tracing(app, service_name=SERVICE_NAME, service_version=SERVICE_VERSION)
 
 # Render errors as the shared {code, message, fieldErrors} shape, in responses
 # and in the generated spec.

--- a/services/genai/app/model_calls.py
+++ b/services/genai/app/model_calls.py
@@ -9,6 +9,9 @@ structured 502/504 rather than an unhandled 500.
 import time
 from collections.abc import Callable
 
+from opentelemetry import trace
+from opentelemetry.trace import Status, StatusCode
+
 from app.errors import ProviderError, ProviderTimeoutError
 from app.metrics import record_model_call
 
@@ -46,18 +49,34 @@ def run_model_call[T](
 
     Returns ``(result, model_name)``. Raises ProviderTimeoutError on a timeout,
     ProviderError on any other failure.
+
+    Wraps the call in a span so a trace shows the model call as its own step
+    under the request; the span is a no-op unless tracing is enabled.
     """
-    start = time.perf_counter()
-    try:
-        result = call()
-    except Exception as exc:
+    tracer = trace.get_tracer(__name__)
+    with tracer.start_as_current_span(f"genai.{operation}") as span:
+        # gen_ai.* keys follow OpenTelemetry's GenAI semantic conventions.
+        span.set_attribute("gen_ai.operation.name", operation)
+        span.set_attribute("gen_ai.system", provider)
+        span.set_attribute("gen_ai.request.model", fallback_model)
+
+        start = time.perf_counter()
+        try:
+            result = call()
+        except Exception as exc:
+            duration = time.perf_counter() - start
+            status = "timeout" if _is_timeout(exc) else "error"
+            span.set_attribute("genai.outcome", status)
+            span.record_exception(exc)
+            span.set_status(Status(StatusCode.ERROR))
+            record_model_call(operation, provider, fallback_model, status, duration)
+            if status == "timeout":
+                raise ProviderTimeoutError() from exc
+            raise ProviderError() from exc
+
         duration = time.perf_counter() - start
-        if _is_timeout(exc):
-            record_model_call(operation, provider, fallback_model, "timeout", duration)
-            raise ProviderTimeoutError() from exc
-        record_model_call(operation, provider, fallback_model, "error", duration)
-        raise ProviderError() from exc
-    duration = time.perf_counter() - start
-    model = model_resolver(result) if model_resolver else fallback_model
-    record_model_call(operation, provider, model, "ok", duration)
-    return result, model
+        model = model_resolver(result) if model_resolver else fallback_model
+        span.set_attribute("gen_ai.response.model", model)
+        span.set_attribute("genai.outcome", "ok")
+        record_model_call(operation, provider, model, "ok", duration)
+        return result, model

--- a/services/genai/app/tracing.py
+++ b/services/genai/app/tracing.py
@@ -1,0 +1,57 @@
+"""OpenTelemetry tracing setup for the GenAI service.
+
+Tracing is opt-in. Unless ``OTEL_EXPORTER_OTLP_ENDPOINT`` is set the service
+keeps the default no-op tracer, so the spans created around model calls (see
+app/model_calls.py) cost effectively nothing and nothing is exported. Point that
+variable at a collector to turn it on; the docker-compose.tracing.yml overlay
+wires it to a local Jaeger.
+
+The instrumentation is intentionally shallow: FastAPI request spans plus one
+span per model/embedding call. That is enough to see where a slow /genai/ask
+goes -- the query embed versus the chat call -- without a LangChain callback
+integration, which doesn't support langchain 1.x yet.
+"""
+
+import os
+
+from fastapi import FastAPI
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+# The Prometheus scrape and the health probe fire on a timer and would bury the
+# actual AI work, so we don't open a span for them.
+_EXCLUDED_URLS = "genai/metrics,genai/health"
+
+
+def tracing_enabled() -> bool:
+    """Return whether an OTLP endpoint is configured (tracing is opt-in)."""
+    return bool(os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT"))
+
+
+def setup_tracing(app: FastAPI, *, service_name: str, service_version: str) -> None:
+    """Export OTLP traces and instrument FastAPI when an endpoint is configured.
+
+    A no-op when ``OTEL_EXPORTER_OTLP_ENDPOINT`` is unset, so the default stack
+    and the test suite never try to reach a collector. ``OTEL_SERVICE_NAME``
+    overrides the service name that shows up in the trace UI.
+    """
+    if not tracing_enabled():
+        return
+
+    resource = Resource.create(
+        {
+            "service.name": os.getenv("OTEL_SERVICE_NAME", service_name),
+            "service.version": service_version,
+        }
+    )
+    provider = TracerProvider(resource=resource)
+    # The exporter reads the endpoint (and any headers) from the standard OTEL_*
+    # environment variables, so the collector address lives in compose, not here.
+    provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+    trace.set_tracer_provider(provider)
+
+    FastAPIInstrumentor.instrument_app(app, excluded_urls=_EXCLUDED_URLS)

--- a/services/genai/pyproject.toml
+++ b/services/genai/pyproject.toml
@@ -18,6 +18,9 @@ dependencies = [
     "boto3~=1.43.44",
     "pypdf~=6.14.2",
     "weaviate-client~=4.22.0",
+    "opentelemetry-sdk~=1.43.0",
+    "opentelemetry-exporter-otlp-proto-http~=1.43.0",
+    "opentelemetry-instrumentation-fastapi~=0.64b0",
 ]
 
 [dependency-groups]

--- a/services/genai/tests/test_model_calls.py
+++ b/services/genai/tests/test_model_calls.py
@@ -1,9 +1,24 @@
 """Unit tests for the model-call instrumentation wrapper."""
 
 import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import StatusCode
 
+from app import model_calls
 from app.errors import ProviderError, ProviderTimeoutError
 from app.model_calls import run_model_call
+
+
+@pytest.fixture
+def span_exporter(monkeypatch):
+    """Route the wrapper's spans into an in-memory exporter for assertions."""
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    monkeypatch.setattr(model_calls.trace, "get_tracer", lambda *args, **kwargs: provider.get_tracer("test"))
+    return exporter
 
 
 def test_success_returns_result_and_configured_model():
@@ -65,3 +80,53 @@ def test_timeout_detected_through_the_cause_chain():
 
     with pytest.raises(ProviderTimeoutError):
         run_model_call(slow, operation="chat", provider="logos", fallback_model="cfg")
+
+
+# --- tracing spans ---
+
+
+def test_success_records_span_with_model_attributes(span_exporter):
+    run_model_call(
+        lambda: "value",
+        operation="chat",
+        provider="logos",
+        fallback_model="cfg-model",
+        model_resolver=lambda _: "served-model",
+    )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.name == "genai.chat"
+    assert span.attributes["gen_ai.operation.name"] == "chat"
+    assert span.attributes["gen_ai.system"] == "logos"
+    assert span.attributes["gen_ai.request.model"] == "cfg-model"
+    assert span.attributes["gen_ai.response.model"] == "served-model"
+    assert span.attributes["genai.outcome"] == "ok"
+    # success leaves the status unset; only failures are marked as errors
+    assert span.status.status_code == StatusCode.UNSET
+
+
+def test_failure_span_marks_error_and_records_exception(span_exporter):
+    def boom():
+        raise RuntimeError("bad gateway response")
+
+    with pytest.raises(ProviderError):
+        run_model_call(boom, operation="embedding", provider="openai", fallback_model="cfg")
+
+    span = span_exporter.get_finished_spans()[0]
+    assert span.attributes["genai.outcome"] == "error"
+    assert span.status.status_code == StatusCode.ERROR
+    assert any(event.name == "exception" for event in span.events)
+
+
+def test_timeout_span_marks_outcome_timeout(span_exporter):
+    def slow():
+        raise TimeoutError("timed out")
+
+    with pytest.raises(ProviderTimeoutError):
+        run_model_call(slow, operation="chat", provider="logos", fallback_model="cfg")
+
+    span = span_exporter.get_finished_spans()[0]
+    assert span.attributes["genai.outcome"] == "timeout"
+    assert span.status.status_code == StatusCode.ERROR

--- a/services/genai/tests/test_tracing.py
+++ b/services/genai/tests/test_tracing.py
@@ -1,0 +1,48 @@
+"""Tests for the opt-in OpenTelemetry tracing setup."""
+
+from unittest.mock import patch
+
+from fastapi import FastAPI
+
+from app import tracing
+
+
+def test_tracing_disabled_without_endpoint(monkeypatch):
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    assert tracing.tracing_enabled() is False
+
+
+def test_tracing_enabled_with_endpoint(monkeypatch):
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://jaeger:4318")
+    assert tracing.tracing_enabled() is True
+
+
+def test_setup_tracing_is_noop_when_disabled(monkeypatch):
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    with (
+        patch.object(tracing, "FastAPIInstrumentor") as instrumentor,
+        patch.object(tracing.trace, "set_tracer_provider") as set_provider,
+    ):
+        tracing.setup_tracing(FastAPI(), service_name="svc", service_version="1.0.0")
+
+    instrumentor.instrument_app.assert_not_called()
+    set_provider.assert_not_called()
+
+
+def test_setup_tracing_wires_exporter_and_instrumentation_when_enabled(monkeypatch):
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://jaeger:4318")
+    with (
+        patch.object(tracing, "OTLPSpanExporter") as exporter,
+        patch.object(tracing, "BatchSpanProcessor") as processor,
+        patch.object(tracing, "TracerProvider") as provider_cls,
+        patch.object(tracing.trace, "set_tracer_provider") as set_provider,
+        patch.object(tracing, "FastAPIInstrumentor") as instrumentor,
+    ):
+        tracing.setup_tracing(FastAPI(), service_name="svc", service_version="1.0.0")
+
+    exporter.assert_called_once()
+    provider = provider_cls.return_value
+    provider.add_span_processor.assert_called_once_with(processor.return_value)
+    set_provider.assert_called_once_with(provider)
+    instrumentor.instrument_app.assert_called_once()
+    assert "excluded_urls" in instrumentor.instrument_app.call_args.kwargs

--- a/services/genai/uv.lock
+++ b/services/genai/uv.lock
@@ -12,6 +12,9 @@ dependencies = [
     { name = "langchain-ollama" },
     { name = "langchain-openai" },
     { name = "langchain-text-splitters" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-instrumentation-fastapi" },
+    { name = "opentelemetry-sdk" },
     { name = "prometheus-client" },
     { name = "prometheus-fastapi-instrumentator" },
     { name = "pydantic" },
@@ -36,6 +39,9 @@ requires-dist = [
     { name = "langchain-ollama", specifier = "~=1.1.0" },
     { name = "langchain-openai", specifier = "~=1.3.4" },
     { name = "langchain-text-splitters", specifier = "~=1.1.2" },
+    { name = "opentelemetry-exporter-otlp-proto-http", specifier = "~=1.43.0" },
+    { name = "opentelemetry-instrumentation-fastapi", specifier = "~=0.64b0" },
+    { name = "opentelemetry-sdk", specifier = "~=1.43.0" },
     { name = "prometheus-client", specifier = "~=0.25.0" },
     { name = "prometheus-fastapi-instrumentator", specifier = "~=8.0.2" },
     { name = "pydantic", specifier = "~=2.13.4" },
@@ -81,6 +87,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3b/72/5562aabb8dd7181e8e860622a38bea08d17842b99ecd4c91f84ac95251b0/anyio-4.14.1.tar.gz", hash = "sha256:8d648a3544c1a700e3ff78615cd679e4c5c3f149904287e73687b2596963629e", size = 254831, upload-time = "2026-06-24T20:56:06.017Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/7b/90df4a0a816d98d6ea26f559d87836d494a2cf1fcf063be67df50a7bcc30/anyio-4.14.1-py3-none-any.whl", hash = "sha256:4e5533c5b8ff0a24f5d7a176cbe6877129cd183893f66b537f8f227d10527d72", size = 124875, upload-time = "2026-06-24T20:56:04.413Z" },
+]
+
+[[package]]
+name = "asgiref"
+version = "3.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/26/3b59f2bdae5f640389becb1f673cded775287f5fc4f816309d9ca9a3f93d/asgiref-3.12.1.tar.gz", hash = "sha256:59dcb51c272ad209d59bed5708a64a333083e86017d7fcdd67498eeab7784340", size = 42378, upload-time = "2026-07-14T09:56:18.087Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/1b/54f4ad77cd8a584fa70746c47df988e002cf1ee1eba43364d46f87803647/asgiref-3.12.1-py3-none-any.whl", hash = "sha256:fe386d1c2bff7259ea95929266d12a8cf9a8b5a1c2598402967d8792e7a7c094", size = 25478, upload-time = "2026-07-14T09:56:16.926Z" },
 ]
 
 [[package]]
@@ -336,6 +351,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d3/af/a5f50ccfa659ec1802cb4ca842c23f06d906a8cc9aef6016a2caeea3d4ed/fastapi-0.139.0.tar.gz", hash = "sha256:99ab7b2d92223c76d6cf10757ab3f89d45b38267fc20b2a136cf02f6beac3145", size = 423016, upload-time = "2026-07-01T16:35:33.436Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/7c/8e3c6ad324ea5cb36604fc3f968554887891c316d9dfde57761611d907ad/fastapi-0.139.0-py3-none-any.whl", hash = "sha256:cf15e1e9e667ddb0ad63811e60bd11390d1aac838ca4a7a23f421807b2308189", size = 130339, upload-time = "2026-07-01T16:35:32.19Z" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
 ]
 
 [[package]]
@@ -668,6 +695,143 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/49/f5/7c7cb955305cb41f7f3c5fd7e0e38bf6bbf2658468863d4b7b868a5cb8df/openai-2.44.0.tar.gz", hash = "sha256:68a5a5ffad82b8ff7d451c437529fb64f7c3b8123aaf0c021966a882d9e3947d", size = 988753, upload-time = "2026-06-24T20:56:02.293Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ae/f4/561ed79fd94876160018a5e75254cfcb9b0e62d4dded9dcb20072e86d623/openai-2.44.0-py3-none-any.whl", hash = "sha256:0a2a3ab2e29aeda368700f662ff9ba0f9df17ba4c54577a64e08b8115a3cc0ad", size = 1366216, upload-time = "2026-06-24T20:55:58.882Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/cc/e4c9584181f86494df0f6bdec1a4f3280c50db44704dc2a407e994fc87bb/opentelemetry_api-1.43.0.tar.gz", hash = "sha256:107d0d03857ea8fc7c5fcbbbd83f800c281f0d560553d61c1d675fccfd1761c1", size = 73476, upload-time = "2026-06-24T15:19:55.323Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/83/6dba32b85f31868400440dc7ad2ca1eab94cbbf3a7b0459ed39f8311a9e2/opentelemetry_api-1.43.0-py3-none-any.whl", hash = "sha256:20acf45e9b21851926835292e4045d290acade1edd2ff3de86d2f069687ba1fd", size = 61912, upload-time = "2026-06-24T15:19:35.434Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/c1/e8098490ab15abf116dcaf9fa89ededcb35547c7d08d4b5a62f573dc1e63/opentelemetry_exporter_otlp_proto_common-1.43.0.tar.gz", hash = "sha256:c4e32ba6d6b13bdb2b8f6764c4fd28d00192826561aa04f6d14eedfce7ac076f", size = 20197, upload-time = "2026-06-24T15:20:00.247Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/b2/41ebc74ae1d5859901f1b69305de58724bf043381103d6ef413521cbc35a/opentelemetry_exporter_otlp_proto_common-1.43.0-py3-none-any.whl", hash = "sha256:123c3f9cc87218562490c63b36f497bf3a722faf174a515d1443f31ababa6264", size = 17048, upload-time = "2026-06-24T15:19:41.264Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/92/0b9f56412483a8891d4843890294796c9df8ab42417bd9bad8035d840cb3/opentelemetry_exporter_otlp_proto_http-1.43.0.tar.gz", hash = "sha256:fa8a42bb7d00ee5391f4c0b04d8e6a46c03caa437903296ab73a81dc11ba118f", size = 25406, upload-time = "2026-06-24T15:20:01.515Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/20/b685ed7af2e17c29ffc8af56f1fa8bc2033258fc30fb0d2b722f49d13ba0/opentelemetry_exporter_otlp_proto_http-1.43.0-py3-none-any.whl", hash = "sha256:647f603aa8efdbdb4dbff842e0729d0406a6fff26b295a72d3d60e7d963b2610", size = 21795, upload-time = "2026-06-24T15:19:43.164Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation"
+version = "0.64b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "packaging" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/97/02fe6e1c8b1ffac42d0b429c18080edb24e0e0d18c86612edf72b5752382/opentelemetry_instrumentation-0.64b0.tar.gz", hash = "sha256:b47d528dead6271d7743114417eb67fc915bd9258111c48dbf9a4951d2efa88d", size = 41935, upload-time = "2026-06-24T15:19:12.951Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/0c/cb9fe342de5299c7af24582eb7d788661cc53a1c4b904da92309caaa9417/opentelemetry_instrumentation-0.64b0-py3-none-any.whl", hash = "sha256:133ab7ffca796557aec059bf6be3190a34b6dea987f25be3d9409e230cbdad8b", size = 35880, upload-time = "2026-06-24T15:18:17.277Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-asgi"
+version = "0.64b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/85/0c/71c696fccb86d37af383ea1604af4729fabad0af2fabaf203e4c79c1e859/opentelemetry_instrumentation_asgi-0.64b0.tar.gz", hash = "sha256:4dd3eee566a4303f8e6b9b84f2a0a7abc57a6640df768926c68a3868bf5b2090", size = 26136, upload-time = "2026-06-24T15:19:17.003Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/20/218b65a63d847a7ed28d1bea84c39234689160b74480b8702272e37f4240/opentelemetry_instrumentation_asgi-0.64b0-py3-none-any.whl", hash = "sha256:e0840b66e15303a9254b0540946010bd008aa0504f4d89b8e1b7fb63490a36f0", size = 15906, upload-time = "2026-06-24T15:18:23.107Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-fastapi"
+version = "0.64b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-asgi" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/a1/52282e2cc5c08f4df13b087896d9907258fe2ff4f34035d3b21aa92684c3/opentelemetry_instrumentation_fastapi-0.64b0.tar.gz", hash = "sha256:05f75149929e433c1630de381688e650bf651c1e1cce7f9a7b649a807dac8a98", size = 26236, upload-time = "2026-06-24T15:19:27.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/2d/4f48dc2d6f289f2febc5b871940dbea9f3b04ab9186d23342581b49cb984/opentelemetry_instrumentation_fastapi-0.64b0-py3-none-any.whl", hash = "sha256:43cbbfb2d3079dc81104478a2950ae93ac6d0e90a5020fa3987a236f8f2bdef1", size = 13263, upload-time = "2026-06-24T15:18:38.553Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/b9/d357faefb40bda1d4799913e6af611171ff22a2dedcb93576bc92242d056/opentelemetry_proto-1.43.0.tar.gz", hash = "sha256:224778df17e1f3fafeaaa21d874236ca5f6ffc2f86e0899298ec7351aac27924", size = 46481, upload-time = "2026-06-24T15:20:07.625Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/a7/3e5308cf548b8f72529c7db1afdb3a404211982376a12927fd7759f77bf3/opentelemetry_proto-1.43.0-py3-none-any.whl", hash = "sha256:c58f1f7ef84bc7dc2834016c0c37fe0081dde7ca9f6339be1970fbf9cdaaa90d", size = 72489, upload-time = "2026-06-24T15:19:51.164Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/eb/5041074274ac0956b03637cc039d434569112468e875eddfcc9a0674ce06/opentelemetry_sdk-1.43.0.tar.gz", hash = "sha256:d8187c81c162df9913e4003dd6485f7390d9a24fc17026ec7387b8b8218b08e9", size = 254744, upload-time = "2026-06-24T15:20:08.467Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/e3/b17be23af124201c9f52eececd4cc8ddfed1597d37b4ee771895d325805c/opentelemetry_sdk-1.43.0-py3-none-any.whl", hash = "sha256:d1323a547c1ce69d6a069a17a44b7da82bb8b332051ecb074041f87642c86823", size = 178852, upload-time = "2026-06-24T15:19:52.169Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.64b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/30/5f26df29509eccd86b99b481ac9ffa39da49ba9577cc69071c552ae30447/opentelemetry_semantic_conventions-0.64b0.tar.gz", hash = "sha256:72f76fb2d1582d9d033dd1fcd84532e961e6ff3d90d24ba6fabc72975a83864c", size = 148340, upload-time = "2026-06-24T15:20:09.267Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/ca/23ba87a221b574a7c5a99d48849d80bfe8b047624681357e2b002e566187/opentelemetry_semantic_conventions-0.64b0-py3-none-any.whl", hash = "sha256:ea77e85e354b8f604ddbe5f3d9135216f982fa4d77e5859ac30f6d8a50505aa6", size = 203713, upload-time = "2026-06-24T15:19:53.339Z" },
+]
+
+[[package]]
+name = "opentelemetry-util-http"
+version = "0.64b0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/1b/1029a805fd7242f7dfce91633b244c3b14a94d703232878f71e01ce862b1/opentelemetry_util_http-0.64b0.tar.gz", hash = "sha256:8a86a220dbfc56d736f47f1e5c4e7932a21fcf69052312e1bcf166444dc79322", size = 11102, upload-time = "2026-06-24T15:19:48.974Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/c7/5f8ec5b30546f2dc22cd5fc5759bce2ab5be6e89a2e710a405ac9ef64ed3/opentelemetry_util_http-0.64b0-py3-none-any.whl", hash = "sha256:c1e5350d25507c1afcd6076cf9ac062485a0a4f79cd9971366996fd3056bacdb", size = 8204, upload-time = "2026-06-24T15:19:09.02Z" },
 ]
 
 [[package]]
@@ -1295,6 +1459,37 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
     { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/a4/282c8e64300a59fc834518a54bf0afabb4ff9218b5fa76958b450459a844/wrapt-2.2.2.tar.gz", hash = "sha256:0788e321027c999bf221b667bd4a54aaefd1a36283749a860ac3eb77daed0302", size = 129068, upload-time = "2026-06-20T23:49:44.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/05/7fd9c3f83b2c74cbfc572a0b88aa37431e04bd8aed70d2c0efd3464206de/wrapt-2.2.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0e64826f920c42d9d9f87e8cc09ffae66c51ede12d59061a5a426deb9aa71745", size = 81341, upload-time = "2026-06-20T23:48:49.39Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/68/1bfa43100dd90d4ef74a05897b86275cf57e1313ca14aae2545bc9f872c9/wrapt-2.2.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:dcaa5e1451bd8751d7bd1568dfa3321c78092a52a7ecb5d1a0f18a5791e1fd00", size = 81921, upload-time = "2026-06-20T23:48:50.986Z" },
+    { url = "https://files.pythonhosted.org/packages/74/eb/df7b7f0b631dbbc750f39be27d8b55f65777d8ac86da80e12be41a644c4b/wrapt-2.2.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0abfd648dac9ac9c5b3aa9b523d27f1789046640b58dcd5652a720ddb325e1fc", size = 167713, upload-time = "2026-06-20T23:48:52.598Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/9a/d1bd36f6d088c8e652a9383cabbd49af30b8c576302a7eccddbab6963e3f/wrapt-2.2.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f4bfd8d1eb438153eff8b8cfe87f032ba65731e1ce06138b5090f745a33f6f95", size = 166779, upload-time = "2026-06-20T23:48:54.33Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/ae/24ffacd4187fac2740a1972093929e836dea092d42c87d728cd98fee11a6/wrapt-2.2.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c427c9d06d859848a69f0d928fe28b5c33a941b2265d10a0e1f15cd244f1ee33", size = 158407, upload-time = "2026-06-20T23:48:55.944Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ed/974427668249a356051e8d67d47fa54ef6c777f0fcf3bae9d292c047d4b6/wrapt-2.2.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4250b43d1a129d947e083c4dc6baf333c9bb34edd26f912d5b0457841fc858ab", size = 166594, upload-time = "2026-06-20T23:48:57.617Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/5f/e1d7c6e4523f78db2fbd7826babd0348da1d5e0834c4f918b9ab5757dfae/wrapt-2.2.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:173e5bb5ca350a6e0abab60b7ec7cdd7992a814cb14b4de670a28f067f105663", size = 157068, upload-time = "2026-06-20T23:48:59.171Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c1/7ebd1027f00700c0b0233b20aceef2b4784294ed64971424c4a78e069e34/wrapt-2.2.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:aa14b01804bce36c6d63d7b6a4f55df390f29f8648cc13a1f40b166f4d54680d", size = 166470, upload-time = "2026-06-20T23:49:00.737Z" },
+    { url = "https://files.pythonhosted.org/packages/99/eb/974e471a6a978b8180186b8a9dc5ae3361ce269a967190b709b8ce17abfb/wrapt-2.2.2-cp314-cp314-win32.whl", hash = "sha256:58f9f8d637c9a6e245c6ef5b109b67ec187d2faed23d1405656b51d96e0a5b56", size = 78062, upload-time = "2026-06-20T23:49:02.327Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ec/e1281156cdc7a66693838ad7a0865ad641c74abd337a957d668b575aaffb/wrapt-2.2.2-cp314-cp314-win_amd64.whl", hash = "sha256:385cb1866f20479e83299af585375bfa0a4b0c6c9907a981483ea782ea8ae406", size = 80832, upload-time = "2026-06-20T23:49:03.837Z" },
+    { url = "https://files.pythonhosted.org/packages/45/7d/1b6b5ddd94005a2dac97a4490c9838f3154977850d633abcb65b30089437/wrapt-2.2.2-cp314-cp314-win_arm64.whl", hash = "sha256:8ffbeaea6771a6eba6e6eeb09767864995726bc8240bb54baf88a9bb1db34d5c", size = 80029, upload-time = "2026-06-20T23:49:05.237Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/33/9ebcf8aafe91c601127cbd93708c16aa8f688f34a10bf004046803ecdc4f/wrapt-2.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:09f811d43f6f33ec7515f0be76b159569f4057ab54d3e079c3204dddb90afa2a", size = 83357, upload-time = "2026-06-20T23:49:06.632Z" },
+    { url = "https://files.pythonhosted.org/packages/39/38/ec45b635153327b52e52732a0ea980e5f00b7efba65f9e018828f1e69daa/wrapt-2.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a795d3c06e5fbf9ea2f13196180b77aeab1b4685917256ee0d014cc163d90063", size = 83794, upload-time = "2026-06-20T23:49:08.098Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ea/1a89e6d3b7a83c3affe5c09cde77792c947e63e4bc85ad84cd5bb9abb0d8/wrapt-2.2.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:45c2f2768e790c9f8db90f239ef23a2af8e7570f25a35619ef902df4a738447f", size = 203362, upload-time = "2026-06-20T23:49:09.811Z" },
+    { url = "https://files.pythonhosted.org/packages/19/d8/3b58763d9863b5a73771c0d97110f9595d248db454009e07e1535ee905a4/wrapt-2.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bbf00ee0cb55ec24e2b0995a71942b85b21a066db8f3f46e1dbfdb9433ffba81", size = 210449, upload-time = "2026-06-20T23:49:11.521Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/6f/17fd9e053103d8be148d20d5d7505facc72d5fe1f9127973904ceaed79cf/wrapt-2.2.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2252f77663651b89255895f58cc6ac08fcb206d4371813e5af61bb62d4f7689c", size = 195349, upload-time = "2026-06-20T23:49:13.346Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/04/d0d1ccaaa12cb7dccf28a23f0279a608ba498f71e81d949d5ed54bcfd5c1/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2cd7181ab1c31192ff5219269830744b5a62020b3a6d433588c4f1c95b8f8bff", size = 206099, upload-time = "2026-06-20T23:49:15.051Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b3/e8aa07b619890a2aa6cde1931b1887abb08820721b564a5f80b7ca3f3aa0/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:6fe35fd51b74867d8b80174c277bd6bbf6a73e443f908129dc531c4b688a20d5", size = 192728, upload-time = "2026-06-20T23:49:16.854Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/f0/1819fb50f0d3c9bd758d8a83b56f1b470dee8b5b8eac8702b7c137cea9d4/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:11d95fc2fbad3163596c39d440e6f21ca9fccece74b56e30a37ac2fca786a07c", size = 198842, upload-time = "2026-06-20T23:49:18.504Z" },
+    { url = "https://files.pythonhosted.org/packages/67/7c/e88313f16a99930b899ef970d91c281544a470749a359decad994483bbda/wrapt-2.2.2-cp314-cp314t-win32.whl", hash = "sha256:d8a15813215f33fa83667bfc978b300e35669ea8bb424e970a1426bcb7bc6cca", size = 79059, upload-time = "2026-06-20T23:49:20.107Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/4f/ac12fda57a55068a094ec42851fb0a40e8489d8941863d517452de62e507/wrapt-2.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d09db0f7e8357060d3c38fc22a018aba683a796bf184360fd1a58f6fc180dc77", size = 82462, upload-time = "2026-06-20T23:49:21.631Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a7/df732dac86d9b2027c56bd163dbc883e037b16c3469614752e148d219c61/wrapt-2.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:f32fe639c39561ccc187bcae17e9271be0eb45f1c2952510d2f29b33ab577347", size = 81182, upload-time = "2026-06-20T23:49:23.199Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d2/6317eb6d4554855bbf12d61857774af34747bf88a42c19bf306de67e2fa3/wrapt-2.2.2-py3-none-any.whl", hash = "sha256:5bad217350f19ce99ca5b5e71d406765ea86fe541628426772b657375ee1c048", size = 61460, upload-time = "2026-06-20T23:49:42.966Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What does this PR do?

Adds OpenTelemetry tracing to the GenAI service so a request shows up as a span tree instead of just a latency number. The FastAPI request span is the parent, and every model/embedding call nests underneath it, so on a slow `/genai/ask` you can finally see whether the time went into the query embedding or the chat call.

Tracing is opt-in and off in the default stack. It only exports when `OTEL_EXPORTER_OTLP_ENDPOINT` is set; otherwise the spans run on OpenTelemetry's no-op tracer and cost effectively nothing. A new `docker-compose.tracing.yml` overlay wires it to a local Jaeger:

```bash
docker compose -f docker-compose.yml -f docker-compose.tracing.yml up
```

Jaeger UI is then at http://localhost/jaeger/ (service `alexandria-genai`).

This ticks the "LangChain tracing to OpenTelemetry" box from the observability checklist in #219 (not closing the whole tracking issue).

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [x] Docs
- [x] CI / infra

## Definition of Done

- [x] CI is green
- [x] If the API changed: `api/openapi.yaml` is updated and lint passes
- [x] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [x] Tests added or updated for the changed behaviour
- [x] Docs updated where it matters (README, ADRs, comments)

## Notes for the reviewer

A few decisions worth a look:

- Spans live in the one place every provider call already funnels through, `run_model_call` in `app/model_calls.py`, so there's a single wrap point rather than instrumentation scattered across summarize/extract/tag/qa/search. The model spans carry the OTel GenAI attributes (`gen_ai.operation.name`, `gen_ai.system`, `gen_ai.request.model`, `gen_ai.response.model`) plus a `genai.outcome` that mirrors the existing metric status label.
- I did not pull in a LangChain callback instrumentation library (openinference/openllmetry). They don't support langchain 1.x yet, and the chokepoint wrapper gives us what we need without the version risk. If we want the full LangChain run tree later, that can be a follow-up once the libs catch up.
- Jaeger uses OTLP over HTTP (port 4318), not gRPC, to avoid dragging `grpcio` into the image (no cp314 wheel story I wanted to bet on).

To try it: bring up the overlay, hit summarize/ask/search a few times, then look at the `alexandria-genai` service in Jaeger. `/genai/health` and `/genai/metrics` are excluded so the probe and scrape traffic doesn't drown out the real requests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in OpenTelemetry tracing for GenAI requests and model calls.
  * Added configurable OTLP endpoint and service name settings.
  * Added a Docker Compose tracing setup with local Jaeger visualization.
  * Excluded health and metrics endpoints from tracing.

* **Documentation**
  * Added setup instructions, configuration guidance, trace details, and Jaeger access information.

* **Tests**
  * Added coverage for tracing activation, span attributes, successful calls, errors, and timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->