### PR TITLE
Task: Increase Spring microservices line coverage, add structured logging and Micrometer instrumentation

### DIFF
--- a/infra/grafana/dashboards/spring-knowledgebase.json
+++ b/infra/grafana/dashboards/spring-knowledgebase.json
@@ -373,6 +373,165 @@
       ],
       "title": "HikariCP database connection pool",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "calls/s",
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "lineWidth": 1,
+            "showPoints": "never"
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(genai_client_calls_total{job=\"knowledgebase-service\"}[5m])) by (operation, outcome)",
+          "legendFormat": "{{operation}} {{outcome}}",
+          "refId": "A"
+        }
+      ],
+      "title": "GenAI client call rate (by operation / outcome)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "calls/s",
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "lineWidth": 1,
+            "showPoints": "never"
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 32
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(s3_operations_total{job=\"knowledgebase-service\"}[5m])) by (operation, outcome)",
+          "legendFormat": "{{operation}} {{outcome}}",
+          "refId": "A"
+        }
+      ],
+      "title": "S3 object storage operation rate (by operation / outcome)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "seconds",
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "lineWidth": 1,
+            "showPoints": "never"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 40
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(genai_client_call_duration_seconds_bucket{job=\"knowledgebase-service\"}[5m])) by (le, operation))",
+          "legendFormat": "p95 {{operation}}",
+          "refId": "A"
+        }
+      ],
+      "title": "GenAI client call p95 latency (by operation)",
+      "type": "timeseries"
     }
   ],
   "preload": false,

--- a/infra/grafana/dashboards/spring-qa.json
+++ b/infra/grafana/dashboards/spring-qa.json
@@ -373,6 +373,112 @@
       ],
       "title": "HikariCP database connection pool",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "calls/s",
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "lineWidth": 1,
+            "showPoints": "never"
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(genai_client_calls_total{job=\"qa-service\"}[5m])) by (outcome)",
+          "legendFormat": "{{outcome}}",
+          "refId": "A"
+        }
+      ],
+      "title": "GenAI ask call rate (by outcome)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "seconds",
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "lineWidth": 1,
+            "showPoints": "never"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 32
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(genai_client_call_duration_seconds_bucket{job=\"qa-service\"}[5m])) by (le))",
+          "legendFormat": "p95 ask",
+          "refId": "A"
+        }
+      ],
+      "title": "GenAI ask call p95 latency",
+      "type": "timeseries"
     }
   ],
   "preload": false,

--- a/infra/prometheus/alert.rules.yml
+++ b/infra/prometheus/alert.rules.yml
@@ -57,6 +57,22 @@ groups:
           summary: "GenAI {{ $labels.operation }} failure rate above 10%"
           description: "More than 10% of GenAI {{ $labels.operation }} calls have failed (provider error or timeout) over the last 5 minutes."
 
+      # More than 10% of a Spring service's calls to the GenAI service are failing
+      # over the last 5 minutes. This is the caller's view (summarize / extract / tag /
+      # index / search / ask), complementing the GenAi* alerts scoped to the model itself.
+      - alert: SpringGenAiClientErrors
+        expr: |
+          sum by (job) (rate(genai_client_calls_total{outcome="error"}[5m]))
+            /
+          sum by (job) (rate(genai_client_calls_total[5m]))
+            > 0.10
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "{{ $labels.job }} GenAI call failure rate above 10%"
+          description: "More than 10% of {{ $labels.job }} calls to the GenAI service have failed over the last 5 minutes."
+
       # Object storage volume has less than 10% free space, so uploads will start failing soon.
       - alert: S3StorageLowDiskSpace
         expr: |

--- a/services/spring/README.md
+++ b/services/spring/README.md
@@ -84,6 +84,36 @@ Each service exposes its own Swagger UI, routed through Traefik:
 
 The three services also expose a set of `/internal/{knowledgebase,qa}/**` endpoints for service-to-service calls. This prefix is deliberately not routed by Traefik or the Kubernetes Ingress, so the endpoints are only reachable from other containers inside the `alexandria` network. They are described in the `info` section of the aggregated OpenAPI spec.
 
+## Observability
+
+### Metrics
+
+Each service uses Spring Boot Actuator with the Micrometer Prometheus registry and exposes
+`/actuator/prometheus` (along with `health`, `info` and `metrics`). Prometheus scrapes one
+job per service; and Grafana visualizes them.
+
+On top of the default JVM and HTTP server metrics, we add a few custom ones:
+- **GenAI client calls** (`GenAiClient`): A `genai.client.call.duration` timer and a
+  `genai.client.calls` counter, tagged with the `operation` (summarize, extract, tag, index,
+  search, ask, ...) and a `success`/`error` outcome, so per-operation latency and error rate
+  are visible
+- **Object storage** (`ObjectStorageService`, knowledgebase-service only): `s3.operation.duration`
+  and `s3.operations`, tagged by operation (upload/download/delete) and outcome
+
+### Logging
+
+The shared `common` module auto-configures structured logging for every service (via
+`LoggingAutoConfiguration`), so logs are consistent without per-service setup:
+
+- Logs are emitted as JSON (Logback) with an additional `service` field
+- The MDC filter puts a `requestId` and `route` on the MDC (Mapped Diagnostic Context) for every
+  request and echoes back the id in the `X-Request-Id` response header. A caller-supplied
+  `X-Request-Id` is reused when it looks like a trace id, otherwise a fresh UUID is generated,
+  so a single request can be followed across services
+- For every write endpoint (`POST`/`PUT`/`PATCH`/`DELETE`), start/finish/failure are logged
+
+Set `SPRING_LOG_LEVEL` to change the root log level (defaults to `INFO`).
+
 ## Production
 
 The three services share one Dockerfile, the concrete image is picked at build

--- a/services/spring/build.gradle
+++ b/services/spring/build.gradle
@@ -74,7 +74,9 @@ subprojects {
 	dependencies {
 		implementation 'org.springframework.boot:spring-boot-starter-web'
 		implementation 'org.springframework.boot:spring-boot-starter-actuator'
+		implementation 'org.aspectj:aspectjweaver'
 		implementation 'io.micrometer:micrometer-registry-prometheus'
+		implementation 'net.logstash.logback:logstash-logback-encoder:8.1'
 		implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.3'
 		implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 		implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/services/spring/build.gradle
+++ b/services/spring/build.gradle
@@ -110,7 +110,12 @@ subprojects {
 		}
 		classDirectories.setFrom(
 			files(classDirectories.files.collect {
-				fileTree(dir: it, exclude: ['com/alexandria/genai/client/**'])
+				fileTree(dir: it, exclude: [
+					'com/alexandria/genai/client/**',
+					'**/auth/**',
+					'**/config/**',
+					'**/*Application.*',
+				])
 			})
 		)
 	}

--- a/services/spring/common/src/main/java/com/alexandria/common/logging/LoggingAutoConfiguration.java
+++ b/services/spring/common/src/main/java/com/alexandria/common/logging/LoggingAutoConfiguration.java
@@ -4,6 +4,11 @@ import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 
+/**
+ * Wires the shared logging support (MDC request-id filter and the write-endpoint logging aspect)
+ * into every service that puts the common module on its classpath. Registered as a Spring Boot
+ * auto-configuration.
+ */
 @AutoConfiguration
 @EnableAspectJAutoProxy
 public class LoggingAutoConfiguration {

--- a/services/spring/common/src/main/java/com/alexandria/common/logging/LoggingAutoConfiguration.java
+++ b/services/spring/common/src/main/java/com/alexandria/common/logging/LoggingAutoConfiguration.java
@@ -1,0 +1,20 @@
+package com.alexandria.common.logging;
+
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+
+@AutoConfiguration
+@EnableAspectJAutoProxy
+public class LoggingAutoConfiguration {
+
+    @Bean
+    public MdcLoggingFilter mdcLoggingFilter() {
+        return new MdcLoggingFilter();
+    }
+
+    @Bean
+    public WriteEndpointLoggingAspect writeEndpointLoggingAspect() {
+        return new WriteEndpointLoggingAspect();
+    }
+}

--- a/services/spring/common/src/main/java/com/alexandria/common/logging/MdcLoggingFilter.java
+++ b/services/spring/common/src/main/java/com/alexandria/common/logging/MdcLoggingFilter.java
@@ -1,0 +1,45 @@
+package com.alexandria.common.logging;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+public class MdcLoggingFilter extends OncePerRequestFilter implements Ordered {
+
+    public static final String REQUEST_ID_HEADER = "X-Request-Id";
+    private static final String REQUEST_ID = "requestId";
+    private static final String ROUTE = "route";
+    // Only accept caller-supplied ids that look like a trace id, otherwise we would
+    // reflect arbitrary input straight back into a response header.
+    private static final Pattern SAFE_REQUEST_ID = Pattern.compile("[A-Za-z0-9._-]{1,128}");
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws ServletException, IOException {
+        String requestId = request.getHeader(REQUEST_ID_HEADER);
+        if (requestId == null || !SAFE_REQUEST_ID.matcher(requestId).matches()) {
+            requestId = UUID.randomUUID().toString();
+        }
+        MDC.put(REQUEST_ID, requestId);
+        MDC.put(ROUTE, request.getMethod() + " " + request.getRequestURI());
+        response.setHeader(REQUEST_ID_HEADER, requestId);
+        try {
+            chain.doFilter(request, response);
+        } finally {
+            MDC.remove(REQUEST_ID);
+            MDC.remove(ROUTE);
+        }
+    }
+
+    @Override
+    public int getOrder() {
+        return Ordered.HIGHEST_PRECEDENCE;
+    }
+}

--- a/services/spring/common/src/main/java/com/alexandria/common/logging/MdcLoggingFilter.java
+++ b/services/spring/common/src/main/java/com/alexandria/common/logging/MdcLoggingFilter.java
@@ -12,6 +12,15 @@ import java.io.IOException;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
+/**
+ * Puts a request id and route onto the SLF4J (Simple Logging Facade for Java) MDC so every
+ * log line for a request can be correlated, and echoes the id back in the X-Request-Id
+ * response header.
+ *
+ * <p>An incoming X-Request-Id is reused when it looks like a trace id, otherwise a fresh
+ * UUID is generated. Runs at highest precedence so the context is set before anything else
+ * logs, and is always cleared in a finally block to avoid leaking ids across pooled threads.
+ */
 public class MdcLoggingFilter extends OncePerRequestFilter implements Ordered {
 
     public static final String REQUEST_ID_HEADER = "X-Request-Id";

--- a/services/spring/common/src/main/java/com/alexandria/common/logging/MdcLoggingFilter.java
+++ b/services/spring/common/src/main/java/com/alexandria/common/logging/MdcLoggingFilter.java
@@ -20,22 +20,25 @@ import java.util.regex.Pattern;
  * <p>An incoming X-Request-Id is reused when it looks like a trace id, otherwise a fresh
  * UUID is generated. Runs at highest precedence so the context is set before anything else
  * logs, and is always cleared in a finally block to avoid leaking ids across pooled threads.
+ *
+ * <p>The filter also runs on the container's ERROR dispatch (see
+ * {@link #shouldNotFilterErrorDispatch()}) and stashes the id as a request attribute, so the
+ * same id is restored onto the MDC when the /error controller renders and logs a failure.
  */
 public class MdcLoggingFilter extends OncePerRequestFilter implements Ordered {
 
     public static final String REQUEST_ID_HEADER = "X-Request-Id";
     private static final String REQUEST_ID = "requestId";
     private static final String ROUTE = "route";
+    private static final String REQUEST_ID_ATTRIBUTE = MdcLoggingFilter.class.getName() + ".requestId";
     // Only accept caller-supplied ids that look like a trace id, otherwise we would
     // reflect arbitrary input straight back into a response header.
     private static final Pattern SAFE_REQUEST_ID = Pattern.compile("[A-Za-z0-9._-]{1,128}");
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws ServletException, IOException {
-        String requestId = request.getHeader(REQUEST_ID_HEADER);
-        if (requestId == null || !SAFE_REQUEST_ID.matcher(requestId).matches()) {
-            requestId = UUID.randomUUID().toString();
-        }
+        String requestId = resolveRequestId(request);
+        request.setAttribute(REQUEST_ID_ATTRIBUTE, requestId);
         MDC.put(REQUEST_ID, requestId);
         MDC.put(ROUTE, request.getMethod() + " " + request.getRequestURI());
         response.setHeader(REQUEST_ID_HEADER, requestId);
@@ -45,6 +48,26 @@ public class MdcLoggingFilter extends OncePerRequestFilter implements Ordered {
             MDC.remove(REQUEST_ID);
             MDC.remove(ROUTE);
         }
+    }
+
+    // Reuse the id carried over from the initial dispatch so an error dispatch keeps the same
+    // trace id, otherwise fall back to the header or a fresh UUID.
+    private String resolveRequestId(HttpServletRequest request) {
+        Object carried = request.getAttribute(REQUEST_ID_ATTRIBUTE);
+        if (carried instanceof String s && !s.isBlank()) {
+            return s;
+        }
+        String fromHeader = request.getHeader(REQUEST_ID_HEADER);
+        if (fromHeader != null && SAFE_REQUEST_ID.matcher(fromHeader).matches()) {
+            return fromHeader;
+        }
+        return UUID.randomUUID().toString();
+    }
+
+    // Also run on the ERROR dispatch so the /error controller logs with the request id set.
+    @Override
+    protected boolean shouldNotFilterErrorDispatch() {
+        return false;
     }
 
     @Override

--- a/services/spring/common/src/main/java/com/alexandria/common/logging/WriteEndpointLoggingAspect.java
+++ b/services/spring/common/src/main/java/com/alexandria/common/logging/WriteEndpointLoggingAspect.java
@@ -7,6 +7,11 @@ import org.aspectj.lang.annotation.Pointcut;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Logs start, finish and failure around every write (POST/PUT/PATCH/DELETE) controller
+ * method, so state-changing requests leave an audit trail without each controller having
+ * to log by hand. Read endpoints are intentionally left out to keep the logs quiet.
+ */
 @Aspect
 public class WriteEndpointLoggingAspect {
 

--- a/services/spring/common/src/main/java/com/alexandria/common/logging/WriteEndpointLoggingAspect.java
+++ b/services/spring/common/src/main/java/com/alexandria/common/logging/WriteEndpointLoggingAspect.java
@@ -1,0 +1,36 @@
+package com.alexandria.common.logging;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Aspect
+public class WriteEndpointLoggingAspect {
+
+    private static final Logger log = LoggerFactory.getLogger(WriteEndpointLoggingAspect.class);
+
+    @Pointcut("within(com.alexandria..*Controller)")
+    void inController() {
+    }
+
+    @Pointcut("@annotation(org.springframework.web.bind.annotation.PostMapping) || @annotation(org.springframework.web.bind.annotation.PutMapping) || @annotation(org.springframework.web.bind.annotation.PatchMapping) || @annotation(org.springframework.web.bind.annotation.DeleteMapping)")
+    void writeMapping() {
+    }
+
+    @Around("inController() && writeMapping()")
+    public Object logAroundWrite(ProceedingJoinPoint joinPoint) throws Throwable {
+        String endpoint = joinPoint.getSignature().getName();
+        log.info("write endpoint {} started", endpoint);
+        try {
+            Object result = joinPoint.proceed();
+            log.info("write endpoint {} finished", endpoint);
+            return result;
+        } catch (Throwable e) {
+            log.warn("write endpoint {} failed: {}", endpoint, e.getMessage());
+            throw e;
+        }
+    }
+}

--- a/services/spring/common/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/services/spring/common/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,2 @@
 com.alexandria.common.metrics.ApplicationInfoMetricsAutoConfiguration
+com.alexandria.common.logging.LoggingAutoConfiguration

--- a/services/spring/common/src/main/resources/logback-spring.xml
+++ b/services/spring/common/src/main/resources/logback-spring.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <springProperty scope="context" name="appName" source="spring.application.name" defaultValue="unknown"/>
+
+    <appender name="JSON" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <customFields>{"service":"${appName}"}</customFields>
+        </encoder>
+    </appender>
+
+    <root level="${SPRING_LOG_LEVEL:-INFO}">
+        <appender-ref ref="JSON"/>
+    </root>
+</configuration>

--- a/services/spring/common/src/test/java/com/alexandria/common/logging/MdcLoggingFilterTest.java
+++ b/services/spring/common/src/test/java/com/alexandria/common/logging/MdcLoggingFilterTest.java
@@ -1,0 +1,55 @@
+package com.alexandria.common.logging;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MdcLoggingFilterTest {
+
+    private final MdcLoggingFilter filter = new MdcLoggingFilter();
+
+    @Test
+    void unit_common_generatesRequestIdWhenHeaderMissing() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/v1/knowledgebase/documents/create");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, (req, res) -> {
+            assertThat(MDC.get("requestId")).isNotBlank();
+            assertThat(MDC.get("route")).isEqualTo("POST /api/v1/knowledgebase/documents/create");
+        });
+
+        assertThat(response.getHeader(MdcLoggingFilter.REQUEST_ID_HEADER)).isNotBlank();
+        assertThat(MDC.get("requestId")).isNull();
+        assertThat(MDC.get("route")).isNull();
+    }
+
+    @Test
+    void unit_common_reusesIncomingRequestId() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/qa/history");
+        request.addHeader(MdcLoggingFilter.REQUEST_ID_HEADER, "trace-123");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, (req, res) -> assertThat(MDC.get("requestId")).isEqualTo("trace-123"));
+
+        assertThat(response.getHeader(MdcLoggingFilter.REQUEST_ID_HEADER)).isEqualTo("trace-123");
+    }
+
+    @Test
+    void unit_common_clearsMdcEvenWhenChainThrows() {
+        MockHttpServletRequest request = new MockHttpServletRequest("DELETE", "/api/v1/users/1");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        try {
+            filter.doFilter(request, response, (req, res) -> {
+                throw new RuntimeException("boom");
+            });
+        } catch (Exception ignored) {
+        }
+
+        assertThat(MDC.get("requestId")).isNull();
+        assertThat(MDC.get("route")).isNull();
+    }
+}

--- a/services/spring/common/src/test/java/com/alexandria/common/logging/MdcLoggingFilterTest.java
+++ b/services/spring/common/src/test/java/com/alexandria/common/logging/MdcLoggingFilterTest.java
@@ -38,6 +38,20 @@ class MdcLoggingFilterTest {
     }
 
     @Test
+    void unit_common_reusesSameRequestIdOnErrorDispatch() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/qa/history");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        String[] seenIds = new String[2];
+        filter.doFilter(request, response, (req, res) -> seenIds[0] = MDC.get("requestId"));
+        // Simulate the container re-running the filter for the ERROR dispatch to /error.
+        filter.doFilter(request, response, (req, res) -> seenIds[1] = MDC.get("requestId"));
+
+        assertThat(seenIds[0]).isNotBlank();
+        assertThat(seenIds[1]).isEqualTo(seenIds[0]);
+    }
+
+    @Test
     void unit_common_clearsMdcEvenWhenChainThrows() {
         MockHttpServletRequest request = new MockHttpServletRequest("DELETE", "/api/v1/users/1");
         MockHttpServletResponse response = new MockHttpServletResponse();

--- a/services/spring/common/src/test/java/com/alexandria/common/logging/WriteEndpointLoggingAspectTest.java
+++ b/services/spring/common/src/test/java/com/alexandria/common/logging/WriteEndpointLoggingAspectTest.java
@@ -1,0 +1,41 @@
+package com.alexandria.common.logging;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.Signature;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class WriteEndpointLoggingAspectTest {
+
+    private final WriteEndpointLoggingAspect aspect = new WriteEndpointLoggingAspect();
+    private ProceedingJoinPoint joinPoint;
+
+    @BeforeEach
+    void setup() {
+        joinPoint = mock(ProceedingJoinPoint.class);
+        Signature signature = mock(Signature.class);
+        when(signature.getName()).thenReturn("createDocument");
+        when(joinPoint.getSignature()).thenReturn(signature);
+    }
+
+    @Test
+    void unit_common_returnsResultAndProceeds() throws Throwable {
+        when(joinPoint.proceed()).thenReturn("ok");
+
+        assertThat(aspect.logAroundWrite(joinPoint)).isEqualTo("ok");
+        verify(joinPoint).proceed();
+    }
+
+    @Test
+    void unit_common_rethrowsFailures() throws Throwable {
+        when(joinPoint.proceed()).thenThrow(new IllegalStateException("boom"));
+
+        assertThatThrownBy(() -> aspect.logAroundWrite(joinPoint)).isInstanceOf(IllegalStateException.class);
+    }
+}

--- a/services/spring/config/spotbugs/exclude.xml
+++ b/services/spring/config/spotbugs/exclude.xml
@@ -24,4 +24,13 @@
   <Match>
     <Bug pattern="SE_NO_SERIALVERSIONID"/>
   </Match>
+
+  <!-- The request id echoed back by MdcLoggingFilter is validated against a strict
+       allowlist ([A-Za-z0-9._-]) before it ever reaches setHeader, so CR/LF response
+       splitting is impossible. SpotBugs' analysis can't see through the regex
+       guard, so this is a false positive. -->
+  <Match>
+    <Class name="com.alexandria.common.logging.MdcLoggingFilter"/>
+    <Bug pattern="HRS_REQUEST_PARAMETER_TO_HTTP_HEADER"/>
+  </Match>
 </FindBugsFilter>

--- a/services/spring/knowledgebase-service/src/main/java/com/alexandria/knowledgebase/InternalController.java
+++ b/services/spring/knowledgebase-service/src/main/java/com/alexandria/knowledgebase/InternalController.java
@@ -17,6 +17,15 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+/**
+ * Service-to-service endpoints for the knowledge-base service.
+ *
+ * <p>This prefix is deliberately not routed by Traefik or the Kubernetes Ingress, so the
+ * endpoints are only reachable from other services inside the cluster network. Instead of
+ * a user bearer token they are authenticated by an HMAC signature, hence the per-method
+ * SecurityRequirements that clears the default bearer scheme. Used by qa-service and
+ * user-service to look up or purge a user's documents by OIDC subject.
+ */
 @RestController
 @RequestMapping(path = "/internal/knowledgebase", produces = MediaType.APPLICATION_JSON_VALUE)
 @Tag(name = "KnowledgeBase Service (Internal)", description = "Service-to-service endpoints authenticated by an HMAC signature")

--- a/services/spring/knowledgebase-service/src/main/java/com/alexandria/knowledgebase/KnowledgeBaseController.java
+++ b/services/spring/knowledgebase-service/src/main/java/com/alexandria/knowledgebase/KnowledgeBaseController.java
@@ -27,6 +27,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+/**
+ * Public REST API for document management and knowledge operations.
+ *
+ * <p>All endpoints are scoped to the authenticated caller; the OIDC subject from the
+ * bearer token is used as the document owner, so a user only ever sees their own
+ * documents. Uploads and creates trigger an asynchronous GenAI pipeline (summary,
+ * entities, tags, indexing) in the service layer, the reprocess endpoints re-run
+ * individual steps on demand.
+ */
 @RestController
 @RequestMapping(path = "/api/v1/knowledgebase", produces = MediaType.APPLICATION_JSON_VALUE)
 @Tag(
@@ -119,6 +128,13 @@ public class KnowledgeBaseController {
         return ResponseEntity.ok(new TextSearchResponseDto(knowledgeBaseService.search(principal.getName(), q)));
     }
 
+    /**
+     * Ranks the user's indexed documents by semantic similarity to the query.
+     * Falls back to keyword search when the GenAI call fails or the index is empty,
+     * so a result set is always returned.
+     *
+     * @param limit maximum number of hits to return, between 1 and 50
+     */
     @GetMapping("/search/semantic")
     @Operation(summary = "Semantic search over document content, with keyword fallback")
     @ApiResponse(responseCode = "200", description = "Ranked search results with match context")
@@ -148,6 +164,10 @@ public class KnowledgeBaseController {
         return ResponseEntity.noContent().build();
     }
 
+    /**
+     * Returns the GenAI-generated summary for a document, or 204 No Content while it is
+     * still being processed (summaries are produced asynchronously after upload).
+     */
     @GetMapping("/documents/{id}/summary")
     @Operation(summary = "Get document summary")
     @ApiResponse(responseCode = "200", description = "Document summary retrieved")

--- a/services/spring/knowledgebase-service/src/main/java/com/alexandria/knowledgebase/KnowledgeBaseController.java
+++ b/services/spring/knowledgebase-service/src/main/java/com/alexandria/knowledgebase/KnowledgeBaseController.java
@@ -165,8 +165,9 @@ public class KnowledgeBaseController {
     }
 
     /**
-     * Returns the GenAI-generated summary for a document, or 204 No Content while it is
-     * still being processed (summaries are produced asynchronously after upload).
+     * Returns the GenAI-generated summary for a document, or 204 No Content when no summary
+     * is available yet (summaries are produced asynchronously after upload and may be missing
+     * if processing has not finished or failed).
      */
     @GetMapping("/documents/{id}/summary")
     @Operation(summary = "Get document summary")

--- a/services/spring/knowledgebase-service/src/main/java/com/alexandria/knowledgebase/KnowledgeBaseService.java
+++ b/services/spring/knowledgebase-service/src/main/java/com/alexandria/knowledgebase/KnowledgeBaseService.java
@@ -31,6 +31,14 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+/**
+ * Core logic for documents, tags, summaries, entities and search.
+ *
+ * <p>Creating or uploading a document persists it and then starts an
+ * asynchronous GenAI pipeline (summarize, extract entities, tag, index) that runs
+ * off the request thread. Every GenAI call is best-effort, failures are logged and
+ * swallowed so a GenAI outage never breaks an upload or a delete.
+ */
 @Service
 public class KnowledgeBaseService {
 

--- a/services/spring/knowledgebase-service/src/main/java/com/alexandria/knowledgebase/ObjectStorageService.java
+++ b/services/spring/knowledgebase-service/src/main/java/com/alexandria/knowledgebase/ObjectStorageService.java
@@ -1,5 +1,7 @@
 package com.alexandria.knowledgebase;
 
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
@@ -9,6 +11,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.*;
 
 import java.io.IOException;
+import java.util.function.Supplier;
 
 // Based on https://www.baeldung.com/java-aws-s3 and
 // https://dev.to/sachithmayantha/seamless-file-storage-integrating-aws-s3-with-spring-boot-3045
@@ -19,9 +22,25 @@ public class ObjectStorageService {
     String bucket;
 
     private final S3Client s3Client;
+    private final MeterRegistry meterRegistry;
 
-    public ObjectStorageService(S3Client s3Client) {
+    public ObjectStorageService(S3Client s3Client, MeterRegistry meterRegistry) {
         this.s3Client = s3Client;
+        this.meterRegistry = meterRegistry;
+    }
+
+    private <T> T tracked(String operation, Supplier<T> call) {
+        Timer.Sample sample = Timer.start(meterRegistry);
+        String outcome = "success";
+        try {
+            return call.get();
+        } catch (RuntimeException e) {
+            outcome = "error";
+            throw e;
+        } finally {
+            sample.stop(meterRegistry.timer("s3.operation.duration", "operation", operation, "outcome", outcome));
+            meterRegistry.counter("s3.operations", "operation", operation, "outcome", outcome).increment();
+        }
     }
 
     public boolean bucketExists(String bucket) {
@@ -46,13 +65,16 @@ public class ObjectStorageService {
     }
 
     public void upload(String bucket, String key, MultipartFile file) {
-        try {
-            PutObjectRequest putRequest = PutObjectRequest.builder().bucket(bucket).key(key).build();
-            RequestBody requestBody = RequestBody.fromBytes(file.getBytes());
-            s3Client.putObject(putRequest, requestBody);
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to upload file.", e);
-        }
+        tracked("upload", () -> {
+            try {
+                PutObjectRequest putRequest = PutObjectRequest.builder().bucket(bucket).key(key).build();
+                RequestBody requestBody = RequestBody.fromBytes(file.getBytes());
+                s3Client.putObject(putRequest, requestBody);
+                return null;
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to upload file.", e);
+            }
+        });
     }
 
     public void upload(String key, MultipartFile file) {
@@ -60,8 +82,10 @@ public class ObjectStorageService {
     }
 
     public byte[] download(String bucket, String key) {
-        GetObjectRequest getRequest = GetObjectRequest.builder().bucket(bucket).key(key).build();
-        return s3Client.getObject(getRequest, ResponseTransformer.toBytes()).asByteArray();
+        return tracked("download", () -> {
+            GetObjectRequest getRequest = GetObjectRequest.builder().bucket(bucket).key(key).build();
+            return s3Client.getObject(getRequest, ResponseTransformer.toBytes()).asByteArray();
+        });
     }
 
     public byte[] download(String key) {
@@ -69,8 +93,11 @@ public class ObjectStorageService {
     }
 
     public void delete(String bucket, String key) {
-        DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder().bucket(bucket).key(key).build();
-        s3Client.deleteObject(deleteRequest);
+        tracked("delete", () -> {
+            DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder().bucket(bucket).key(key).build();
+            s3Client.deleteObject(deleteRequest);
+            return null;
+        });
     }
 
     public void delete(String key) {

--- a/services/spring/knowledgebase-service/src/main/java/com/alexandria/knowledgebase/ObjectStorageService.java
+++ b/services/spring/knowledgebase-service/src/main/java/com/alexandria/knowledgebase/ObjectStorageService.java
@@ -13,9 +13,17 @@ import software.amazon.awssdk.services.s3.model.*;
 import java.io.IOException;
 import java.util.function.Supplier;
 
-// Based on https://www.baeldung.com/java-aws-s3 and
-// https://dev.to/sachithmayantha/seamless-file-storage-integrating-aws-s3-with-spring-boot-3045
-
+/**
+ * Wrapper over the AWS S3 client for the SeaweedFS object store.
+ *
+ * <p>Handles bucket lifecycle and object upload/download/delete against the bucket
+ * configured by {@code app.config.s3-bucket}. Each operation is timed and counted
+ * ({@code s3.operation.duration}, {@code s3.operations}, tagged by operation and
+ * outcome) so object storage latency and errors surface in Prometheus.
+ *
+ * <p>Based on https://www.baeldung.com/java-aws-s3 and
+ * https://dev.to/sachithmayantha/seamless-file-storage-integrating-aws-s3-with-spring-boot-3045
+ */
 @Component
 public class ObjectStorageService {
     @Value("${app.config.s3-bucket}")

--- a/services/spring/knowledgebase-service/src/main/java/com/alexandria/knowledgebase/S3ClientConfig.java
+++ b/services/spring/knowledgebase-service/src/main/java/com/alexandria/knowledgebase/S3ClientConfig.java
@@ -10,9 +10,16 @@ import software.amazon.awssdk.services.s3.S3Client;
 
 import java.net.URI;
 
-// Based on https://www.baeldung.com/java-aws-s3 and
-// https://dev.to/sachithmayantha/seamless-file-storage-integrating-aws-s3-with-spring-boot-3045
-
+/**
+ * Builds the S3 client used to talk to the SeaweedFS object store.
+ *
+ * <p>Uses static credentials and an endpoint override with path-style access, which
+ * SeaweedFS (and most S3-compatible stores that are not AWS) require. All values come from
+ * {@code app.config.s3-*} properties.
+ *
+ * <p>Based on https://www.baeldung.com/java-aws-s3 and
+ * https://dev.to/sachithmayantha/seamless-file-storage-integrating-aws-s3-with-spring-boot-3045
+ */
 @Configuration
 public class S3ClientConfig {
     @Value("${app.config.s3-endpoint}")

--- a/services/spring/knowledgebase-service/src/main/java/com/alexandria/knowledgebase/TextExtractor.java
+++ b/services/spring/knowledgebase-service/src/main/java/com/alexandria/knowledgebase/TextExtractor.java
@@ -11,13 +11,23 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
-// inspired by https://medium.com/@georgeberar/springboot-extract-text-from-pdf-1d8d41b5adac
-
+/**
+ * Extracts raw text from an uploaded file for indexing and GenAI processing.
+ *
+ * <p>Handles PDFs (via PDFBox) and any {@code text/*} content; other types yield
+ * {@code null}. Extraction failures are logged rather than thrown so an upload of an
+ * unreadable file still succeeds, just without searchable text.
+ *
+ * <p>Inspired by https://medium.com/@georgeberar/springboot-extract-text-from-pdf-1d8d41b5adac
+ */
 @Component
 public class TextExtractor {
 
     private static final Logger log = LoggerFactory.getLogger(TextExtractor.class);
 
+    /**
+     * Returns the extracted text, or {@code null} if the type is unsupported or extraction fails.
+     */
     public String extract(MultipartFile file) {
         String contentType = file.getContentType();
         if (contentType == null) {

--- a/services/spring/knowledgebase-service/src/main/java/com/alexandria/knowledgebase/auth/SecurityConfig.java
+++ b/services/spring/knowledgebase-service/src/main/java/com/alexandria/knowledgebase/auth/SecurityConfig.java
@@ -14,8 +14,16 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtAut
 import org.springframework.security.oauth2.server.resource.web.authentication.BearerTokenAuthenticationFilter;
 import org.springframework.security.web.SecurityFilterChain;
 
+/**
+ * Stateless security for the knowledgebase-service.
+ *
+ * <p>Runs as an OAuth2 resource server: public API calls need a valid JWT, internal
+ * fan-out endpoints instead require an HMAC signature (checked by a filter placed before
+ * the bearer-token filter). The Swagger docs, actuator and health endpoints are open.
+ * Auth failures are rendered through the shared ErrorResponse handlers.
+ */
 // final (+ proxyBeanMethods=false so Spring won't try to CGLIB-subclass it) closes the
-// finalizer-attack window SpotBugs flags via CT_CONSTRUCTOR_THROW on the constructor.
+// finalizer-attack window on the constructor.
 @Configuration(proxyBeanMethods = false)
 @EnableWebSecurity
 public final class SecurityConfig {

--- a/services/spring/knowledgebase-service/src/main/java/com/alexandria/knowledgebase/config/OpenApiConfig.java
+++ b/services/spring/knowledgebase-service/src/main/java/com/alexandria/knowledgebase/config/OpenApiConfig.java
@@ -18,7 +18,7 @@ import org.springframework.context.annotation.Configuration;
 
 /**
  * OpenAPI/Swagger metadata and the bearer auth scheme for knowledgebase-service, additionally
- * a customizer that points every error response at the shared ErrorResponse schema.
+ * a customizer that points numeric 4xx/5xx responses at the shared ErrorResponse schema.
  */
 @Configuration
 @OpenAPIDefinition(

--- a/services/spring/knowledgebase-service/src/main/java/com/alexandria/knowledgebase/config/OpenApiConfig.java
+++ b/services/spring/knowledgebase-service/src/main/java/com/alexandria/knowledgebase/config/OpenApiConfig.java
@@ -16,6 +16,10 @@ import org.springdoc.core.customizers.OpenApiCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+/**
+ * OpenAPI/Swagger metadata and the bearer auth scheme for knowledgebase-service, additionally
+ * a customizer that points every error response at the shared ErrorResponse schema.
+ */
 @Configuration
 @OpenAPIDefinition(
         info = @Info(

--- a/services/spring/knowledgebase-service/src/main/java/com/alexandria/knowledgebase/exception/GlobalExceptionHandler.java
+++ b/services/spring/knowledgebase-service/src/main/java/com/alexandria/knowledgebase/exception/GlobalExceptionHandler.java
@@ -2,6 +2,8 @@ package com.alexandria.knowledgebase.exception;
 
 import com.alexandria.common.web.BaseExceptionHandler;
 import com.alexandria.common.web.ErrorResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -10,8 +12,11 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler extends BaseExceptionHandler {
 
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
     @ExceptionHandler(DocumentNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleDocumentNotFound(DocumentNotFoundException e) {
+        log.warn("Document not found: {}", e.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorResponse("NOT_FOUND", e.getMessage()));
     }
 }

--- a/services/spring/knowledgebase-service/src/main/java/com/alexandria/knowledgebase/integration/GenAiClient.java
+++ b/services/spring/knowledgebase-service/src/main/java/com/alexandria/knowledgebase/integration/GenAiClient.java
@@ -23,6 +23,15 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Supplier;
 
+/**
+ * HTTP client for the GenAI service, built on the OpenAPI-generated AiApi.
+ *
+ * <p>Wraps the summarize, extract, tag, index, delete-index and search operations and
+ * maps the generated response models onto the small records exposed here. Every call is
+ * timed and counted through GenAiMetrics so latency and error rate per operation
+ * show up in Prometheus. Connect and read timeouts are set explicitly so a hung GenAI
+ * service cannot block request threads indefinitely.
+ */
 @Component
 public class GenAiClient {
 

--- a/services/spring/knowledgebase-service/src/main/java/com/alexandria/knowledgebase/integration/GenAiClient.java
+++ b/services/spring/knowledgebase-service/src/main/java/com/alexandria/knowledgebase/integration/GenAiClient.java
@@ -9,6 +9,7 @@ import com.alexandria.genai.client.model.GenAiSearchRequest;
 import com.alexandria.genai.client.model.GenAiSummarizeRequest;
 import com.alexandria.genai.client.model.GenAiTagRequest;
 import com.alexandria.knowledgebase.document.EntityType;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.client.JdkClientHttpRequestFactory;
@@ -20,41 +21,53 @@ import java.net.http.HttpClient;
 import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Supplier;
 
 @Component
 public class GenAiClient {
 
     private final AiApi genaiClient;
+    private final GenAiMetrics metrics;
 
     @Autowired
-    public GenAiClient(@Value("${genai.base-url:http://localhost:8000}") String baseUrl) {
+    public GenAiClient(@Value("${genai.base-url:http://localhost:8000}") String baseUrl, MeterRegistry meterRegistry) {
         HttpClient httpClient = HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).connectTimeout(Duration.ofSeconds(5)).build();
         JdkClientHttpRequestFactory factory = new JdkClientHttpRequestFactory(httpClient);
         factory.setReadTimeout(Duration.ofSeconds(30));
         RestClient restClient = ApiClient.buildRestClientBuilder().requestFactory(factory).build();
         ApiClient apiClient = new ApiClient(restClient).setBasePath(baseUrl);
         this.genaiClient = new AiApi(apiClient);
+        this.metrics = new GenAiMetrics(meterRegistry);
     }
 
-    GenAiClient(AiApi genaiClient) {
+    GenAiClient(AiApi genaiClient, MeterRegistry meterRegistry) {
         this.genaiClient = genaiClient;
+        this.metrics = new GenAiMetrics(meterRegistry);
+    }
+
+    private <T> T tracked(String operation, Supplier<T> call) {
+        return metrics.record(operation, call);
     }
 
     public SummarizeResponse summarize(String objectKey) {
-        var r = genaiClient.summarizeDocumentGenaiSummarizePost(new GenAiSummarizeRequest().objectKey(objectKey));
-        return new SummarizeResponse(r.getSummary(), r.getModelUsed());
+        return tracked("summarize", () -> {
+            var r = genaiClient.summarizeDocumentGenaiSummarizePost(new GenAiSummarizeRequest().objectKey(objectKey));
+            return new SummarizeResponse(r.getSummary(), r.getModelUsed());
+        });
     }
 
     public ExtractResponse extract(String objectKey) {
-        var r = genaiClient.extractGenaiExtractPost(new GenAiExtractRequest().objectKey(objectKey));
-        List<ExtractedEntityDto> entities = r.getEntities().stream().map(e -> {
-            EntityType type = parseEntityType(e.getType());
-            if (type == null) {
-                return null;
-            }
-            return new ExtractedEntityDto(e.getName(), type, toDouble(e.getConfidence()));
-        }).filter(Objects::nonNull).toList();
-        return new ExtractResponse(entities, r.getModelUsed());
+        return tracked("extract", () -> {
+            var r = genaiClient.extractGenaiExtractPost(new GenAiExtractRequest().objectKey(objectKey));
+            List<ExtractedEntityDto> entities = r.getEntities().stream().map(e -> {
+                EntityType type = parseEntityType(e.getType());
+                if (type == null) {
+                    return null;
+                }
+                return new ExtractedEntityDto(e.getName(), type, toDouble(e.getConfidence()));
+            }).filter(Objects::nonNull).toList();
+            return new ExtractResponse(entities, r.getModelUsed());
+        });
     }
 
     private static EntityType parseEntityType(String value) {
@@ -69,29 +82,37 @@ public class GenAiClient {
     }
 
     public SearchResponse search(String query, List<String> objectKeys, Integer limit) {
-        var request = new GenAiSearchRequest().query(query).objectKeys(objectKeys == null ? List.of() : objectKeys);
-        if (limit != null) {
-            request.limit(limit);
-        }
-        var r = genaiClient.searchGenaiSearchPost(request);
-        List<SearchResult> results = r.getResults().stream().map(res -> new SearchResult(res.getObjectKey(), toDouble(res.getScore()), res.getSnippet())).toList();
-        return new SearchResponse(results, r.getEmbeddingModel());
+        return tracked("search", () -> {
+            var request = new GenAiSearchRequest().query(query).objectKeys(objectKeys == null ? List.of() : objectKeys);
+            if (limit != null) {
+                request.limit(limit);
+            }
+            var r = genaiClient.searchGenaiSearchPost(request);
+            List<SearchResult> results = r.getResults().stream().map(res -> new SearchResult(res.getObjectKey(), toDouble(res.getScore()), res.getSnippet())).toList();
+            return new SearchResponse(results, r.getEmbeddingModel());
+        });
     }
 
     public TagResponse tag(String objectKey, List<String> knownTags) {
-        var request = new GenAiTagRequest().objectKey(objectKey).knownTags(knownTags == null ? List.of() : knownTags);
-        var r = genaiClient.tagGenaiTagPost(request);
-        return new TagResponse(r.getTags(), r.getModelUsed());
+        return tracked("tag", () -> {
+            var request = new GenAiTagRequest().objectKey(objectKey).knownTags(knownTags == null ? List.of() : knownTags);
+            var r = genaiClient.tagGenaiTagPost(request);
+            return new TagResponse(r.getTags(), r.getModelUsed());
+        });
     }
 
     public IndexResponse index(String objectKey) {
-        var r = genaiClient.indexGenaiIndexPost(new GenAiIndexRequest().objectKey(objectKey));
-        return new IndexResponse(r.getObjectKey(), r.getChunksIndexed(), r.getEmbeddingModel());
+        return tracked("index", () -> {
+            var r = genaiClient.indexGenaiIndexPost(new GenAiIndexRequest().objectKey(objectKey));
+            return new IndexResponse(r.getObjectKey(), r.getChunksIndexed(), r.getEmbeddingModel());
+        });
     }
 
     public DeleteIndexResponse deleteIndex(String objectKey) {
-        GenAiDeleteIndexResponse r = genaiClient.deleteIndexGenaiIndexObjectKeyDelete(objectKey);
-        return new DeleteIndexResponse(r.getObjectKey(), r.getChunksDeleted());
+        return tracked("deleteIndex", () -> {
+            GenAiDeleteIndexResponse r = genaiClient.deleteIndexGenaiIndexObjectKeyDelete(objectKey);
+            return new DeleteIndexResponse(r.getObjectKey(), r.getChunksDeleted());
+        });
     }
 
     private static Double toDouble(BigDecimal value) {

--- a/services/spring/knowledgebase-service/src/main/java/com/alexandria/knowledgebase/integration/GenAiMetrics.java
+++ b/services/spring/knowledgebase-service/src/main/java/com/alexandria/knowledgebase/integration/GenAiMetrics.java
@@ -5,6 +5,13 @@ import io.micrometer.core.instrument.Timer;
 
 import java.util.function.Supplier;
 
+/**
+ * Records latency and outcome for each GenAI client call.
+ *
+ * <p>Emits a {@code genai.client.call.duration} timer and a {@code genai.client.calls}
+ * counter, both tagged with the operation name and a success/error outcome, so
+ * per-operation error rate and latency are visible in Prometheus and Grafana.
+ */
 class GenAiMetrics {
 
     private final MeterRegistry registry;
@@ -13,6 +20,11 @@ class GenAiMetrics {
         this.registry = registry;
     }
 
+    /**
+     * Runs {@code call}, timing it and recording its outcome even if it throws.
+     *
+     * @return the value produced by {@code call}
+     */
     <T> T record(String operation, Supplier<T> call) {
         Timer.Sample sample = Timer.start(registry);
         String outcome = "success";

--- a/services/spring/knowledgebase-service/src/main/java/com/alexandria/knowledgebase/integration/GenAiMetrics.java
+++ b/services/spring/knowledgebase-service/src/main/java/com/alexandria/knowledgebase/integration/GenAiMetrics.java
@@ -1,0 +1,29 @@
+package com.alexandria.knowledgebase.integration;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+
+import java.util.function.Supplier;
+
+class GenAiMetrics {
+
+    private final MeterRegistry registry;
+
+    GenAiMetrics(MeterRegistry registry) {
+        this.registry = registry;
+    }
+
+    <T> T record(String operation, Supplier<T> call) {
+        Timer.Sample sample = Timer.start(registry);
+        String outcome = "success";
+        try {
+            return call.get();
+        } catch (RuntimeException e) {
+            outcome = "error";
+            throw e;
+        } finally {
+            sample.stop(registry.timer("genai.client.call.duration", "operation", operation, "outcome", outcome));
+            registry.counter("genai.client.calls", "operation", operation, "outcome", outcome).increment();
+        }
+    }
+}

--- a/services/spring/knowledgebase-service/src/test/java/com/alexandria/knowledgebase/InternalControllerTest.java
+++ b/services/spring/knowledgebase-service/src/test/java/com/alexandria/knowledgebase/InternalControllerTest.java
@@ -1,0 +1,73 @@
+package com.alexandria.knowledgebase;
+
+import com.alexandria.knowledgebase.document.Document;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class InternalControllerTest {
+
+    @Mock
+    private KnowledgeBaseService knowledgeBaseService;
+
+    @InjectMocks
+    private InternalController controller;
+
+    private static Document docWithId(String key, String fileName) {
+        Document doc = new Document("owner", fileName, key, "application/pdf", 1L);
+        ReflectionTestUtils.setField(doc, "id", UUID.randomUUID());
+        return doc;
+    }
+
+    @Test
+    void unit_kb_internalDeleteUserDataDelegates() {
+        ResponseEntity<Void> response = controller.deleteUserData("owner");
+
+        assertThat(response.getStatusCode().value()).isEqualTo(204);
+        verify(knowledgeBaseService).deleteAllForUser("owner");
+    }
+
+    @Test
+    void unit_kb_internalListDocumentKeysMapsObjectKeys() {
+        when(knowledgeBaseService.getDocuments("owner")).thenReturn(List.of(docWithId("/uploads/a.pdf", "a.pdf")));
+
+        ResponseEntity<List<String>> response = controller.listDocumentKeys("owner");
+
+        assertThat(response.getBody()).containsExactly("/uploads/a.pdf");
+    }
+
+    @Test
+    void unit_kb_internalResolveDocumentsMapsToReferences() {
+        Document doc = docWithId("/uploads/a.pdf", "a.pdf");
+        when(knowledgeBaseService.resolveDocuments("owner", List.of("/uploads/a.pdf"))).thenReturn(List.of(doc));
+
+        ResponseEntity<List<InternalController.DocumentReferenceResponse>> response = controller.resolveDocuments("owner", new InternalController.ResolveDocumentsRequest(List.of("/uploads/a.pdf")));
+
+        assertThat(response.getBody()).singleElement().satisfies(ref -> {
+            assertThat(ref.objectKey()).isEqualTo("/uploads/a.pdf");
+            assertThat(ref.fileName()).isEqualTo("a.pdf");
+            assertThat(ref.documentId()).isEqualTo(doc.getId().toString());
+        });
+    }
+
+    @Test
+    void unit_kb_internalResolveDocumentsHandlesNullRequest() {
+        when(knowledgeBaseService.resolveDocuments("owner", List.of())).thenReturn(List.of());
+
+        ResponseEntity<List<InternalController.DocumentReferenceResponse>> response = controller.resolveDocuments("owner", null);
+
+        assertThat(response.getBody()).isEmpty();
+    }
+}

--- a/services/spring/knowledgebase-service/src/test/java/com/alexandria/knowledgebase/KnowledgeBaseControllerTest.java
+++ b/services/spring/knowledgebase-service/src/test/java/com/alexandria/knowledgebase/KnowledgeBaseControllerTest.java
@@ -1,0 +1,239 @@
+package com.alexandria.knowledgebase;
+
+import com.alexandria.knowledgebase.document.Document;
+import com.alexandria.knowledgebase.document.EntityType;
+import com.alexandria.knowledgebase.document.ExtractedEntity;
+import com.alexandria.knowledgebase.document.Summary;
+import com.alexandria.knowledgebase.document.TagSource;
+import com.alexandria.knowledgebase.dto.SemanticSearchResponseDto;
+import com.alexandria.knowledgebase.dto.SemanticSearchResultDto;
+import com.alexandria.knowledgebase.dto.DocumentRefDto;
+import com.alexandria.knowledgebase.dto.UpdateDocumentRequest;
+import com.alexandria.knowledgebase.exception.DocumentNotFoundException;
+import com.alexandria.knowledgebase.search.SearchQuery;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class KnowledgeBaseControllerTest {
+
+    private static final String SUBJECT = "mock-user";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private KnowledgeBaseService knowledgeBaseService;
+
+    private static Document doc() {
+        Document d = new Document(SUBJECT, "a.pdf", "/uploads/a.pdf", "application/pdf", 100L);
+        return d;
+    }
+
+    @Test
+    void integration_kb_listDocuments() throws Exception {
+        when(knowledgeBaseService.getDocuments(SUBJECT)).thenReturn(List.of(doc()));
+
+        mockMvc.perform(get("/api/v1/knowledgebase/documents").with(jwt().jwt(j -> j.subject(SUBJECT)))).andExpect(status().isOk()).andExpect(jsonPath("$[0].fileName").value("a.pdf"));
+    }
+
+    @Test
+    void integration_kb_listDocumentsRequiresAuth() throws Exception {
+        mockMvc.perform(get("/api/v1/knowledgebase/documents")).andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void integration_kb_createDocument() throws Exception {
+        when(knowledgeBaseService.createDocument(eq(SUBJECT), anyString(), anyString(), anyString(), any(), anyString())).thenReturn(doc());
+
+        mockMvc.perform(post("/api/v1/knowledgebase/documents/create").with(jwt().jwt(j -> j.subject(SUBJECT))).contentType(MediaType.APPLICATION_JSON).content("{\"fileName\":\"a.pdf\",\"objectKey\":\"/uploads/a.pdf\",\"fileType\":\"application/pdf\",\"fileSize\":100,\"textContent\":\"hi\"}")).andExpect(status().isCreated()).andExpect(jsonPath("$.fileName").value("a.pdf"));
+    }
+
+    @Test
+    void integration_kb_uploadDocument() throws Exception {
+        when(knowledgeBaseService.uploadDocument(eq(SUBJECT), any())).thenReturn(doc());
+        MockMultipartFile file = new MockMultipartFile("file", "a.pdf", "application/pdf", "hi".getBytes());
+
+        mockMvc.perform(multipart("/api/v1/knowledgebase/documents/upload").file(file).with(jwt().jwt(j -> j.subject(SUBJECT)))).andExpect(status().isCreated());
+    }
+
+    @Test
+    void integration_kb_getDocument() throws Exception {
+        UUID id = UUID.randomUUID();
+        when(knowledgeBaseService.getDocument(id, SUBJECT)).thenReturn(doc());
+
+        mockMvc.perform(get("/api/v1/knowledgebase/documents/" + id).with(jwt().jwt(j -> j.subject(SUBJECT)))).andExpect(status().isOk());
+    }
+
+    @Test
+    void integration_kb_getDocumentNotFoundReturns404() throws Exception {
+        UUID id = UUID.randomUUID();
+        when(knowledgeBaseService.getDocument(id, SUBJECT)).thenThrow(new DocumentNotFoundException(id));
+
+        mockMvc.perform(get("/api/v1/knowledgebase/documents/" + id).with(jwt().jwt(j -> j.subject(SUBJECT)))).andExpect(status().isNotFound());
+    }
+
+    @Test
+    void integration_kb_deleteDocument() throws Exception {
+        UUID id = UUID.randomUUID();
+
+        mockMvc.perform(delete("/api/v1/knowledgebase/documents/" + id).with(jwt().jwt(j -> j.subject(SUBJECT)))).andExpect(status().isNoContent());
+        verify(knowledgeBaseService).deleteDocument(id, SUBJECT);
+    }
+
+    @Test
+    void integration_kb_updateDocument() throws Exception {
+        UUID id = UUID.randomUUID();
+        when(knowledgeBaseService.updateDocument(eq(id), any(UpdateDocumentRequest.class), eq(SUBJECT))).thenReturn(doc());
+
+        mockMvc.perform(patch("/api/v1/knowledgebase/documents/" + id).with(jwt().jwt(j -> j.subject(SUBJECT))).contentType(MediaType.APPLICATION_JSON).content("{\"fileName\":\"b.pdf\"}")).andExpect(status().isOk());
+    }
+
+    @Test
+    void integration_kb_downloadDocumentReturnsBytes() throws Exception {
+        UUID id = UUID.randomUUID();
+        when(knowledgeBaseService.getDocument(id, SUBJECT)).thenReturn(doc());
+        when(knowledgeBaseService.getFileContent(id, SUBJECT)).thenReturn(Optional.of("hi".getBytes()));
+
+        mockMvc.perform(get("/api/v1/knowledgebase/documents/" + id + "/download").with(jwt().jwt(j -> j.subject(SUBJECT)))).andExpect(status().isOk()).andExpect(content().bytes("hi".getBytes()));
+    }
+
+    @Test
+    void integration_kb_downloadDocumentMissingContentReturns404() throws Exception {
+        UUID id = UUID.randomUUID();
+        when(knowledgeBaseService.getDocument(id, SUBJECT)).thenReturn(doc());
+        when(knowledgeBaseService.getFileContent(id, SUBJECT)).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/v1/knowledgebase/documents/" + id + "/download").with(jwt().jwt(j -> j.subject(SUBJECT)))).andExpect(status().isNotFound());
+    }
+
+    @Test
+    void integration_kb_searchText() throws Exception {
+        DocumentRefDto ref = new DocumentRefDto(UUID.randomUUID(), "a.pdf", "application/pdf", 100L, Instant.now());
+        when(knowledgeBaseService.search(SUBJECT, "report")).thenReturn(List.of(ref));
+
+        mockMvc.perform(get("/api/v1/knowledgebase/search/text").param("q", "report").with(jwt().jwt(j -> j.subject(SUBJECT)))).andExpect(status().isOk()).andExpect(jsonPath("$.results[0].fileName").value("a.pdf"));
+    }
+
+    @Test
+    void integration_kb_searchSemantic() throws Exception {
+        DocumentRefDto ref = new DocumentRefDto(UUID.randomUUID(), "a.pdf", "application/pdf", 100L, Instant.now());
+        SemanticSearchResponseDto response = new SemanticSearchResponseDto(List.of(new SemanticSearchResultDto(ref, 0.9, "snippet")), false);
+        when(knowledgeBaseService.semanticSearch(SUBJECT, "budget", 10)).thenReturn(response);
+
+        mockMvc.perform(get("/api/v1/knowledgebase/search/semantic").param("q", "budget").with(jwt().jwt(j -> j.subject(SUBJECT)))).andExpect(status().isOk()).andExpect(jsonPath("$.results[0].score").value(0.9));
+    }
+
+    @Test
+    void integration_kb_searchSemanticRejectsInvalidLimit() throws Exception {
+        mockMvc.perform(get("/api/v1/knowledgebase/search/semantic").param("q", "budget").param("limit", "0").with(jwt().jwt(j -> j.subject(SUBJECT)))).andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void integration_kb_addTag() throws Exception {
+        UUID id = UUID.randomUUID();
+
+        mockMvc.perform(post("/api/v1/knowledgebase/documents/" + id + "/tags").with(jwt().jwt(j -> j.subject(SUBJECT))).contentType(MediaType.APPLICATION_JSON).content("{\"label\":\"finance\"}")).andExpect(status().isNoContent());
+        verify(knowledgeBaseService).addTag(id, SUBJECT, "finance", TagSource.USER);
+    }
+
+    @Test
+    void integration_kb_removeTag() throws Exception {
+        UUID docId = UUID.randomUUID();
+        UUID tagId = UUID.randomUUID();
+
+        mockMvc.perform(delete("/api/v1/knowledgebase/documents/" + docId + "/tags/" + tagId).with(jwt().jwt(j -> j.subject(SUBJECT)))).andExpect(status().isNoContent());
+        verify(knowledgeBaseService).removeTag(docId, SUBJECT, tagId);
+    }
+
+    @Test
+    void integration_kb_getSummaryReturnsDto() throws Exception {
+        UUID id = UUID.randomUUID();
+        Summary summary = new Summary(doc(), "content", "model");
+        when(knowledgeBaseService.getDocumentSummary(id, SUBJECT)).thenReturn(summary);
+
+        mockMvc.perform(get("/api/v1/knowledgebase/documents/" + id + "/summary").with(jwt().jwt(j -> j.subject(SUBJECT)))).andExpect(status().isOk()).andExpect(jsonPath("$.summary").value("content"));
+    }
+
+    @Test
+    void integration_kb_getSummaryReturns204WhenMissing() throws Exception {
+        UUID id = UUID.randomUUID();
+        when(knowledgeBaseService.getDocumentSummary(id, SUBJECT)).thenReturn(null);
+
+        mockMvc.perform(get("/api/v1/knowledgebase/documents/" + id + "/summary").with(jwt().jwt(j -> j.subject(SUBJECT)))).andExpect(status().isNoContent());
+    }
+
+    @Test
+    void integration_kb_getEntities() throws Exception {
+        UUID id = UUID.randomUUID();
+        ExtractedEntity entity = new ExtractedEntity(doc(), "Ada", EntityType.PERSON, 0.9);
+        when(knowledgeBaseService.getDocumentEntities(id, SUBJECT)).thenReturn(List.of(entity));
+
+        mockMvc.perform(get("/api/v1/knowledgebase/documents/" + id + "/entities").with(jwt().jwt(j -> j.subject(SUBJECT)))).andExpect(status().isOk()).andExpect(jsonPath("$.entities[0].name").value("Ada"));
+    }
+
+    @Test
+    void integration_kb_reprocessSummary() throws Exception {
+        UUID id = UUID.randomUUID();
+        mockMvc.perform(post("/api/v1/knowledgebase/documents/" + id + "/reprocess/summary").with(jwt().jwt(j -> j.subject(SUBJECT)))).andExpect(status().isNoContent());
+        verify(knowledgeBaseService).reprocessSummary(id, SUBJECT);
+    }
+
+    @Test
+    void integration_kb_reprocessEntities() throws Exception {
+        UUID id = UUID.randomUUID();
+        mockMvc.perform(post("/api/v1/knowledgebase/documents/" + id + "/reprocess/entities").with(jwt().jwt(j -> j.subject(SUBJECT)))).andExpect(status().isNoContent());
+        verify(knowledgeBaseService).reprocessEntities(id, SUBJECT);
+    }
+
+    @Test
+    void integration_kb_reprocessTags() throws Exception {
+        UUID id = UUID.randomUUID();
+        mockMvc.perform(post("/api/v1/knowledgebase/documents/" + id + "/reprocess/tags").with(jwt().jwt(j -> j.subject(SUBJECT)))).andExpect(status().isNoContent());
+        verify(knowledgeBaseService).reprocessTags(id, SUBJECT);
+    }
+
+    @Test
+    void integration_kb_getSearchHistory() throws Exception {
+        when(knowledgeBaseService.getSearchHistory(SUBJECT)).thenReturn(List.of(new SearchQuery(SUBJECT, "report", 1)));
+
+        mockMvc.perform(get("/api/v1/knowledgebase/history/search").with(jwt().jwt(j -> j.subject(SUBJECT)))).andExpect(status().isOk()).andExpect(jsonPath("$[0].queryText").value("report"));
+    }
+
+    @Test
+    void integration_kb_deleteSearchHistory() throws Exception {
+        mockMvc.perform(delete("/api/v1/knowledgebase/history/search").with(jwt().jwt(j -> j.subject(SUBJECT)))).andExpect(status().isNoContent());
+        verify(knowledgeBaseService).deleteSearchHistory(SUBJECT);
+    }
+
+    @Test
+    void integration_kb_getTagsSortedByCount() throws Exception {
+        when(knowledgeBaseService.getTagsForUserWithCount(SUBJECT)).thenReturn(Map.of("finance", 3L, "report", 1L));
+
+        mockMvc.perform(get("/api/v1/knowledgebase/tags").with(jwt().jwt(j -> j.subject(SUBJECT)))).andExpect(status().isOk()).andExpect(jsonPath("$.tags[0].name").value("finance")).andExpect(jsonPath("$.tags[0].documentCount").value(3));
+    }
+}

--- a/services/spring/knowledgebase-service/src/test/java/com/alexandria/knowledgebase/KnowledgeBaseServiceTest.java
+++ b/services/spring/knowledgebase-service/src/test/java/com/alexandria/knowledgebase/KnowledgeBaseServiceTest.java
@@ -3,6 +3,7 @@ package com.alexandria.knowledgebase;
 import com.alexandria.knowledgebase.document.*;
 import com.alexandria.knowledgebase.dto.DocumentRefDto;
 import com.alexandria.knowledgebase.dto.SemanticSearchResponseDto;
+import com.alexandria.knowledgebase.dto.UpdateDocumentRequest;
 import com.alexandria.knowledgebase.integration.GenAiClient;
 import com.alexandria.knowledgebase.search.SearchQuery;
 import com.alexandria.knowledgebase.search.SearchQueryRepository;
@@ -302,6 +303,189 @@ class KnowledgeBaseServiceTest {
         knowledgeBaseService.reprocessTags(docId, OWNER);
 
         assertThat(doc.getTags()).extracting(Tag::getLabel).containsExactlyInAnyOrder("keep-me", "fresh");
+    }
+
+    @Test
+    void unit_kb_getDocumentsDelegates() {
+        Document doc = new Document(OWNER, "a.pdf", "/uploads/a.pdf", "application/pdf", 1L);
+        when(documentService.findByOwnerSubject(OWNER)).thenReturn(List.of(doc));
+        assertThat(knowledgeBaseService.getDocuments(OWNER)).containsExactly(doc);
+    }
+
+    @Test
+    void unit_kb_resolveDocumentsReturnsEmptyForNoKeys() {
+        assertThat(knowledgeBaseService.resolveDocuments(OWNER, List.of())).isEmpty();
+        assertThat(knowledgeBaseService.resolveDocuments(OWNER, null)).isEmpty();
+        verify(documentService, never()).findByOwnerSubjectAndObjectKeyIn(anyString(), anyList());
+    }
+
+    @Test
+    void unit_kb_resolveDocumentsDelegatesForKeys() {
+        Document doc = new Document(OWNER, "a.pdf", "/uploads/a.pdf", "application/pdf", 1L);
+        when(documentService.findByOwnerSubjectAndObjectKeyIn(OWNER, List.of("/uploads/a.pdf"))).thenReturn(List.of(doc));
+        assertThat(knowledgeBaseService.resolveDocuments(OWNER, List.of("/uploads/a.pdf"))).containsExactly(doc);
+    }
+
+    @Test
+    void unit_kb_getDocumentSummaryAndEntitiesReadThroughDocument() {
+        UUID docId = UUID.randomUUID();
+        Document doc = new Document(OWNER, "a.pdf", "/uploads/a.pdf", "application/pdf", 1L);
+        Summary summary = new Summary(doc, "text", "model");
+        doc.setSummary(summary);
+        ExtractedEntity entity = new ExtractedEntity(doc, "Ada", EntityType.PERSON, 0.9);
+        doc.setExtractedEntities(List.of(entity));
+        when(documentService.findByIdAndOwner(docId, OWNER)).thenReturn(doc);
+
+        assertThat(knowledgeBaseService.getDocumentSummary(docId, OWNER)).isSameAs(summary);
+        assertThat(knowledgeBaseService.getDocumentEntities(docId, OWNER)).containsExactly(entity);
+    }
+
+    @Test
+    void unit_kb_getFileContentReturnsBytes() {
+        UUID docId = UUID.randomUUID();
+        Document doc = new Document(OWNER, "a.pdf", "/uploads/a.pdf", "application/pdf", 1L);
+        when(documentService.findByIdAndOwner(docId, OWNER)).thenReturn(doc);
+        when(objectStorageService.download("/uploads/a.pdf")).thenReturn("hi".getBytes());
+
+        assertThat(knowledgeBaseService.getFileContent(docId, OWNER)).contains("hi".getBytes());
+    }
+
+    @Test
+    void unit_kb_getFileContentEmptyOnDownloadFailure() {
+        UUID docId = UUID.randomUUID();
+        Document doc = new Document(OWNER, "a.pdf", "/uploads/a.pdf", "application/pdf", 1L);
+        when(documentService.findByIdAndOwner(docId, OWNER)).thenReturn(doc);
+        when(objectStorageService.download("/uploads/a.pdf")).thenThrow(new RuntimeException("s3 down"));
+
+        assertThat(knowledgeBaseService.getFileContent(docId, OWNER)).isEmpty();
+    }
+
+    @Test
+    void unit_kb_updateDocumentChangesFileName() {
+        UUID docId = UUID.randomUUID();
+        Document doc = new Document(OWNER, "a.pdf", "/uploads/a.pdf", "application/pdf", 1L);
+        when(documentService.findByIdAndOwner(docId, OWNER)).thenReturn(doc);
+        when(documentService.save(any(Document.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        knowledgeBaseService.updateDocument(docId, new UpdateDocumentRequest("b.pdf"), OWNER);
+
+        assertThat(doc.getFileName()).isEqualTo("b.pdf");
+    }
+
+    @Test
+    void unit_kb_updateDocumentIgnoresNullFileName() {
+        UUID docId = UUID.randomUUID();
+        Document doc = new Document(OWNER, "a.pdf", "/uploads/a.pdf", "application/pdf", 1L);
+        when(documentService.findByIdAndOwner(docId, OWNER)).thenReturn(doc);
+        when(documentService.save(any(Document.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        knowledgeBaseService.updateDocument(docId, new UpdateDocumentRequest(null), OWNER);
+
+        assertThat(doc.getFileName()).isEqualTo("a.pdf");
+    }
+
+    @Test
+    void unit_kb_addTagReusesOrCreates() {
+        UUID docId = UUID.randomUUID();
+        Document doc = new Document(OWNER, "a.pdf", "/uploads/a.pdf", "application/pdf", 1L);
+        when(documentService.findByIdAndOwner(docId, OWNER)).thenReturn(doc);
+        when(tagRepository.findByLabel("finance")).thenReturn(Optional.empty());
+        when(tagRepository.save(any(Tag.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        knowledgeBaseService.addTag(docId, OWNER, "finance", TagSource.USER);
+
+        assertThat(doc.getTags()).extracting(Tag::getLabel).containsExactly("finance");
+        verify(documentService).save(doc);
+    }
+
+    @Test
+    void unit_kb_removeTagWhenPresent() {
+        UUID docId = UUID.randomUUID();
+        UUID tagId = UUID.randomUUID();
+        Document doc = new Document(OWNER, "a.pdf", "/uploads/a.pdf", "application/pdf", 1L);
+        Tag tag = new Tag("finance", TagSource.USER);
+        doc.addTag(tag);
+        when(documentService.findByIdAndOwner(docId, OWNER)).thenReturn(doc);
+        when(tagRepository.findById(tagId)).thenReturn(Optional.of(tag));
+
+        knowledgeBaseService.removeTag(docId, OWNER, tagId);
+
+        assertThat(doc.getTags()).isEmpty();
+        verify(documentService).save(doc);
+    }
+
+    @Test
+    void unit_kb_removeTagNoopWhenMissing() {
+        UUID docId = UUID.randomUUID();
+        UUID tagId = UUID.randomUUID();
+        Document doc = new Document(OWNER, "a.pdf", "/uploads/a.pdf", "application/pdf", 1L);
+        when(documentService.findByIdAndOwner(docId, OWNER)).thenReturn(doc);
+        when(tagRepository.findById(tagId)).thenReturn(Optional.empty());
+
+        knowledgeBaseService.removeTag(docId, OWNER, tagId);
+
+        verify(documentService, never()).save(any(Document.class));
+    }
+
+    @Test
+    void unit_kb_reprocessSummaryDropsExistingBeforeRegenerating() {
+        UUID docId = UUID.randomUUID();
+        Document doc = new Document(OWNER, "a.pdf", "/uploads/a.pdf", "application/pdf", 1L);
+        Summary existing = new Summary(doc, "old", "model");
+        doc.setSummary(existing);
+        when(documentService.findByIdAndOwner(docId, OWNER)).thenReturn(doc);
+        when(genAiClient.summarize("/uploads/a.pdf")).thenReturn(new GenAiClient.SummarizeResponse("new", "model"));
+        when(summaryRepository.save(any(Summary.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        knowledgeBaseService.reprocessSummary(docId, OWNER);
+
+        verify(summaryRepository).delete(existing);
+        assertThat(doc.getSummary().getContent()).isEqualTo("new");
+    }
+
+    @Test
+    void unit_kb_reprocessEntitiesRebuildsFromGenAi() {
+        UUID docId = UUID.randomUUID();
+        Document doc = new Document(OWNER, "a.pdf", "/uploads/a.pdf", "application/pdf", 1L);
+        when(documentService.findByIdAndOwner(docId, OWNER)).thenReturn(doc);
+        when(genAiClient.extract("/uploads/a.pdf")).thenReturn(new GenAiClient.ExtractResponse(List.of(new GenAiClient.ExtractedEntityDto("Ada", EntityType.PERSON, 0.9)), "model"));
+        when(extractedEntityRepository.save(any(ExtractedEntity.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        knowledgeBaseService.reprocessEntities(docId, OWNER);
+
+        verify(extractedEntityRepository).deleteByDocumentId(docId);
+        org.mockito.ArgumentCaptor<ExtractedEntity> captor = org.mockito.ArgumentCaptor.forClass(ExtractedEntity.class);
+        verify(extractedEntityRepository).save(captor.capture());
+        assertThat(captor.getValue().getName()).isEqualTo("Ada");
+    }
+
+    @Test
+    void unit_kb_getSearchHistoryDelegates() {
+        SearchQuery query = new SearchQuery(OWNER, "report", 1);
+        when(searchQueryRepository.findByUserSubjectOrderByTimestampDesc(OWNER)).thenReturn(List.of(query));
+        assertThat(knowledgeBaseService.getSearchHistory(OWNER)).containsExactly(query);
+    }
+
+    @Test
+    void unit_kb_deleteSearchHistoryDelegates() {
+        knowledgeBaseService.deleteSearchHistory(OWNER);
+        verify(searchQueryRepository).deleteByUserSubject(OWNER);
+    }
+
+    @Test
+    void unit_kb_getTagsForUserWithCountMapsProjection() {
+        when(tagRepository.findTagCountsByOwnerSubject(OWNER)).thenReturn(List.of(tagCount("finance", 3)));
+        assertThat(knowledgeBaseService.getTagsForUserWithCount(OWNER)).containsEntry("finance", 3L);
+    }
+
+    @Test
+    void unit_kb_processDocumentAsyncSkipsMissingDocument() {
+        UUID docId = UUID.randomUUID();
+        when(documentService.findById(docId)).thenThrow(new RuntimeException("gone"));
+
+        knowledgeBaseService.processDocumentAsync(docId);
+
+        verifyNoInteractions(genAiClient);
     }
 
     private static TagRepository.TagCountProjection tagCount(String label, long count) {

--- a/services/spring/knowledgebase-service/src/test/java/com/alexandria/knowledgebase/ObjectStorageServiceTest.java
+++ b/services/spring/knowledgebase-service/src/test/java/com/alexandria/knowledgebase/ObjectStorageServiceTest.java
@@ -1,5 +1,7 @@
 package com.alexandria.knowledgebase;
 
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,11 +31,12 @@ class ObjectStorageServiceTest {
     @Mock
     private S3Client s3Client;
 
+    private final MeterRegistry registry = new SimpleMeterRegistry();
     private ObjectStorageService service;
 
     @BeforeEach
     void setup() {
-        service = new ObjectStorageService(s3Client);
+        service = new ObjectStorageService(s3Client, registry);
         ReflectionTestUtils.setField(service, "bucket", "default-bucket");
     }
 
@@ -107,5 +110,21 @@ class ObjectStorageServiceTest {
     void unit_kb_deleteUsesDefaultBucket() {
         service.delete("key");
         verify(s3Client).deleteObject(any(DeleteObjectRequest.class));
+    }
+
+    @Test
+    void unit_kb_recordsUploadSuccessAndErrorMetrics() {
+        MultipartFile file = new MockMultipartFile("f", "a.pdf", "application/pdf", "hi".getBytes());
+        service.upload("key", file);
+        assertThat(registry.get("s3.operations").tags("operation", "upload", "outcome", "success").counter().count()).isEqualTo(1.0);
+
+        MultipartFile broken = new MockMultipartFile("f", "a.pdf", "application/pdf", new byte[0]) {
+            @Override
+            public byte[] getBytes() throws IOException {
+                throw new IOException("boom");
+            }
+        };
+        assertThatThrownBy(() -> service.upload("bucket", "key", broken)).isInstanceOf(RuntimeException.class);
+        assertThat(registry.get("s3.operations").tags("operation", "upload", "outcome", "error").counter().count()).isEqualTo(1.0);
     }
 }

--- a/services/spring/knowledgebase-service/src/test/java/com/alexandria/knowledgebase/ObjectStorageServiceTest.java
+++ b/services/spring/knowledgebase-service/src/test/java/com/alexandria/knowledgebase/ObjectStorageServiceTest.java
@@ -1,0 +1,111 @@
+package com.alexandria.knowledgebase;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.core.sync.ResponseTransformer;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.*;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ObjectStorageServiceTest {
+
+    @Mock
+    private S3Client s3Client;
+
+    private ObjectStorageService service;
+
+    @BeforeEach
+    void setup() {
+        service = new ObjectStorageService(s3Client);
+        ReflectionTestUtils.setField(service, "bucket", "default-bucket");
+    }
+
+    @Test
+    void unit_kb_bucketExistsTrue() {
+        when(s3Client.headBucket(any(HeadBucketRequest.class))).thenReturn(HeadBucketResponse.builder().build());
+        assertThat(service.bucketExists("b")).isTrue();
+    }
+
+    @Test
+    void unit_kb_bucketExistsFalseOnNoSuchBucket() {
+        when(s3Client.headBucket(any(HeadBucketRequest.class))).thenThrow(NoSuchBucketException.builder().build());
+        assertThat(service.bucketExists("b")).isFalse();
+    }
+
+    @Test
+    void unit_kb_createBucketOnlyWhenMissing() {
+        when(s3Client.headBucket(any(HeadBucketRequest.class))).thenThrow(NoSuchBucketException.builder().build());
+        service.createBucket("b");
+        verify(s3Client).createBucket(any(CreateBucketRequest.class));
+    }
+
+    @Test
+    void unit_kb_createBucketSkipsWhenPresent() {
+        when(s3Client.headBucket(any(HeadBucketRequest.class))).thenReturn(HeadBucketResponse.builder().build());
+        service.createBucket("b");
+        verify(s3Client, never()).createBucket(any(CreateBucketRequest.class));
+    }
+
+    @Test
+    void unit_kb_deleteBucketOnlyWhenPresent() {
+        when(s3Client.headBucket(any(HeadBucketRequest.class))).thenReturn(HeadBucketResponse.builder().build());
+        service.deleteBucket("b");
+        verify(s3Client).deleteBucket(any(DeleteBucketRequest.class));
+    }
+
+    @Test
+    void unit_kb_deleteBucketSkipsWhenMissing() {
+        when(s3Client.headBucket(any(HeadBucketRequest.class))).thenThrow(NoSuchBucketException.builder().build());
+        service.deleteBucket("b");
+        verify(s3Client, never()).deleteBucket(any(DeleteBucketRequest.class));
+    }
+
+    @Test
+    void unit_kb_uploadUsesDefaultBucket() {
+        MultipartFile file = new MockMultipartFile("f", "a.pdf", "application/pdf", "hi".getBytes());
+        service.upload("key", file);
+        verify(s3Client).putObject(any(PutObjectRequest.class), any(RequestBody.class));
+    }
+
+    @Test
+    void unit_kb_uploadWrapsIoException() throws IOException {
+        MultipartFile file = new MockMultipartFile("f", "a.pdf", "application/pdf", new byte[0]) {
+            @Override
+            public byte[] getBytes() throws IOException {
+                throw new IOException("boom");
+            }
+        };
+        assertThatThrownBy(() -> service.upload("b", "key", file)).isInstanceOf(RuntimeException.class).hasMessageContaining("Failed to upload");
+    }
+
+    @Test
+    void unit_kb_downloadReturnsBytes() {
+        ResponseBytes<GetObjectResponse> bytes = ResponseBytes.fromByteArray(GetObjectResponse.builder().build(), "hi".getBytes());
+        when(s3Client.getObject(any(GetObjectRequest.class), any(ResponseTransformer.class))).thenReturn(bytes);
+
+        assertThat(service.download("key")).isEqualTo("hi".getBytes());
+    }
+
+    @Test
+    void unit_kb_deleteUsesDefaultBucket() {
+        service.delete("key");
+        verify(s3Client).deleteObject(any(DeleteObjectRequest.class));
+    }
+}

--- a/services/spring/knowledgebase-service/src/test/java/com/alexandria/knowledgebase/S3ClientConfigTest.java
+++ b/services/spring/knowledgebase-service/src/test/java/com/alexandria/knowledgebase/S3ClientConfigTest.java
@@ -1,0 +1,23 @@
+package com.alexandria.knowledgebase;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import software.amazon.awssdk.services.s3.S3Client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class S3ClientConfigTest {
+
+    @Test
+    void unit_kb_buildsS3ClientFromConfiguredValues() {
+        S3ClientConfig config = new S3ClientConfig();
+        ReflectionTestUtils.setField(config, "endpoint", "http://localhost:9000");
+        ReflectionTestUtils.setField(config, "region", "eu-central-1");
+        ReflectionTestUtils.setField(config, "accessKey", "key");
+        ReflectionTestUtils.setField(config, "secretKey", "secret");
+
+        try (S3Client client = config.s3Client()) {
+            assertThat(client).isNotNull();
+        }
+    }
+}

--- a/services/spring/knowledgebase-service/src/test/java/com/alexandria/knowledgebase/TextExtractorTest.java
+++ b/services/spring/knowledgebase-service/src/test/java/com/alexandria/knowledgebase/TextExtractorTest.java
@@ -1,0 +1,73 @@
+package com.alexandria.knowledgebase;
+
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.font.PDType1Font;
+import org.apache.pdfbox.pdmodel.font.Standard14Fonts;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TextExtractorTest {
+
+    private final TextExtractor extractor = new TextExtractor();
+
+    @Test
+    void unit_kb_extractReturnsNullWhenContentTypeMissing() {
+        MultipartFile file = new MockMultipartFile("f", "a.bin", null, "hi".getBytes());
+        assertThat(extractor.extract(file)).isNull();
+    }
+
+    @Test
+    void unit_kb_extractReadsPlainText() {
+        MultipartFile file = new MockMultipartFile("f", "a.txt", "text/plain", "hello world".getBytes());
+        assertThat(extractor.extract(file)).isEqualTo("hello world");
+    }
+
+    @Test
+    void unit_kb_extractStripsNullBytes() {
+        MultipartFile file = new MockMultipartFile("f", "a.txt", "text/plain", "a\u0000b".getBytes());
+        assertThat(extractor.extract(file)).isEqualTo("ab");
+    }
+
+    @Test
+    void unit_kb_extractReturnsNullForUnsupportedType() {
+        MultipartFile file = new MockMultipartFile("f", "a.png", "image/png", "hi".getBytes());
+        assertThat(extractor.extract(file)).isNull();
+    }
+
+    @Test
+    void unit_kb_extractReadsPdfText() throws IOException {
+        byte[] pdf = pdfWithText("Alexandria");
+        MultipartFile file = new MockMultipartFile("f", "a.pdf", "application/pdf", pdf);
+        assertThat(extractor.extract(file)).contains("Alexandria");
+    }
+
+    @Test
+    void unit_kb_extractReturnsNullOnUnreadablePdf() {
+        MultipartFile file = new MockMultipartFile("f", "a.pdf", "application/pdf", "not a pdf".getBytes());
+        assertThat(extractor.extract(file)).isNull();
+    }
+
+    private static byte[] pdfWithText(String text) throws IOException {
+        try (PDDocument document = new PDDocument(); ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            PDPage page = new PDPage();
+            document.addPage(page);
+            try (PDPageContentStream content = new PDPageContentStream(document, page)) {
+                content.beginText();
+                content.setFont(new PDType1Font(Standard14Fonts.FontName.HELVETICA), 12);
+                content.newLineAtOffset(100, 700);
+                content.showText(text);
+                content.endText();
+            }
+            document.save(out);
+            return out.toByteArray();
+        }
+    }
+}

--- a/services/spring/knowledgebase-service/src/test/java/com/alexandria/knowledgebase/document/DocumentModelTest.java
+++ b/services/spring/knowledgebase-service/src/test/java/com/alexandria/knowledgebase/document/DocumentModelTest.java
@@ -1,0 +1,121 @@
+package com.alexandria.knowledgebase.document;
+
+import com.alexandria.knowledgebase.search.SearchQuery;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// Getter/setter and relationship-helper coverage the service tests only touch indirectly.
+class DocumentModelTest {
+
+    @Test
+    void unit_kb_documentSettersAndTagLinkBothSides() {
+        Document doc = new Document("owner", "a.pdf", "/uploads/a.pdf", "application/pdf", 100L);
+        doc.setFileName("b.pdf");
+        doc.setObjectKey("/uploads/b.pdf");
+        doc.setFileType("text/plain");
+        doc.setFileSize(200L);
+        doc.setOwnerSubject("owner2");
+        doc.setRawTextContent("hello");
+
+        assertThat(doc.getFileName()).isEqualTo("b.pdf");
+        assertThat(doc.getObjectKey()).isEqualTo("/uploads/b.pdf");
+        assertThat(doc.getFileType()).isEqualTo("text/plain");
+        assertThat(doc.getFileSize()).isEqualTo(200L);
+        assertThat(doc.getOwnerSubject()).isEqualTo("owner2");
+        assertThat(doc.getRawTextContent()).isEqualTo("hello");
+
+        Tag tag = new Tag("finance", TagSource.USER);
+        doc.addTag(tag);
+        assertThat(doc.getTags()).containsExactly(tag);
+
+        doc.removeTag(tag);
+        assertThat(doc.getTags()).isEmpty();
+    }
+
+    @Test
+    void unit_kb_documentSummaryAndEntitiesAccessors() {
+        Document doc = new Document("owner", "a.pdf", "/uploads/a.pdf", "application/pdf", 100L);
+        Summary summary = new Summary(doc, "content", "model");
+        doc.setSummary(summary);
+        assertThat(doc.getSummary()).isSameAs(summary);
+
+        ExtractedEntity entity = new ExtractedEntity(doc, "Ada", EntityType.PERSON, 0.9);
+        doc.setExtractedEntities(List.of(entity));
+        assertThat(doc.getExtractedEntities()).containsExactly(entity);
+
+        doc.setExtractedEntities(null);
+        assertThat(doc.getExtractedEntities()).isEmpty();
+
+        doc.setTags(null);
+        assertThat(doc.getTags()).isNull();
+        doc.setTags(Set.of(new Tag("x", TagSource.AUTO)));
+        assertThat(doc.getTags()).hasSize(1);
+    }
+
+    @Test
+    void unit_kb_tagSetters() {
+        Tag tag = new Tag("finance", TagSource.USER);
+        tag.setLabel("budget");
+        tag.setSource(TagSource.AUTO);
+        assertThat(tag.getLabel()).isEqualTo("budget");
+        assertThat(tag.getSource()).isEqualTo(TagSource.AUTO);
+
+        tag.setDocuments(null);
+        assertThat(tag.getDocuments()).isEmpty();
+    }
+
+    @Test
+    void unit_kb_extractedEntitySetters() {
+        Document doc = new Document("owner", "a.pdf", "/uploads/a.pdf", "application/pdf", 100L);
+        ExtractedEntity entity = new ExtractedEntity();
+        entity.setDocument(doc);
+        entity.setName("Ada");
+        entity.setType(EntityType.PERSON);
+        entity.setConfidence(0.8);
+
+        assertThat(entity.getDocument()).isSameAs(doc);
+        assertThat(entity.getName()).isEqualTo("Ada");
+        assertThat(entity.getType()).isEqualTo(EntityType.PERSON);
+        assertThat(entity.getConfidence()).isEqualTo(0.8);
+    }
+
+    @Test
+    void unit_kb_summarySetters() {
+        Document doc = new Document("owner", "a.pdf", "/uploads/a.pdf", "application/pdf", 100L);
+        Summary summary = new Summary();
+        summary.setDocument(doc);
+        summary.setContent("text");
+        summary.setModelUsed("gpt");
+
+        assertThat(summary.getDocument()).isSameAs(doc);
+        assertThat(summary.getContent()).isEqualTo("text");
+        assertThat(summary.getModelUsed()).isEqualTo("gpt");
+        assertThat(summary.getGeneratedAt()).isNull();
+    }
+
+    @Test
+    void unit_kb_searchQuerySetters() {
+        SearchQuery query = new SearchQuery("owner", "report", 5);
+        assertThat(query.getUserSubject()).isEqualTo("owner");
+        assertThat(query.getQueryText()).isEqualTo("report");
+        assertThat(query.getResultCount()).isEqualTo(5);
+        assertThat(query.getTimestamp()).isNotNull();
+
+        query.setUserSubject("owner2");
+        query.setQueryText("budget");
+        query.setResultCount(10);
+        assertThat(query.getUserSubject()).isEqualTo("owner2");
+        assertThat(query.getQueryText()).isEqualTo("budget");
+        assertThat(query.getResultCount()).isEqualTo(10);
+    }
+
+    @Test
+    void unit_kb_entityTypeAndTagSourceValues() {
+        assertThat(EntityType.valueOf("PERSON")).isEqualTo(EntityType.PERSON);
+        assertThat(TagSource.valueOf("USER")).isEqualTo(TagSource.USER);
+    }
+}

--- a/services/spring/knowledgebase-service/src/test/java/com/alexandria/knowledgebase/integration/GenAiClientTest.java
+++ b/services/spring/knowledgebase-service/src/test/java/com/alexandria/knowledgebase/integration/GenAiClientTest.java
@@ -10,6 +10,8 @@ import com.alexandria.genai.client.model.GenAiSearchResult;
 import com.alexandria.genai.client.model.GenAiSummarizeResponse;
 import com.alexandria.genai.client.model.GenAiTagResponse;
 import com.alexandria.knowledgebase.document.EntityType;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
@@ -23,6 +25,12 @@ import static org.mockito.Mockito.when;
 
 class GenAiClientTest {
 
+    private final MeterRegistry registry = new SimpleMeterRegistry();
+
+    private GenAiClient client(AiApi aiApi) {
+        return new GenAiClient(aiApi, registry);
+    }
+
     private GenAiExtractedEntity entity(String name, String type, BigDecimal confidence) {
         return new GenAiExtractedEntity().name(name).type(type).confidence(confidence);
     }
@@ -34,7 +42,7 @@ class GenAiClientTest {
                 entity("Ada Lovelace", "PERSON", new BigDecimal("0.95")), entity("Something", "NONSENSE", new BigDecimal("0.5")), entity("Untyped", null, new BigDecimal("0.7"))));
         when(aiApi.extractGenaiExtractPost(any())).thenReturn(response);
 
-        GenAiClient client = new GenAiClient(aiApi);
+        GenAiClient client = client(aiApi);
         GenAiClient.ExtractResponse result = client.extract("/uploads/doc.pdf");
 
         assertThat(result.modelUsed()).isEqualTo("gpt-test");
@@ -50,7 +58,7 @@ class GenAiClientTest {
         AiApi aiApi = mock(AiApi.class);
         when(aiApi.summarizeDocumentGenaiSummarizePost(any())).thenReturn(new GenAiSummarizeResponse().summary("s").modelUsed("m"));
 
-        GenAiClient.SummarizeResponse result = new GenAiClient(aiApi).summarize("/uploads/a.pdf");
+        GenAiClient.SummarizeResponse result = client(aiApi).summarize("/uploads/a.pdf");
 
         assertThat(result.summary()).isEqualTo("s");
         assertThat(result.modelUsed()).isEqualTo("m");
@@ -61,7 +69,7 @@ class GenAiClientTest {
         AiApi aiApi = mock(AiApi.class);
         when(aiApi.tagGenaiTagPost(any())).thenReturn(new GenAiTagResponse().tags(List.of("finance")).modelUsed("m"));
 
-        GenAiClient.TagResponse result = new GenAiClient(aiApi).tag("/uploads/a.pdf", List.of("finance"));
+        GenAiClient.TagResponse result = client(aiApi).tag("/uploads/a.pdf", List.of("finance"));
 
         assertThat(result.tags()).containsExactly("finance");
         assertThat(result.modelUsed()).isEqualTo("m");
@@ -72,7 +80,7 @@ class GenAiClientTest {
         AiApi aiApi = mock(AiApi.class);
         when(aiApi.tagGenaiTagPost(any())).thenReturn(new GenAiTagResponse().tags(List.of()).modelUsed("m"));
 
-        new GenAiClient(aiApi).tag("/uploads/a.pdf", null);
+        client(aiApi).tag("/uploads/a.pdf", null);
     }
 
     @Test
@@ -80,7 +88,7 @@ class GenAiClientTest {
         AiApi aiApi = mock(AiApi.class);
         when(aiApi.indexGenaiIndexPost(any())).thenReturn(new GenAiIndexResponse().objectKey("/uploads/a.pdf").chunksIndexed(3).embeddingModel("e"));
 
-        GenAiClient.IndexResponse result = new GenAiClient(aiApi).index("/uploads/a.pdf");
+        GenAiClient.IndexResponse result = client(aiApi).index("/uploads/a.pdf");
 
         assertThat(result.objectKey()).isEqualTo("/uploads/a.pdf");
         assertThat(result.chunksIndexed()).isEqualTo(3);
@@ -92,7 +100,7 @@ class GenAiClientTest {
         AiApi aiApi = mock(AiApi.class);
         when(aiApi.deleteIndexGenaiIndexObjectKeyDelete(eq("/uploads/a.pdf"))).thenReturn(new GenAiDeleteIndexResponse().objectKey("/uploads/a.pdf").chunksDeleted(3));
 
-        GenAiClient.DeleteIndexResponse result = new GenAiClient(aiApi).deleteIndex("/uploads/a.pdf");
+        GenAiClient.DeleteIndexResponse result = client(aiApi).deleteIndex("/uploads/a.pdf");
 
         assertThat(result.objectKey()).isEqualTo("/uploads/a.pdf");
         assertThat(result.chunksDeleted()).isEqualTo(3);
@@ -104,7 +112,7 @@ class GenAiClientTest {
         GenAiSearchResult hit = new GenAiSearchResult().objectKey("/uploads/a.pdf").score(new BigDecimal("0.8")).snippet("snip");
         when(aiApi.searchGenaiSearchPost(any())).thenReturn(new GenAiSearchResponse().results(List.of(hit)).embeddingModel("e"));
 
-        GenAiClient.SearchResponse result = new GenAiClient(aiApi).search("q", List.of("/uploads/a.pdf"), 5);
+        GenAiClient.SearchResponse result = client(aiApi).search("q", List.of("/uploads/a.pdf"), 5);
 
         assertThat(result.embeddingModel()).isEqualTo("e");
         assertThat(result.results()).singleElement().satisfies(r -> {
@@ -119,8 +127,26 @@ class GenAiClientTest {
         AiApi aiApi = mock(AiApi.class);
         when(aiApi.searchGenaiSearchPost(any())).thenReturn(new GenAiSearchResponse().results(List.of()).embeddingModel("e"));
 
-        GenAiClient.SearchResponse result = new GenAiClient(aiApi).search("q", null, null);
+        GenAiClient.SearchResponse result = client(aiApi).search("q", null, null);
 
         assertThat(result.results()).isEmpty();
+    }
+
+    @Test
+    void unit_genai_recordsSuccessAndErrorMetrics() {
+        AiApi aiApi = mock(AiApi.class);
+        when(aiApi.summarizeDocumentGenaiSummarizePost(any())).thenReturn(new GenAiSummarizeResponse().summary("s").modelUsed("m"));
+        when(aiApi.indexGenaiIndexPost(any())).thenThrow(new RuntimeException("genai down"));
+        GenAiClient client = client(aiApi);
+
+        client.summarize("/uploads/a.pdf");
+        try {
+            client.index("/uploads/a.pdf");
+        } catch (RuntimeException ignored) {
+        }
+
+        assertThat(registry.get("genai.client.calls").tags("operation", "summarize", "outcome", "success").counter().count()).isEqualTo(1.0);
+        assertThat(registry.get("genai.client.calls").tags("operation", "index", "outcome", "error").counter().count()).isEqualTo(1.0);
+        assertThat(registry.get("genai.client.call.duration").tags("operation", "summarize", "outcome", "success").timer().count()).isEqualTo(1L);
     }
 }

--- a/services/spring/knowledgebase-service/src/test/java/com/alexandria/knowledgebase/integration/GenAiClientTest.java
+++ b/services/spring/knowledgebase-service/src/test/java/com/alexandria/knowledgebase/integration/GenAiClientTest.java
@@ -1,8 +1,14 @@
 package com.alexandria.knowledgebase.integration;
 
 import com.alexandria.genai.client.api.AiApi;
+import com.alexandria.genai.client.model.GenAiDeleteIndexResponse;
 import com.alexandria.genai.client.model.GenAiExtractResponse;
 import com.alexandria.genai.client.model.GenAiExtractedEntity;
+import com.alexandria.genai.client.model.GenAiIndexResponse;
+import com.alexandria.genai.client.model.GenAiSearchResponse;
+import com.alexandria.genai.client.model.GenAiSearchResult;
+import com.alexandria.genai.client.model.GenAiSummarizeResponse;
+import com.alexandria.genai.client.model.GenAiTagResponse;
 import com.alexandria.knowledgebase.document.EntityType;
 import org.junit.jupiter.api.Test;
 
@@ -11,6 +17,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -36,5 +43,84 @@ class GenAiClientTest {
         assertThat(dto.name()).isEqualTo("Ada Lovelace");
         assertThat(dto.type()).isEqualTo(EntityType.PERSON);
         assertThat(dto.confidence()).isEqualTo(0.95);
+    }
+
+    @Test
+    void unit_genai_summarizeMapsResponse() {
+        AiApi aiApi = mock(AiApi.class);
+        when(aiApi.summarizeDocumentGenaiSummarizePost(any())).thenReturn(new GenAiSummarizeResponse().summary("s").modelUsed("m"));
+
+        GenAiClient.SummarizeResponse result = new GenAiClient(aiApi).summarize("/uploads/a.pdf");
+
+        assertThat(result.summary()).isEqualTo("s");
+        assertThat(result.modelUsed()).isEqualTo("m");
+    }
+
+    @Test
+    void unit_genai_tagMapsResponse() {
+        AiApi aiApi = mock(AiApi.class);
+        when(aiApi.tagGenaiTagPost(any())).thenReturn(new GenAiTagResponse().tags(List.of("finance")).modelUsed("m"));
+
+        GenAiClient.TagResponse result = new GenAiClient(aiApi).tag("/uploads/a.pdf", List.of("finance"));
+
+        assertThat(result.tags()).containsExactly("finance");
+        assertThat(result.modelUsed()).isEqualTo("m");
+    }
+
+    @Test
+    void unit_genai_tagTreatsNullKnownTagsAsEmpty() {
+        AiApi aiApi = mock(AiApi.class);
+        when(aiApi.tagGenaiTagPost(any())).thenReturn(new GenAiTagResponse().tags(List.of()).modelUsed("m"));
+
+        new GenAiClient(aiApi).tag("/uploads/a.pdf", null);
+    }
+
+    @Test
+    void unit_genai_indexMapsResponse() {
+        AiApi aiApi = mock(AiApi.class);
+        when(aiApi.indexGenaiIndexPost(any())).thenReturn(new GenAiIndexResponse().objectKey("/uploads/a.pdf").chunksIndexed(3).embeddingModel("e"));
+
+        GenAiClient.IndexResponse result = new GenAiClient(aiApi).index("/uploads/a.pdf");
+
+        assertThat(result.objectKey()).isEqualTo("/uploads/a.pdf");
+        assertThat(result.chunksIndexed()).isEqualTo(3);
+        assertThat(result.embeddingModel()).isEqualTo("e");
+    }
+
+    @Test
+    void unit_genai_deleteIndexMapsResponse() {
+        AiApi aiApi = mock(AiApi.class);
+        when(aiApi.deleteIndexGenaiIndexObjectKeyDelete(eq("/uploads/a.pdf"))).thenReturn(new GenAiDeleteIndexResponse().objectKey("/uploads/a.pdf").chunksDeleted(3));
+
+        GenAiClient.DeleteIndexResponse result = new GenAiClient(aiApi).deleteIndex("/uploads/a.pdf");
+
+        assertThat(result.objectKey()).isEqualTo("/uploads/a.pdf");
+        assertThat(result.chunksDeleted()).isEqualTo(3);
+    }
+
+    @Test
+    void unit_genai_searchMapsResultsAndConvertsScore() {
+        AiApi aiApi = mock(AiApi.class);
+        GenAiSearchResult hit = new GenAiSearchResult().objectKey("/uploads/a.pdf").score(new BigDecimal("0.8")).snippet("snip");
+        when(aiApi.searchGenaiSearchPost(any())).thenReturn(new GenAiSearchResponse().results(List.of(hit)).embeddingModel("e"));
+
+        GenAiClient.SearchResponse result = new GenAiClient(aiApi).search("q", List.of("/uploads/a.pdf"), 5);
+
+        assertThat(result.embeddingModel()).isEqualTo("e");
+        assertThat(result.results()).singleElement().satisfies(r -> {
+            assertThat(r.objectKey()).isEqualTo("/uploads/a.pdf");
+            assertThat(r.score()).isEqualTo(0.8);
+            assertThat(r.snippet()).isEqualTo("snip");
+        });
+    }
+
+    @Test
+    void unit_genai_searchTreatsNullKeysAndLimitAsDefaults() {
+        AiApi aiApi = mock(AiApi.class);
+        when(aiApi.searchGenaiSearchPost(any())).thenReturn(new GenAiSearchResponse().results(List.of()).embeddingModel("e"));
+
+        GenAiClient.SearchResponse result = new GenAiClient(aiApi).search("q", null, null);
+
+        assertThat(result.results()).isEmpty();
     }
 }

--- a/services/spring/qa-service/src/main/java/com/alexandria/qa/InternalController.java
+++ b/services/spring/qa-service/src/main/java/com/alexandria/qa/InternalController.java
@@ -11,6 +11,13 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * Service-to-service endpoints for the qa-service.
+ *
+ * <p>Not routed by Traefik or the Kubernetes Ingress, so only reachable from inside the
+ * cluster network, and authenticated by an HMAC signature instead of a user bearer token.
+ * Used by user-service to purge a user's Q&amp;A data on account deletion.
+ */
 @RestController
 @RequestMapping(path = "/internal/qa", produces = MediaType.APPLICATION_JSON_VALUE)
 @Tag(name = "QA Service (Internal)", description = "Service-to-service endpoints, reachable only inside the cluster network")

--- a/services/spring/qa-service/src/main/java/com/alexandria/qa/QAController.java
+++ b/services/spring/qa-service/src/main/java/com/alexandria/qa/QAController.java
@@ -14,6 +14,14 @@ import org.springframework.web.bind.annotation.*;
 import java.security.Principal;
 import java.util.List;
 
+/**
+ * Public REST API for question answering over the caller's knowledge base.
+ *
+ * <p>All endpoints are scoped to the authenticated user via the OIDC subject from the
+ * bearer token. Asking a question fans out to knowledgebase-service (for the user's
+ * document keys) and to the GenAI service (for the answer and citations). The resulting
+ * interaction is persisted so it shows up in the user's history.
+ */
 @RestController
 @RequestMapping(path = "/api/v1/qa", produces = MediaType.APPLICATION_JSON_VALUE)
 @Tag(name = "QA Service", description = "Question answering over the user's knowledge base")

--- a/services/spring/qa-service/src/main/java/com/alexandria/qa/QAService.java
+++ b/services/spring/qa-service/src/main/java/com/alexandria/qa/QAService.java
@@ -11,6 +11,13 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+/**
+ * Core logic for answering questions and keeping the Q&amp;A history.
+ *
+ * <p>Answering pulls the user's document keys from knowledgebase-service, sends the
+ * question and keys to the GenAI service, then resolves the returned citations back to
+ * concrete document ids and file names before persisting the interaction.
+ */
 @Service
 public class QAService {
 

--- a/services/spring/qa-service/src/main/java/com/alexandria/qa/auth/SecurityConfig.java
+++ b/services/spring/qa-service/src/main/java/com/alexandria/qa/auth/SecurityConfig.java
@@ -14,8 +14,16 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtAut
 import org.springframework.security.oauth2.server.resource.web.authentication.BearerTokenAuthenticationFilter;
 import org.springframework.security.web.SecurityFilterChain;
 
+/**
+ * Stateless security for qa-service.
+ *
+ * <p>Runs as an OAuth2 resource server: public API calls need a valid JWT, internal
+ * fan-out endpoints instead require an HMAC signature (checked by a filter placed before
+ * the bearer-token filter). The Swagger docs, actuator and health endpoints are open.
+ * Auth failures are rendered through the shared ErrorResponse handlers.
+ */
 // final (+ proxyBeanMethods=false so Spring won't try to CGLIB-subclass it) closes the
-// finalizer-attack window SpotBugs flags via CT_CONSTRUCTOR_THROW on the constructor.
+// finalizer-attack window on the constructor.
 @Configuration(proxyBeanMethods = false)
 @EnableWebSecurity
 public final class SecurityConfig {

--- a/services/spring/qa-service/src/main/java/com/alexandria/qa/config/OpenApiConfig.java
+++ b/services/spring/qa-service/src/main/java/com/alexandria/qa/config/OpenApiConfig.java
@@ -16,6 +16,10 @@ import org.springdoc.core.customizers.OpenApiCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+/**
+ * OpenAPI/Swagger metadata and the bearer auth scheme for qa-service, additionally
+ * a customizer that points every error response at the shared ErrorResponse schema.
+ */
 @Configuration
 @OpenAPIDefinition(
         info = @Info(

--- a/services/spring/qa-service/src/main/java/com/alexandria/qa/config/OpenApiConfig.java
+++ b/services/spring/qa-service/src/main/java/com/alexandria/qa/config/OpenApiConfig.java
@@ -18,7 +18,7 @@ import org.springframework.context.annotation.Configuration;
 
 /**
  * OpenAPI/Swagger metadata and the bearer auth scheme for qa-service, additionally
- * a customizer that points every error response at the shared ErrorResponse schema.
+ * a customizer that points numeric 4xx/5xx responses at the shared ErrorResponse schema.
  */
 @Configuration
 @OpenAPIDefinition(

--- a/services/spring/qa-service/src/main/java/com/alexandria/qa/integration/GenAiClient.java
+++ b/services/spring/qa-service/src/main/java/com/alexandria/qa/integration/GenAiClient.java
@@ -3,6 +3,8 @@ package com.alexandria.qa.integration;
 import com.alexandria.genai.client.api.AiApi;
 import com.alexandria.genai.client.invoker.ApiClient;
 import com.alexandria.genai.client.model.GenAiAskRequest;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.client.JdkClientHttpRequestFactory;
@@ -17,25 +19,38 @@ import java.util.List;
 public class GenAiClient {
 
     private final AiApi genaiClient;
+    private final MeterRegistry meterRegistry;
 
     @Autowired
-    public GenAiClient(@Value("${genai.base-url:http://localhost:8000}") String baseUrl) {
+    public GenAiClient(@Value("${genai.base-url:http://localhost:8000}") String baseUrl, MeterRegistry meterRegistry) {
         HttpClient httpClient = HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).connectTimeout(Duration.ofSeconds(5)).build();
         JdkClientHttpRequestFactory factory = new JdkClientHttpRequestFactory(httpClient);
         factory.setReadTimeout(Duration.ofSeconds(30));
         RestClient restClient = ApiClient.buildRestClientBuilder().requestFactory(factory).build();
         ApiClient apiClient = new ApiClient(restClient).setBasePath(baseUrl);
         this.genaiClient = new AiApi(apiClient);
+        this.meterRegistry = meterRegistry;
     }
 
-    GenAiClient(AiApi genaiClient) {
+    GenAiClient(AiApi genaiClient, MeterRegistry meterRegistry) {
         this.genaiClient = genaiClient;
+        this.meterRegistry = meterRegistry;
     }
 
     public AskResponse ask(String question, List<String> objectKeys) {
-        var r = genaiClient.askGenaiAskPost(new GenAiAskRequest().question(question).objectKeys(objectKeys));
-        List<Citation> citations = r.getCitations().stream().map(c -> new Citation(c.getMarker(), c.getObjectKey(), c.getSnippet())).toList();
-        return new AskResponse(r.getAnswer(), citations, r.getModelUsed());
+        Timer.Sample sample = Timer.start(meterRegistry);
+        String outcome = "success";
+        try {
+            var r = genaiClient.askGenaiAskPost(new GenAiAskRequest().question(question).objectKeys(objectKeys));
+            List<Citation> citations = r.getCitations().stream().map(c -> new Citation(c.getMarker(), c.getObjectKey(), c.getSnippet())).toList();
+            return new AskResponse(r.getAnswer(), citations, r.getModelUsed());
+        } catch (RuntimeException e) {
+            outcome = "error";
+            throw e;
+        } finally {
+            sample.stop(meterRegistry.timer("genai.client.call.duration", "operation", "ask", "outcome", outcome));
+            meterRegistry.counter("genai.client.calls", "operation", "ask", "outcome", outcome).increment();
+        }
     }
 
     public record AskResponse(String answer, List<Citation> citations, String modelUsed) {

--- a/services/spring/qa-service/src/main/java/com/alexandria/qa/integration/GenAiClient.java
+++ b/services/spring/qa-service/src/main/java/com/alexandria/qa/integration/GenAiClient.java
@@ -15,6 +15,15 @@ import java.net.http.HttpClient;
 import java.time.Duration;
 import java.util.List;
 
+/**
+ * HTTP client for the GenAI service's ask endpoint, built on the generated AiApi.
+ *
+ * <p>Sends the question plus the user's document keys and maps the response onto the
+ * records exposed here. The call is timed and counted (genai.client.call.duration and
+ * genai.client.calls, tagged operation=ask and a success/error outcome) so its latency
+ * and error rate show up in Prometheus. Connect and read timeouts are set so a hung
+ * GenAI service cannot block request threads.
+ */
 @Component
 public class GenAiClient {
 

--- a/services/spring/qa-service/src/main/java/com/alexandria/qa/integration/KnowledgeBaseClient.java
+++ b/services/spring/qa-service/src/main/java/com/alexandria/qa/integration/KnowledgeBaseClient.java
@@ -12,6 +12,13 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Internal client for knowledgebase-service, used to fetch a user's document keys and
+ * resolve object keys back to document ids and file names when building citations.
+ *
+ * <p>Talks to the /internal/knowledgebase endpoints, so requests carry an HMAC signature
+ * added by the shared signing interceptor rather than a user bearer token.
+ */
 @Component
 public class KnowledgeBaseClient {
 

--- a/services/spring/qa-service/src/test/java/com/alexandria/qa/InternalControllerTest.java
+++ b/services/spring/qa-service/src/test/java/com/alexandria/qa/InternalControllerTest.java
@@ -1,0 +1,29 @@
+package com.alexandria.qa;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class InternalControllerTest {
+
+    @Mock
+    private QAService qaService;
+
+    @InjectMocks
+    private InternalController controller;
+
+    @Test
+    void unit_qa_internalDeleteUserDataDelegates() {
+        ResponseEntity<Void> response = controller.deleteUserData("owner");
+
+        assertThat(response.getStatusCode().value()).isEqualTo(204);
+        verify(qaService).deleteAllForUser("owner");
+    }
+}

--- a/services/spring/qa-service/src/test/java/com/alexandria/qa/QAControllerTest.java
+++ b/services/spring/qa-service/src/test/java/com/alexandria/qa/QAControllerTest.java
@@ -1,0 +1,64 @@
+package com.alexandria.qa;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class QAControllerTest {
+
+    private static final String SUBJECT = "mock-user";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private QAService qaService;
+
+    @Test
+    void integration_qa_ask() throws Exception {
+        QAInteraction interaction = new QAInteraction(SUBJECT, "q?", "answer", List.of(), "model");
+        when(qaService.ask(eq(SUBJECT), eq("q?"))).thenReturn(interaction);
+
+        mockMvc.perform(post("/api/v1/qa/ask").with(jwt().jwt(j -> j.subject(SUBJECT))).contentType(MediaType.APPLICATION_JSON).content("{\"question\":\"q?\"}")).andExpect(status().isOk()).andExpect(jsonPath("$.answer").value("answer"));
+    }
+
+    @Test
+    void integration_qa_askRejectsBlankQuestion() throws Exception {
+        mockMvc.perform(post("/api/v1/qa/ask").with(jwt().jwt(j -> j.subject(SUBJECT))).contentType(MediaType.APPLICATION_JSON).content("{\"question\":\"\"}")).andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void integration_qa_askRequiresAuth() throws Exception {
+        mockMvc.perform(post("/api/v1/qa/ask").contentType(MediaType.APPLICATION_JSON).content("{\"question\":\"q?\"}")).andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void integration_qa_getHistory() throws Exception {
+        when(qaService.getHistory(SUBJECT)).thenReturn(List.of(new QAInteraction(SUBJECT, "q?", "a", List.of(), "m")));
+
+        mockMvc.perform(get("/api/v1/qa/history").with(jwt().jwt(j -> j.subject(SUBJECT)))).andExpect(status().isOk()).andExpect(jsonPath("$[0].question").value("q?"));
+    }
+
+    @Test
+    void integration_qa_deleteHistory() throws Exception {
+        mockMvc.perform(delete("/api/v1/qa/history").with(jwt().jwt(j -> j.subject(SUBJECT)))).andExpect(status().isNoContent());
+        verify(qaService).deleteHistory(SUBJECT);
+    }
+}

--- a/services/spring/qa-service/src/test/java/com/alexandria/qa/QaModelTest.java
+++ b/services/spring/qa-service/src/test/java/com/alexandria/qa/QaModelTest.java
@@ -1,0 +1,56 @@
+package com.alexandria.qa;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// Getter/setter and equals/hashCode coverage the service tests only touch indirectly.
+class QaModelTest {
+
+    @Test
+    void unit_qa_citationSettersAndEquality() {
+        QaCitation citation = new QaCitation();
+        citation.setMarker(2);
+        citation.setObjectKey("/uploads/a.pdf");
+        citation.setDocumentId("doc-1");
+        citation.setFileName("a.pdf");
+        citation.setSnippet("snip");
+
+        assertThat(citation.getMarker()).isEqualTo(2);
+        assertThat(citation.getObjectKey()).isEqualTo("/uploads/a.pdf");
+        assertThat(citation.getDocumentId()).isEqualTo("doc-1");
+        assertThat(citation.getFileName()).isEqualTo("a.pdf");
+        assertThat(citation.getSnippet()).isEqualTo("snip");
+
+        QaCitation same = new QaCitation(2, "/uploads/a.pdf", "doc-1", "a.pdf", "snip");
+        QaCitation different = new QaCitation(3, "/uploads/b.pdf", "doc-2", "b.pdf", "other");
+        assertThat(citation).isEqualTo(citation).isEqualTo(same).isNotEqualTo(different).isNotEqualTo("not a citation");
+        assertThat(citation.hashCode()).isEqualTo(same.hashCode());
+    }
+
+    @Test
+    void unit_qa_interactionSetters() {
+        QAInteraction interaction = new QAInteraction();
+        List<QaCitation> citations = List.of(new QaCitation(1, "/uploads/a.pdf", "doc", "a.pdf", "snip"));
+        Instant now = Instant.now();
+        interaction.setUserSubject("owner");
+        interaction.setQuestion("q?");
+        interaction.setAnswer("a");
+        interaction.setCitations(citations);
+        interaction.setTimestamp(now);
+        interaction.setModelUsed("model");
+
+        assertThat(interaction.getUserSubject()).isEqualTo("owner");
+        assertThat(interaction.getQuestion()).isEqualTo("q?");
+        assertThat(interaction.getAnswer()).isEqualTo("a");
+        assertThat(interaction.getCitations()).hasSize(1);
+        assertThat(interaction.getTimestamp()).isEqualTo(now);
+        assertThat(interaction.getModelUsed()).isEqualTo("model");
+
+        interaction.setCitations(null);
+        assertThat(interaction.getCitations()).isEmpty();
+    }
+}

--- a/services/spring/qa-service/src/test/java/com/alexandria/qa/integration/GenAiClientTest.java
+++ b/services/spring/qa-service/src/test/java/com/alexandria/qa/integration/GenAiClientTest.java
@@ -1,0 +1,33 @@
+package com.alexandria.qa.integration;
+
+import com.alexandria.genai.client.api.AiApi;
+import com.alexandria.genai.client.model.GenAiAskResponse;
+import com.alexandria.genai.client.model.GenAiCitation;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class GenAiClientTest {
+
+    @Test
+    void unit_qa_askMapsAnswerAndCitations() {
+        AiApi aiApi = mock(AiApi.class);
+        GenAiCitation citation = new GenAiCitation().marker(1).objectKey("/uploads/a.pdf").snippet("snip");
+        when(aiApi.askGenaiAskPost(any())).thenReturn(new GenAiAskResponse().answer("answer").citations(List.of(citation)).modelUsed("model"));
+
+        GenAiClient.AskResponse result = new GenAiClient(aiApi).ask("q?", List.of("/uploads/a.pdf"));
+
+        assertThat(result.answer()).isEqualTo("answer");
+        assertThat(result.modelUsed()).isEqualTo("model");
+        assertThat(result.citations()).singleElement().satisfies(c -> {
+            assertThat(c.marker()).isEqualTo(1);
+            assertThat(c.objectKey()).isEqualTo("/uploads/a.pdf");
+            assertThat(c.snippet()).isEqualTo("snip");
+        });
+    }
+}

--- a/services/spring/qa-service/src/test/java/com/alexandria/qa/integration/GenAiClientTest.java
+++ b/services/spring/qa-service/src/test/java/com/alexandria/qa/integration/GenAiClientTest.java
@@ -3,16 +3,21 @@ package com.alexandria.qa.integration;
 import com.alexandria.genai.client.api.AiApi;
 import com.alexandria.genai.client.model.GenAiAskResponse;
 import com.alexandria.genai.client.model.GenAiCitation;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class GenAiClientTest {
+
+    private final MeterRegistry registry = new SimpleMeterRegistry();
 
     @Test
     void unit_qa_askMapsAnswerAndCitations() {
@@ -20,7 +25,7 @@ class GenAiClientTest {
         GenAiCitation citation = new GenAiCitation().marker(1).objectKey("/uploads/a.pdf").snippet("snip");
         when(aiApi.askGenaiAskPost(any())).thenReturn(new GenAiAskResponse().answer("answer").citations(List.of(citation)).modelUsed("model"));
 
-        GenAiClient.AskResponse result = new GenAiClient(aiApi).ask("q?", List.of("/uploads/a.pdf"));
+        GenAiClient.AskResponse result = new GenAiClient(aiApi, registry).ask("q?", List.of("/uploads/a.pdf"));
 
         assertThat(result.answer()).isEqualTo("answer");
         assertThat(result.modelUsed()).isEqualTo("model");
@@ -29,5 +34,16 @@ class GenAiClientTest {
             assertThat(c.objectKey()).isEqualTo("/uploads/a.pdf");
             assertThat(c.snippet()).isEqualTo("snip");
         });
+        assertThat(registry.get("genai.client.calls").tags("operation", "ask", "outcome", "success").counter().count()).isEqualTo(1.0);
+    }
+
+    @Test
+    void unit_qa_askRecordsErrorMetricOnFailure() {
+        AiApi aiApi = mock(AiApi.class);
+        when(aiApi.askGenaiAskPost(any())).thenThrow(new RuntimeException("genai down"));
+
+        assertThatThrownBy(() -> new GenAiClient(aiApi, registry).ask("q?", List.of())).isInstanceOf(RuntimeException.class);
+
+        assertThat(registry.get("genai.client.calls").tags("operation", "ask", "outcome", "error").counter().count()).isEqualTo(1.0);
     }
 }

--- a/services/spring/qa-service/src/test/java/com/alexandria/qa/integration/KnowledgeBaseClientTest.java
+++ b/services/spring/qa-service/src/test/java/com/alexandria/qa/integration/KnowledgeBaseClientTest.java
@@ -1,0 +1,65 @@
+package com.alexandria.qa.integration;
+
+import com.alexandria.common.internal.HmacRequestSigningInterceptor;
+import com.alexandria.common.internal.HmacSigner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.POST;
+
+class KnowledgeBaseClientTest {
+
+    private KnowledgeBaseClient client;
+    private MockRestServiceServer server;
+
+    @BeforeEach
+    void setup() {
+        HmacRequestSigningInterceptor signer = new HmacRequestSigningInterceptor(new HmacSigner("secret", 300));
+        client = new KnowledgeBaseClient("http://knowledgebase-service:8080", signer);
+
+        RestClient restClient = (RestClient) ReflectionTestUtils.getField(client, "restClient");
+        RestClient.Builder builder = restClient.mutate();
+        server = MockRestServiceServer.bindTo(builder).build();
+        ReflectionTestUtils.setField(client, "restClient", builder.build());
+    }
+
+    @Test
+    void unit_qa_listDocumentKeysReturnsKeys() {
+        server.expect(requestTo("http://knowledgebase-service:8080/internal/knowledgebase/users/owner/document-keys")).andExpect(method(GET)).andRespond(withStatus(HttpStatus.OK).contentType(MediaType.APPLICATION_JSON).body("[\"/uploads/a.pdf\"]"));
+
+        assertThat(client.listDocumentKeys("owner")).containsExactly("/uploads/a.pdf");
+        server.verify();
+    }
+
+    @Test
+    void unit_qa_resolveDocumentsReturnsEmptyForNoKeys() {
+        assertThat(client.resolveDocuments("owner", List.of())).isEmpty();
+        assertThat(client.resolveDocuments("owner", null)).isEmpty();
+    }
+
+    @Test
+    void unit_qa_resolveDocumentsMapsReferences() {
+        server.expect(requestTo("http://knowledgebase-service:8080/internal/knowledgebase/users/owner/documents/resolve")).andExpect(method(POST)).andRespond(withStatus(HttpStatus.OK).contentType(MediaType.APPLICATION_JSON).body("[{\"objectKey\":\"/uploads/a.pdf\",\"documentId\":\"doc-1\",\"fileName\":\"a.pdf\"}]"));
+
+        List<KnowledgeBaseClient.DocumentReference> refs = client.resolveDocuments("owner", List.of("/uploads/a.pdf"));
+
+        assertThat(refs).singleElement().satisfies(ref -> {
+            assertThat(ref.objectKey()).isEqualTo("/uploads/a.pdf");
+            assertThat(ref.documentId()).isEqualTo("doc-1");
+            assertThat(ref.fileName()).isEqualTo("a.pdf");
+        });
+        server.verify();
+    }
+}

--- a/services/spring/user-service/src/main/java/com/alexandria/user/UserController.java
+++ b/services/spring/user-service/src/main/java/com/alexandria/user/UserController.java
@@ -18,6 +18,13 @@ import org.springframework.web.bind.annotation.*;
 import java.security.Principal;
 import java.util.UUID;
 
+/**
+ * Public REST API for the caller's own account and preferences.
+ *
+ * <p>Every endpoint resolves the user from the OIDC subject in the bearer token; a user
+ * can only read or delete their own account. Deleting an account also purges the user's
+ * knowledgebase and Q&amp;A data through the service layer's internal fan-out.
+ */
 @RestController
 @RequestMapping(path = "/api/v1/users", produces = MediaType.APPLICATION_JSON_VALUE)
 @Tag(name = "User Service", description = "User account management")

--- a/services/spring/user-service/src/main/java/com/alexandria/user/UserService.java
+++ b/services/spring/user-service/src/main/java/com/alexandria/user/UserService.java
@@ -18,6 +18,14 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+/**
+ * Account lifecycle and user preferences.
+ *
+ * <p>Users are provisioned lazily from OIDC claims on first sight. Preferences are stored
+ * as a small JSON blob on the user row and fall back to sane defaults if missing or
+ * corrupted. Deleting an account fans the delete out to knowledgebase-service and
+ * qa-service before the local row is removed.
+ */
 @Service
 public class UserService {
 
@@ -35,6 +43,11 @@ public class UserService {
         this.objectMapper = objectMapper;
     }
 
+    /**
+     * Returns the user for the given OIDC subject, creating one on first login.
+     * If a row already exists for the email (e.g. a pre-OIDC account), it is adopted by
+     * attaching the subject rather than creating a duplicate.
+     */
     @Transactional
     public User findOrCreateByOidcSubject(String oidcSubject, String username, String email) {
         Optional<User> bySubject = repository.findByOidcSubject(oidcSubject);
@@ -60,6 +73,11 @@ public class UserService {
         return parsePreferences(user.getPreferences());
     }
 
+    /**
+     * Deletes the user and purges their data in knowledgebase-service and qa-service.
+     * If either peer delete fails the local row is kept and a UserDeletionException is
+     * thrown, so the operation can be retried until every service has converged.
+     */
     public void deleteUser(UUID id) {
         // KB and QA services key their rows on the OIDC subject, not on the
         // local user UUID, so we fan out on the subject.

--- a/services/spring/user-service/src/main/java/com/alexandria/user/auth/OidcUserFilter.java
+++ b/services/spring/user-service/src/main/java/com/alexandria/user/auth/OidcUserFilter.java
@@ -14,6 +14,13 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
+/**
+ * Provisions a local user row from the JWT on every authenticated request.
+ *
+ * <p>After the bearer token is validated, this filter reads the configured subject and
+ * username claims plus the email and inserts the user via the service layer, so the first
+ * authenticated call for a new identity creates their account without a separate signup step.
+ */
 @Component
 public class OidcUserFilter extends OncePerRequestFilter {
 

--- a/services/spring/user-service/src/main/java/com/alexandria/user/auth/SecurityConfig.java
+++ b/services/spring/user-service/src/main/java/com/alexandria/user/auth/SecurityConfig.java
@@ -13,8 +13,16 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtAut
 import org.springframework.security.oauth2.server.resource.web.authentication.BearerTokenAuthenticationFilter;
 import org.springframework.security.web.SecurityFilterChain;
 
+/**
+ * Stateless security for user-service.
+ *
+ * <p>Runs as an OAuth2 resource server: public API calls need a valid JWT, internal
+ * fan-out endpoints instead require an HMAC signature (checked by a filter placed before
+ * the bearer-token filter). The Swagger docs, actuator and health endpoints are open.
+ * Auth failures are rendered through the shared ErrorResponse handlers.
+ */
 // final (+ proxyBeanMethods=false so Spring won't try to CGLIB-subclass it) closes the
-// finalizer-attack window SpotBugs flags via CT_CONSTRUCTOR_THROW on the constructor.
+// finalizer-attack window on the constructor.
 @Configuration(proxyBeanMethods = false)
 @EnableWebSecurity
 public final class SecurityConfig {

--- a/services/spring/user-service/src/main/java/com/alexandria/user/config/OpenApiConfig.java
+++ b/services/spring/user-service/src/main/java/com/alexandria/user/config/OpenApiConfig.java
@@ -18,7 +18,7 @@ import org.springframework.context.annotation.Configuration;
 
 /**
  * OpenAPI/Swagger metadata and the bearer auth scheme for user-service, additionally
- * a customizer that points every error response at the shared ErrorResponse schema.
+ * a customizer that points numeric 4xx/5xx responses at the shared ErrorResponse schema.
  */
 @Configuration
 @OpenAPIDefinition(

--- a/services/spring/user-service/src/main/java/com/alexandria/user/config/OpenApiConfig.java
+++ b/services/spring/user-service/src/main/java/com/alexandria/user/config/OpenApiConfig.java
@@ -16,6 +16,10 @@ import org.springdoc.core.customizers.OpenApiCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+/**
+ * OpenAPI/Swagger metadata and the bearer auth scheme for user-service, additionally
+ * a customizer that points every error response at the shared ErrorResponse schema.
+ */
 @Configuration
 @OpenAPIDefinition(
         info = @Info(

--- a/services/spring/user-service/src/main/java/com/alexandria/user/exception/GlobalExceptionHandler.java
+++ b/services/spring/user-service/src/main/java/com/alexandria/user/exception/GlobalExceptionHandler.java
@@ -9,6 +9,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+/**
+ * Maps user-service specific exceptions onto the shared ErrorResponse schema, on top of the
+ * common handlers in BaseExceptionHandler. A failed cross-service delete surfaces as 502 so
+ * the caller knows to retry rather than assuming the account is fully gone.
+ */
 @RestControllerAdvice
 public class GlobalExceptionHandler extends BaseExceptionHandler {
 

--- a/services/spring/user-service/src/main/java/com/alexandria/user/exception/GlobalExceptionHandler.java
+++ b/services/spring/user-service/src/main/java/com/alexandria/user/exception/GlobalExceptionHandler.java
@@ -2,6 +2,8 @@ package com.alexandria.user.exception;
 
 import com.alexandria.common.web.BaseExceptionHandler;
 import com.alexandria.common.web.ErrorResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -10,18 +12,23 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler extends BaseExceptionHandler {
 
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
     @ExceptionHandler(UserNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleUserNotFound(UserNotFoundException e) {
+        log.warn("User not found: {}", e.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorResponse("NOT_FOUND", e.getMessage()));
     }
 
     @ExceptionHandler(InvalidCredentialsException.class)
     public ResponseEntity<ErrorResponse> handleUnauthorized(InvalidCredentialsException e) {
+        log.warn("Invalid credentials: {}", e.getMessage());
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new ErrorResponse("UNAUTHORIZED", e.getMessage()));
     }
 
     @ExceptionHandler(UserDeletionException.class)
     public ResponseEntity<ErrorResponse> handleUserDeletionFailed(UserDeletionException e) {
+        log.warn("User deletion cleanup failed: {}", e.getMessage());
         return ResponseEntity.status(HttpStatus.BAD_GATEWAY).body(new ErrorResponse("USER_DELETE_FAILED", "Could not fully delete the user account, please retry"));
     }
 }

--- a/services/spring/user-service/src/main/java/com/alexandria/user/integration/KnowledgeBaseClient.java
+++ b/services/spring/user-service/src/main/java/com/alexandria/user/integration/KnowledgeBaseClient.java
@@ -9,6 +9,11 @@ import org.springframework.web.client.RestClient;
 import java.net.http.HttpClient;
 import java.time.Duration;
 
+/**
+ * Internal client used to purge a user's documents in knowledgebase-service when their
+ * account is deleted. Calls the /internal endpoints, so requests are signed with an HMAC
+ * signature by the shared interceptor rather than carrying a user bearer token.
+ */
 @Component
 public class KnowledgeBaseClient {
 

--- a/services/spring/user-service/src/main/java/com/alexandria/user/integration/QAClient.java
+++ b/services/spring/user-service/src/main/java/com/alexandria/user/integration/QAClient.java
@@ -9,6 +9,11 @@ import org.springframework.web.client.RestClient;
 import java.net.http.HttpClient;
 import java.time.Duration;
 
+/**
+ * Internal client used to purge a user's Q&amp;A history in qa-service when their account is
+ * deleted. Calls the /internal endpoints, so requests are signed with an HMAC signature
+ * by the shared interceptor rather than carrying a user bearer token.
+ */
 @Component
 public class QAClient {
 

--- a/services/spring/user-service/src/test/java/com/alexandria/user/UserControllerTest.java
+++ b/services/spring/user-service/src/test/java/com/alexandria/user/UserControllerTest.java
@@ -13,6 +13,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
+import static org.mockito.Mockito.doThrow;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -72,5 +73,12 @@ class UserControllerTest {
     @Test
     void integration_user_updatePreferencesPartialUpdate() throws Exception {
         mockMvc.perform(patch("/api/v1/users/me/preferences").with(jwt().jwt(j -> j.subject("sub123"))).contentType(MediaType.APPLICATION_JSON).content("{\"language\":\"fr\"}")).andExpect(status().isOk()).andExpect(jsonPath("$.darkTheme").value(false)).andExpect(jsonPath("$.language").value("fr"));
+    }
+
+    @Test
+    void integration_user_deleteReturns502WhenDownstreamCleanupFails() throws Exception {
+        doThrow(new RuntimeException("kb down")).when(knowledgeBaseClient).deleteUserData("sub123");
+
+        mockMvc.perform(delete("/api/v1/users/" + testUser.getId()).with(jwt().jwt(j -> j.subject("sub123")))).andExpect(status().isBadGateway());
     }
 }

--- a/services/spring/user-service/src/test/java/com/alexandria/user/UserModelTest.java
+++ b/services/spring/user-service/src/test/java/com/alexandria/user/UserModelTest.java
@@ -1,0 +1,59 @@
+package com.alexandria.user;
+
+import com.alexandria.common.web.ErrorResponse;
+import com.alexandria.user.exception.GlobalExceptionHandler;
+import com.alexandria.user.exception.InvalidCredentialsException;
+import com.alexandria.user.exception.PreferencesSerializationException;
+import com.alexandria.user.exception.UserDeletionException;
+import com.alexandria.user.exception.UserNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserModelTest {
+
+    @Test
+    void unit_user_entitySetters() {
+        User user = new User("oidc|123", "testuser", "test@example.com");
+        user.setOidcSubject("oidc|456");
+        user.setUsername("renamed");
+        user.setEmail("new@example.com");
+        user.setPreferences("{\"darkTheme\":true}");
+
+        assertThat(user.getOidcSubject()).isEqualTo("oidc|456");
+        assertThat(user.getUsername()).isEqualTo("renamed");
+        assertThat(user.getEmail()).isEqualTo("new@example.com");
+        assertThat(user.getPreferences()).isEqualTo("{\"darkTheme\":true}");
+        assertThat(user.getId()).isNull();
+        assertThat(user.getCreatedAt()).isNull();
+    }
+
+    @Test
+    void unit_user_exceptionMessages() {
+        UUID id = UUID.randomUUID();
+        assertThat(new UserNotFoundException(id)).hasMessageContaining(id.toString());
+        assertThat(new UserNotFoundException("oidc|1")).hasMessageContaining("oidc|1");
+        assertThat(new InvalidCredentialsException()).hasMessageContaining("Invalid credentials");
+        assertThat(new UserDeletionException(id, List.of("qa-service"))).hasMessageContaining("qa-service");
+        assertThat(new PreferencesSerializationException("failed", new RuntimeException("cause"))).hasMessage("failed").hasCauseInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void unit_user_exceptionHandlerMapsStatuses() {
+        GlobalExceptionHandler handler = new GlobalExceptionHandler();
+        UUID id = UUID.randomUUID();
+
+        ResponseEntity<ErrorResponse> notFound = handler.handleUserNotFound(new UserNotFoundException(id));
+        ResponseEntity<ErrorResponse> unauthorized = handler.handleUnauthorized(new InvalidCredentialsException());
+        ResponseEntity<ErrorResponse> deletionFailed = handler.handleUserDeletionFailed(new UserDeletionException(id, List.of("qa-service")));
+
+        assertThat(notFound.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(unauthorized.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThat(deletionFailed.getStatusCode()).isEqualTo(HttpStatus.BAD_GATEWAY);
+    }
+}

--- a/services/spring/user-service/src/test/java/com/alexandria/user/UserServiceTest.java
+++ b/services/spring/user-service/src/test/java/com/alexandria/user/UserServiceTest.java
@@ -172,4 +172,51 @@ class UserServiceTest {
         assertThatThrownBy(
                 () -> userService.updatePreferences("unknown", new UpdatePreferencesRequest(true, "en"))).isInstanceOf(UserNotFoundException.class);
     }
+
+    @Test
+    void unit_user_findOrCreateLinksSubjectToExistingEmail() {
+        String oidcSubject = "auth0|new";
+        User existingByEmail = new User("old-subject", "testuser", "test@example.com");
+        when(userRepository.findByOidcSubject(oidcSubject)).thenReturn(Optional.empty());
+        when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(existingByEmail));
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        User result = userService.findOrCreateByOidcSubject(oidcSubject, "testuser", "test@example.com");
+
+        assertThat(result.getOidcSubject()).isEqualTo(oidcSubject);
+        verify(userRepository).save(existingByEmail);
+    }
+
+    @Test
+    void unit_user_getPreferencesReturnsDefaultsForBlankJson() {
+        userService = new UserService(userRepository, knowledgeBaseClient, qaClient, new ObjectMapper());
+        User user = new User("oidc|123", "testuser", "test@example.com");
+
+        UserService.UserPreferences prefs = userService.getPreferences(user);
+
+        assertThat(prefs.darkTheme()).isFalse();
+        assertThat(prefs.language()).isEqualTo("en");
+    }
+
+    @Test
+    void unit_user_getPreferencesFallsBackToDefaultsOnCorruptJson() {
+        userService = new UserService(userRepository, knowledgeBaseClient, qaClient, new ObjectMapper());
+        User user = new User("oidc|123", "testuser", "test@example.com");
+        user.setPreferences("{not valid json");
+
+        UserService.UserPreferences prefs = userService.getPreferences(user);
+
+        assertThat(prefs).isEqualTo(UserService.UserPreferences.defaultPreferences());
+    }
+
+    @Test
+    void unit_user_updatePreferencesWrapsSerializationFailure() throws JsonProcessingException {
+        String oidcSubject = "auth0|123";
+        User user = new User(oidcSubject, "testuser", "test@example.com");
+        when(userRepository.findByOidcSubject(oidcSubject)).thenReturn(Optional.of(user));
+        when(objectMapper.writeValueAsString(any())).thenThrow(new JsonProcessingException("boom") {
+        });
+
+        assertThatThrownBy(() -> userService.updatePreferences(oidcSubject, new UpdatePreferencesRequest(true, "de"))).isInstanceOf(com.alexandria.user.exception.PreferencesSerializationException.class);
+    }
 }

--- a/services/spring/user-service/src/test/java/com/alexandria/user/integration/UserIntegrationClientTest.java
+++ b/services/spring/user-service/src/test/java/com/alexandria/user/integration/UserIntegrationClientTest.java
@@ -1,0 +1,49 @@
+package com.alexandria.user.integration;
+
+import com.alexandria.common.internal.HmacRequestSigningInterceptor;
+import com.alexandria.common.internal.HmacSigner;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+import static org.springframework.http.HttpMethod.DELETE;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+
+class UserIntegrationClientTest {
+
+    private static MockRestServiceServer bind(Object client) {
+        RestClient restClient = (RestClient) ReflectionTestUtils.getField(client, "restClient");
+        RestClient.Builder builder = restClient.mutate();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+        ReflectionTestUtils.setField(client, "restClient", builder.build());
+        return server;
+    }
+
+    private static HmacRequestSigningInterceptor signer() {
+        return new HmacRequestSigningInterceptor(new HmacSigner("secret", 300));
+    }
+
+    @Test
+    void unit_user_knowledgeBaseClientDeletesUserData() {
+        KnowledgeBaseClient client = new KnowledgeBaseClient("http://knowledgebase-service:8080", signer());
+        MockRestServiceServer server = bind(client);
+        server.expect(requestTo("http://knowledgebase-service:8080/internal/knowledgebase/users/owner")).andExpect(method(DELETE)).andRespond(withStatus(HttpStatus.NO_CONTENT));
+
+        client.deleteUserData("owner");
+        server.verify();
+    }
+
+    @Test
+    void unit_user_qaClientDeletesUserData() {
+        QAClient client = new QAClient("http://qa-service:8080", signer());
+        MockRestServiceServer server = bind(client);
+        server.expect(requestTo("http://qa-service:8080/internal/qa/users/owner")).andExpect(method(DELETE)).andRespond(withStatus(HttpStatus.NO_CONTENT));
+
+        client.deleteUserData("owner");
+        server.verify();
+    }
+}


### PR DESCRIPTION
## What does this PR do?
Closes #224 and closes #225. 

- Bumps line coverage across the three microservices (see table below)
- Adds structured logging and Micrometer instrumentation so we can actually see what the services are doing in Grafana
- Adds additional JavaDoc documentation to public facing methods and methods that aren't self-explanatory

| Service | Line coverage |
|---|---|
| `user-service` | 70% → 97.1% |
| `knowledgebase-service` | 52% → 96.8% |
| `qa-service` | 57% → 98.6% |

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor / cleanup
- [X] Docs
- [ ] CI / infra

## Definition of Done

- [ ] CI is green
- [ ] If the API changed: `api/openapi.yaml` is updated and lint passes
- [X] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [X] Tests added or updated for the changed behaviour
- [X] Docs updated where it matters (README, ADRs, comments)

## Notes for the reviewer

<!-- Anything they should look at first, gotchas, screenshots, ... -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added monitoring dashboards for GenAI request rates, latency, outcomes, and object-storage operations.
  * Added an alert for elevated GenAI client failure rates.
  * Added structured JSON logging with request IDs and route information.
  * Write operations now produce start, completion, and failure audit logs.

* **Documentation**
  * Expanded service documentation covering monitoring, logging, APIs, security, and document processing behavior.

* **Testing**
  * Increased automated coverage across APIs, integrations, storage, logging, and core service workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->