### PR TITLE
CI: pass INTERNAL_SHARED_SECRET to Helm deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,8 @@ env:
   GRAFANA_ADMIN_PASSWORD: ${{ secrets.GRAFANA_ADMIN_PASSWORD }}
   # ----------- GenAI -----------
   LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+  # ----------- Internal service-to-service auth -----------
+  INTERNAL_SHARED_SECRET: ${{ secrets.INTERNAL_SHARED_SECRET }}
 
 jobs:
   # ---------------------------------------------------------------------
@@ -959,6 +961,7 @@ jobs:
             --set "seaweedfs.s3.credentials.admin.secretKey=$S3_SECRET_KEY" \
             --set "grafana.adminPassword=$GRAFANA_ADMIN_PASSWORD" \
             --set "genai.llmApiKey=$LLM_API_KEY" \
+            --set "spring.internal.sharedSecret=$INTERNAL_SHARED_SECRET" \
             --wait \
             --timeout 5m
 


### PR DESCRIPTION
## What does this PR do?

Adds `INTERNAL_SHARED_SECRET` to the CI workflow so the Helm deploy job passes it to the chart via `--set spring.internal.sharedSecret=...`. Without this the secret was always empty in the stud cluster deployment.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [x] CI / infra

## Definition of Done

- [x] CI is green
- [x] If the API changed: `api/openapi.yaml` is updated and lint passes
- [x] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [x] Tests added or updated for the changed behaviour
- [x] Docs updated where it matters (README, ADRs, comments)

## Notes for the reviewer

The `INTERNAL_CLOCK_SKEW_SECONDS` is not passed here -- its default in `values.yaml` matches the docker-compose default (300), so there's nothing to override.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to support secure authentication between internal services.
  * Passed the shared authentication secret to the Stud Cluster deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->