### PR TITLE
Feat: Add search UI with semantic and keyword modes

### DIFF
--- a/services/client/README.md
+++ b/services/client/README.md
@@ -39,7 +39,7 @@ or via a `.env` file in this directory (see the [Vite env docs](https://vite.dev
 
 ### Search
 
-The **Search** tab lets users find documents by meaning (semantic) or exact
+The **Search** tab lets users find documents by meaning (semantic) or
 keyword matches (text). Semantic search ranks results by relevance and shows
 the matching text snippet from each document alongside a relevance score.
 Keyword search matches against filenames and document content. Both modes use

--- a/services/client/README.md
+++ b/services/client/README.md
@@ -37,6 +37,16 @@ VITE_API_URL=https://api.example.com npm run build
 
 or via a `.env` file in this directory (see the [Vite env docs](https://vite.dev/guide/env-and-mode)).
 
+### Search
+
+The **Search** tab lets users find documents by meaning (semantic) or exact
+keyword matches (text). Semantic search ranks results by relevance and shows
+the matching text snippet from each document alongside a relevance score.
+Keyword search matches against filenames and document content. Both modes use
+the knowledgebase-service endpoints introduced in the semantic search work.
+If the vector index is unavailable, semantic mode falls back to keyword search
+and shows a notice.
+
 ## Production
 
 Build and run the production image (uses the multi-stage Dockerfile):
@@ -84,6 +94,7 @@ npm run test:e2e
 ```
 
 ## Notes
+
 - The dev Dockerfile starts Vite with --host 0.0.0.0 so the dev server is reachable from the host when running in a container.
 - The production image is based on `nginxinc/nginx-unprivileged` and serves the built files on port 8080 inside the container (Traefik in docker-compose routes to it via the internal network, no host port published by default).
 - When starting the development server, `--build --renew-anon-volumes` has to be specified.

--- a/services/client/src/App.tsx
+++ b/services/client/src/App.tsx
@@ -5,6 +5,7 @@ import LoginPage from "./components/LoginPage";
 import MainView from "./components/MainView";
 import DocumentDetail from "./components/DocumentDetail";
 import QAPanel from "./components/QAPanel";
+import SearchPanel from "./components/SearchPanel";
 
 function AuthGuard({ children }: { children: React.ReactNode }) {
   const auth = useAuth();
@@ -33,6 +34,7 @@ export default function App() {
         }
       >
         <Route path="ask" element={<QAPanel />} />
+        <Route path="search" element={<SearchPanel />} />
         <Route path="documents" element={<DocumentDetail />} />
         <Route path="documents/:id" element={<DocumentDetail />} />
       </Route>

--- a/services/client/src/components/DocumentDetail.tsx
+++ b/services/client/src/components/DocumentDetail.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import { useParams } from "react-router";
 import $api from "../api/client";
-import { formatDateTime } from "../utils/format";
+import { formatBytes, formatDateTime } from "../utils/format";
 
 const ENTITY_TYPE_LABELS: Record<string, string> = {
   PERSON: "Person",
@@ -10,13 +10,6 @@ const ENTITY_TYPE_LABELS: Record<string, string> = {
   TOPIC: "Topic",
   ORGANIZATION: "Organization",
 };
-
-function formatBytes(bytes?: number): string {
-  if (bytes == null) return "—";
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-}
 
 export default function DocumentDetail() {
   const { id: documentId = null } = useParams<{ id: string }>();
@@ -125,7 +118,7 @@ export default function DocumentDetail() {
           <dt>Type</dt>
           <dd>{document.fileType || "—"}</dd>
           <dt>Size</dt>
-          <dd>{formatBytes(document.fileSize)}</dd>
+          <dd>{formatBytes(document.fileSize, "\u2014")}</dd>
           <dt>Uploaded</dt>
           <dd>{formatDateTime(document.createdAt, "—")}</dd>
         </dl>

--- a/services/client/src/components/MainView.tsx
+++ b/services/client/src/components/MainView.tsx
@@ -29,6 +29,15 @@ export default function MainView() {
               <span className="app-tab__sizer">Ask</span>
             </NavLink>
             <NavLink
+              to="/search"
+              className={({ isActive }) =>
+                `app-tab${isActive ? " app-tab--active" : ""}`
+              }
+            >
+              <span className="app-tab__label">Search</span>
+              <span className="app-tab__sizer">Search</span>
+            </NavLink>
+            <NavLink
               to="/documents"
               className={({ isActive }) =>
                 `app-tab${isActive ? " app-tab--active" : ""}`

--- a/services/client/src/components/SearchPanel.tsx
+++ b/services/client/src/components/SearchPanel.tsx
@@ -1,0 +1,304 @@
+import React, { useEffect, useState } from "react";
+import { Link, useSearchParams } from "react-router";
+import $api from "../api/client";
+import type { components } from "../api/schema";
+
+type SemanticSearchResultDto = components["schemas"]["SemanticSearchResultDto"];
+type DocumentRefDto = components["schemas"]["DocumentRefDto"];
+
+/**
+ * Maps a fetch error to a user-facing message, following the same pattern used
+ * in QAPanel and DocumentDetail.
+ */
+function errorMessage(
+  err: unknown,
+  messages: { notAuthenticated: string; forbidden: string; fallback: string },
+): string {
+  const code = err instanceof Error ? err.message : String(err);
+  if (code === "NOT_AUTHENTICATED") return messages.notAuthenticated;
+  if (code === "FORBIDDEN") return messages.forbidden;
+  return messages.fallback;
+}
+
+function formatFileSize(bytes: number | undefined): string {
+  if (bytes == null) return "";
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function formatFileType(mimeType: string | undefined): string {
+  if (!mimeType) return "";
+  const known: Record<string, string> = {
+    "application/pdf": "PDF",
+    "text/plain": "Text",
+    "text/markdown": "Markdown",
+    "application/msword": "Word",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
+      "Word",
+  };
+  return known[mimeType] ?? mimeType.split("/")[1]?.toUpperCase() ?? mimeType;
+}
+
+interface TextResultListProps {
+  results: DocumentRefDto[];
+}
+
+function TextResultList({ results }: TextResultListProps) {
+  if (results.length === 0) {
+    return <p className="search-empty">No documents matched.</p>;
+  }
+
+  return (
+    <ul className="search-result-list" aria-label="Text search results">
+      {results.map((doc) => {
+        const type = formatFileType(doc.fileType);
+        const size = doc.fileSize != null ? formatFileSize(doc.fileSize) : null;
+        const meta = [type, size].filter(Boolean).join(", ");
+        return (
+          <li
+            key={doc.id}
+            className="search-result-item search-result-item--text"
+          >
+            <div className="search-result-header">
+              <Link
+                to={`/documents/${doc.id}`}
+                className="search-result-title"
+                title={doc.fileName}
+              >
+                {doc.fileName}
+              </Link>
+            </div>
+            {meta && <p className="search-result-meta">{meta}</p>}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+interface SemanticResultListProps {
+  results: SemanticSearchResultDto[];
+  fallbackUsed: boolean;
+}
+
+function SemanticResultList({ results, fallbackUsed }: SemanticResultListProps) {
+  if (results.length === 0) {
+    return <p className="search-empty">No documents matched.</p>;
+  }
+
+  return (
+    <>
+      {fallbackUsed && (
+        <p className="search-fallback-notice">
+          Vector search unavailable -- showing keyword results instead.
+        </p>
+      )}
+      <ul className="search-result-list" aria-label="Semantic search results">
+        {results.map((result, index) => {
+          const doc = result.document;
+          const score =
+            result.score != null
+              ? Math.round(result.score * 100)
+              : null;
+          return (
+            <li
+              key={doc?.id ?? index}
+              className="search-result-item search-result-item--semantic"
+            >
+              <div className="search-result-header">
+                <Link
+                  to={`/documents/${doc?.id}`}
+                  className="search-result-title"
+                  title={doc?.fileName}
+                >
+                  {doc?.fileName ?? "Untitled document"}
+                </Link>
+                {score != null && (
+                  <span
+                    className="search-result-score"
+                    title="Relevance score"
+                    aria-label={`Relevance: ${score}%`}
+                  >
+                    {score}%
+                  </span>
+                )}
+              </div>
+              {result.snippet && (
+                <p className="search-result-snippet">{result.snippet}</p>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </>
+  );
+}
+
+type SearchMode = "semantic" | "text";
+
+function isSearchMode(value: string | null): value is SearchMode {
+  return value === "semantic" || value === "text";
+}
+
+export default function SearchPanel() {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const urlQuery = searchParams.get("q") ?? "";
+  const urlModeRaw = searchParams.get("mode");
+  const urlMode: SearchMode = isSearchMode(urlModeRaw) ? urlModeRaw : "semantic";
+
+  // inputValue tracks what's currently typed; initialised from the URL so
+  // the field is pre-filled when the user navigates back to a previous search.
+  const [inputValue, setInputValue] = useState(urlQuery);
+
+  // Keep inputValue in sync if the URL changes externally (e.g. back/forward).
+  useEffect(() => {
+    setInputValue(urlQuery);
+  }, [urlQuery]);
+
+  // submittedQuery and mode are derived from the URL, not local state.
+  const submittedQuery = urlQuery;
+  const mode = urlMode;
+
+  function commitSearch(query: string, nextMode: SearchMode) {
+    const trimmed = query.trim();
+    if (!trimmed) return;
+    setSearchParams({ q: trimmed, mode: nextMode }, { replace: false });
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    commitSearch(inputValue, mode);
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      commitSearch(inputValue, mode);
+    }
+  }
+
+  function handleModeChange(next: SearchMode) {
+    // Switching mode re-runs the search for the current committed query.
+    if (submittedQuery) {
+      setSearchParams({ q: submittedQuery, mode: next }, { replace: true });
+    } else {
+      setSearchParams(
+        (prev) => {
+          const p = new URLSearchParams(prev);
+          p.set("mode", next);
+          return p;
+        },
+        { replace: true },
+      );
+    }
+  }
+
+  // Semantic search -- fires when submittedQuery is non-empty
+  const {
+    data: semanticData,
+    isLoading: semanticLoading,
+    error: semanticError,
+  } = $api.useQuery(
+    "get",
+    "/api/v1/knowledgebase/search/semantic",
+    { params: { query: { q: submittedQuery, limit: 10 } } },
+    { enabled: mode === "semantic" && submittedQuery.length > 0 },
+  );
+
+  // Text search -- fires when submittedQuery is non-empty
+  const {
+    data: textData,
+    isLoading: textLoading,
+    error: textError,
+  } = $api.useQuery(
+    "get",
+    "/api/v1/knowledgebase/search/text",
+    { params: { query: { q: submittedQuery } } },
+    { enabled: mode === "text" && submittedQuery.length > 0 },
+  );
+
+  const isLoading = mode === "semantic" ? semanticLoading : textLoading;
+  const error = mode === "semantic" ? semanticError : textError;
+
+  const errorMsg = error
+    ? errorMessage(error, {
+        notAuthenticated: "Authentication error. Retrying login...",
+        forbidden: "You do not have permission to search.",
+        fallback: "Search failed. Please try again.",
+      })
+    : null;
+
+  return (
+    <section className="search-panel">
+      <form className="search-form" onSubmit={handleSubmit} role="search">
+        <label htmlFor="search-input" className="search-form-label">
+          Search documents
+        </label>
+        <div className="search-input-row">
+          <input
+            id="search-input"
+            type="search"
+            className="search-input"
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Search by keyword or meaning..."
+            disabled={isLoading}
+            aria-label="Search query"
+          />
+          <button
+            type="submit"
+            className="search-submit"
+            disabled={isLoading || !inputValue.trim()}
+          >
+            {isLoading ? "Searching..." : "Search"}
+          </button>
+        </div>
+        <div className="search-mode-toggle" role="group" aria-label="Search mode">
+          <button
+            type="button"
+            className={`search-mode-btn${mode === "semantic" ? " search-mode-btn--active" : ""}`}
+            onClick={() => handleModeChange("semantic")}
+          >
+            Semantic
+          </button>
+          <button
+            type="button"
+            className={`search-mode-btn${mode === "text" ? " search-mode-btn--active" : ""}`}
+            onClick={() => handleModeChange("text")}
+          >
+            Keyword
+          </button>
+        </div>
+      </form>
+
+      {errorMsg && <p className="search-error">{errorMsg}</p>}
+
+      <div className="search-results">
+        {submittedQuery.length === 0 && (
+          <p className="search-empty">Enter a query above to search.</p>
+        )}
+
+        {isLoading && (
+          <p className="search-status">Searching...</p>
+        )}
+
+        {!isLoading && !error && submittedQuery.length > 0 && (
+          <>
+            {mode === "semantic" && semanticData?.results != null && (
+              <SemanticResultList
+                results={semanticData.results}
+                fallbackUsed={semanticData.fallbackUsed ?? false}
+              />
+            )}
+            {mode === "text" && textData?.results != null && (
+              <TextResultList results={textData.results} />
+            )}
+          </>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/services/client/src/components/SearchPanel.tsx
+++ b/services/client/src/components/SearchPanel.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { Link, useSearchParams } from "react-router";
 import $api from "../api/client";
 import type { components } from "../api/schema";
+import { formatBytes } from "../utils/format";
 
 type SemanticSearchResultDto = components["schemas"]["SemanticSearchResultDto"];
 type DocumentRefDto = components["schemas"]["DocumentRefDto"];
@@ -18,13 +19,6 @@ function errorMessage(
   if (code === "NOT_AUTHENTICATED") return messages.notAuthenticated;
   if (code === "FORBIDDEN") return messages.forbidden;
   return messages.fallback;
-}
-
-function formatFileSize(bytes: number | undefined): string {
-  if (bytes == null) return "";
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
 function formatFileType(mimeType: string | undefined): string {
@@ -53,7 +47,7 @@ function TextResultList({ results }: TextResultListProps) {
     <ul className="search-result-list" aria-label="Text search results">
       {results.map((doc) => {
         const type = formatFileType(doc.fileType);
-        const size = doc.fileSize != null ? formatFileSize(doc.fileSize) : null;
+        const size = doc.fileSize != null ? formatBytes(doc.fileSize) : null;
         const meta = [type, size].filter(Boolean).join(", ");
         return (
           <li

--- a/services/client/src/components/SearchPanel.tsx
+++ b/services/client/src/components/SearchPanel.tsx
@@ -76,8 +76,21 @@ interface SemanticResultListProps {
   fallbackUsed: boolean;
 }
 
-function SemanticResultList({ results, fallbackUsed }: SemanticResultListProps) {
+function SemanticResultList({
+  results,
+  fallbackUsed,
+}: SemanticResultListProps) {
   if (results.length === 0) {
+    if (fallbackUsed) {
+      return (
+        <>
+          <p className="search-fallback-notice">
+            Vector search unavailable -- showing keyword results instead.
+          </p>
+          <p className="search-empty">No documents matched.</p>
+        </>
+      );
+    }
     return <p className="search-empty">No documents matched.</p>;
   }
 
@@ -92,9 +105,7 @@ function SemanticResultList({ results, fallbackUsed }: SemanticResultListProps) 
         {results.map((result, index) => {
           const doc = result.document;
           const score =
-            result.score != null
-              ? Math.round(result.score * 100)
-              : null;
+            result.score != null ? Math.round(result.score * 100) : null;
           return (
             <li
               key={doc?.id ?? index}
@@ -140,7 +151,9 @@ export default function SearchPanel() {
 
   const urlQuery = searchParams.get("q") ?? "";
   const urlModeRaw = searchParams.get("mode");
-  const urlMode: SearchMode = isSearchMode(urlModeRaw) ? urlModeRaw : "semantic";
+  const urlMode: SearchMode = isSearchMode(urlModeRaw)
+    ? urlModeRaw
+    : "semantic";
 
   // inputValue tracks what's currently typed; initialised from the URL so
   // the field is pre-filled when the user navigates back to a previous search.
@@ -157,20 +170,12 @@ export default function SearchPanel() {
 
   function commitSearch(query: string, nextMode: SearchMode) {
     const trimmed = query.trim();
-    if (!trimmed) return;
     setSearchParams({ q: trimmed, mode: nextMode }, { replace: false });
   }
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     commitSearch(inputValue, mode);
-  }
-
-  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
-    if (e.key === "Enter") {
-      e.preventDefault();
-      commitSearch(inputValue, mode);
-    }
   }
 
   function handleModeChange(next: SearchMode) {
@@ -237,7 +242,6 @@ export default function SearchPanel() {
             className="search-input"
             value={inputValue}
             onChange={(e) => setInputValue(e.target.value)}
-            onKeyDown={handleKeyDown}
             placeholder="Search by keyword or meaning..."
             disabled={isLoading}
             aria-label="Search query"
@@ -245,12 +249,18 @@ export default function SearchPanel() {
           <button
             type="submit"
             className="search-submit"
-            disabled={isLoading || !inputValue.trim()}
+            disabled={
+              isLoading || (submittedQuery.length > 0 && !inputValue.trim())
+            }
           >
             {isLoading ? "Searching..." : "Search"}
           </button>
         </div>
-        <div className="search-mode-toggle" role="group" aria-label="Search mode">
+        <div
+          className="search-mode-toggle"
+          role="group"
+          aria-label="Search mode"
+        >
           <button
             type="button"
             className={`search-mode-btn${mode === "semantic" ? " search-mode-btn--active" : ""}`}
@@ -275,9 +285,7 @@ export default function SearchPanel() {
           <p className="search-empty">Enter a query above to search.</p>
         )}
 
-        {isLoading && (
-          <p className="search-status">Searching...</p>
-        )}
+        {isLoading && <p className="search-status">Searching...</p>}
 
         {!isLoading && !error && submittedQuery.length > 0 && (
           <>

--- a/services/client/src/styles/_search.scss
+++ b/services/client/src/styles/_search.scss
@@ -1,0 +1,242 @@
+@use "variables" as *;
+
+// ── Panel shell ──────────────────────────────────────────────
+
+.search-panel {
+    display: flex;
+    flex-direction: column;
+    padding: 1.5rem 2rem;
+    height: 100%;
+    box-sizing: border-box;
+}
+
+// ── Search form ──────────────────────────────────────────────
+
+.search-form {
+    flex-shrink: 0;
+    margin-bottom: 1.25rem;
+}
+
+.search-form-label {
+    display: block;
+    margin-bottom: 0.5rem;
+    font-size: 0.85rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: $color-text-muted;
+}
+
+.search-input-row {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+}
+
+.search-input {
+    flex: 1;
+    padding: 0.55rem 0.75rem;
+    font-family: $font-family;
+    font-size: 0.9rem;
+    color: $color-text-dark;
+    background: $color-bg-white;
+    border: 1px solid $color-border-input;
+    border-radius: 6px;
+    transition: border-color 0.15s;
+
+    &:focus {
+        outline: none;
+        border-color: $color-primary;
+        box-shadow: 0 0 0 2px rgba($color-primary, 0.15);
+    }
+
+    &:disabled {
+        background: $color-bg-subtle;
+        color: $color-text-muted;
+        cursor: not-allowed;
+    }
+
+    &::placeholder {
+        color: $color-text-light;
+    }
+}
+
+.search-submit {
+    flex-shrink: 0;
+    padding: 0.55rem 1.1rem;
+    font-family: $font-family;
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: $color-bg-white;
+    background: $color-primary;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: background 0.15s;
+    white-space: nowrap;
+
+    &:hover:not(:disabled) {
+        background: $color-primary-dark;
+    }
+
+    &:disabled {
+        background: $color-text-light;
+        cursor: not-allowed;
+    }
+}
+
+// ── Mode toggle ──────────────────────────────────────────────
+
+.search-mode-toggle {
+    display: flex;
+    gap: 0.3rem;
+    margin-top: 0.6rem;
+}
+
+.search-mode-btn {
+    padding: 0.25rem 0.7rem;
+    font-family: $font-family;
+    font-size: 0.8rem;
+    font-weight: 500;
+    color: $color-text-secondary;
+    background: none;
+    border: 1px solid $color-border;
+    border-radius: 999px;
+    cursor: pointer;
+    transition:
+        background 0.12s,
+        color 0.12s,
+        border-color 0.12s;
+
+    &:hover:not(.search-mode-btn--active) {
+        background: $color-bg-hover;
+        border-color: rgba($color-primary, 0.4);
+        color: $color-primary;
+    }
+
+    &--active {
+        color: $color-primary;
+        background: $color-bg-tag-user;
+        border-color: rgba($color-primary, 0.35);
+        font-weight: 600;
+        cursor: default;
+    }
+}
+
+// ── Error / status messages ──────────────────────────────────
+
+.search-error {
+    margin: 0 0 1rem;
+    padding: 0.5rem 0.75rem;
+    font-size: 0.85rem;
+    color: $color-error;
+    background: lighten($color-error, 48%);
+    border: 1px solid lighten($color-error, 38%);
+    border-radius: 6px;
+}
+
+.search-status {
+    margin: 0;
+    font-size: 0.9rem;
+    color: $color-text-muted;
+}
+
+.search-empty {
+    margin: 0;
+    font-size: 0.9rem;
+    color: $color-text-muted;
+    font-style: italic;
+}
+
+.search-fallback-notice {
+    margin: 0 0 0.75rem;
+    padding: 0.35rem 0.65rem;
+    font-size: 0.8rem;
+    color: $color-warn;
+    background: lighten($color-warn, 50%);
+    border: 1px solid lighten($color-warn, 35%);
+    border-radius: 6px;
+}
+
+// ── Results container ────────────────────────────────────────
+
+.search-results {
+    flex: 1;
+    overflow-y: auto;
+}
+
+.search-result-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+}
+
+// ── Individual result ────────────────────────────────────────
+
+.search-result-item {
+    padding: 0.85rem 1.1rem;
+    background: $color-bg-white;
+    border: 1px solid $color-border-subtle;
+    border-radius: 8px;
+    transition: border-color 0.12s;
+
+    &:hover {
+        border-color: rgba($color-primary, 0.3);
+    }
+}
+
+.search-result-header {
+    display: flex;
+    align-items: baseline;
+    gap: 0.6rem;
+    margin-bottom: 0.4rem;
+}
+
+.search-result-title {
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: $color-primary;
+    text-decoration: none;
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    &:hover {
+        text-decoration: underline;
+    }
+}
+
+.search-result-score {
+    flex-shrink: 0;
+    padding: 0.1rem 0.45rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: $color-success;
+    background: lighten($color-success, 58%);
+    border: 1px solid lighten($color-success, 40%);
+    border-radius: 999px;
+}
+
+.search-result-snippet {
+    margin: 0;
+    font-size: 0.82rem;
+    line-height: 1.5;
+    color: $color-text-body;
+
+    // Truncate long snippets to 3 lines
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.search-result-meta {
+    margin: 0;
+    font-size: 0.8rem;
+    color: $color-text-light;
+}

--- a/services/client/src/styles/index.scss
+++ b/services/client/src/styles/index.scss
@@ -4,3 +4,4 @@
 @use "upload";
 @use "login";
 @use "qa";
+@use "search";

--- a/services/client/src/utils/format.ts
+++ b/services/client/src/utils/format.ts
@@ -25,3 +25,14 @@ export function formatDate(isoString?: string, fallback = ""): string {
     day: "numeric",
   });
 }
+
+/**
+ * Formats a byte count as a human-readable size string (B / KB / MB).
+ * Returns `fallback` when the input is nullish.
+ */
+export function formatBytes(bytes?: number, fallback = ""): string {
+  if (bytes == null) return fallback;
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/services/client/tests/app.spec.ts
+++ b/services/client/tests/app.spec.ts
@@ -928,4 +928,349 @@ test.describe("Alexandria client", () => {
       await expect(page.locator(".qa-empty")).toContainText("No questions yet");
     });
   });
+
+  test.describe("Search panel", () => {
+    test("Search tab is visible and navigates to /search", async ({ page }) => {
+      await page.goto("/ask");
+
+      const searchTab = page
+        .locator(".app-header-nav .app-tab")
+        .filter({ hasText: "Search" });
+      await expect(searchTab).toBeVisible();
+
+      await searchTab.click();
+      await expect(page).toHaveURL(/\/search/);
+
+      await expect(searchTab).toHaveClass(/app-tab--active/);
+    });
+
+    test("shows empty prompt before any query is submitted", async ({
+      page,
+    }) => {
+      await page.goto("/search");
+
+      const panel = page.locator(".search-panel");
+      await expect(panel).toBeVisible();
+
+      const empty = panel.locator(".search-empty");
+      await expect(empty).toBeVisible();
+      await expect(empty).toContainText("Enter a query");
+    });
+
+    test("search input and submit button are rendered", async ({ page }) => {
+      await page.goto("/search");
+
+      await expect(page.locator(".search-input")).toBeVisible();
+      await expect(page.locator(".search-submit")).toBeVisible();
+      await expect(page.locator(".search-submit")).toHaveText("Search");
+    });
+
+    test("semantic and keyword mode toggle buttons are rendered", async ({
+      page,
+    }) => {
+      await page.goto("/search");
+
+      const semanticBtn = page
+        .locator(".search-mode-btn")
+        .filter({ hasText: "Semantic" });
+      const keywordBtn = page
+        .locator(".search-mode-btn")
+        .filter({ hasText: "Keyword" });
+
+      await expect(semanticBtn).toBeVisible();
+      await expect(keywordBtn).toBeVisible();
+      // Semantic should be active by default
+      await expect(semanticBtn).toHaveClass(/search-mode-btn--active/);
+      await expect(keywordBtn).not.toHaveClass(/search-mode-btn--active/);
+    });
+
+    test("submitting a query updates the URL with ?q= and ?mode=", async ({
+      page,
+    }) => {
+      await page.route("/api/v1/knowledgebase/search/semantic*", (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ results: [], fallbackUsed: false }),
+        }),
+      );
+
+      await page.goto("/search");
+      await page.locator(".search-input").fill("hello world");
+      await page.locator(".search-submit").click();
+
+      await expect(page).toHaveURL(/[?&]q=hello\+world/);
+      await expect(page).toHaveURL(/[?&]mode=semantic/);
+    });
+
+    test("navigating to /search?q=foo pre-fills the input and runs the search", async ({
+      page,
+    }) => {
+      await page.route("/api/v1/knowledgebase/search/semantic*", (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            results: [
+              {
+                document: {
+                  id: "bbbbbbbb-0000-0000-0000-000000000010",
+                  fileName: "prefilled.pdf",
+                  fileType: "application/pdf",
+                  fileSize: 1024,
+                  createdAt: "2026-07-01T00:00:00Z",
+                },
+                score: 0.9,
+                snippet: "Matching content.",
+              },
+            ],
+            fallbackUsed: false,
+          }),
+        }),
+      );
+
+      await page.goto("/search?q=foo&mode=semantic");
+
+      // Input should be pre-filled
+      await expect(page.locator(".search-input")).toHaveValue("foo");
+
+      // Results should load automatically
+      const resultList = page.locator(".search-result-list");
+      await expect(resultList).toBeVisible({ timeout: 5000 });
+      await expect(resultList).toContainText("prefilled.pdf");
+    });
+
+    test("semantic search shows results with snippet and score", async ({
+      page,
+    }) => {
+      const docId = "bbbbbbbb-0000-0000-0000-000000000001";
+
+      await page.route("/api/v1/knowledgebase/search/semantic*", (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            results: [
+              {
+                document: {
+                  id: docId,
+                  fileName: "annual-report.pdf",
+                  fileType: "application/pdf",
+                  fileSize: 204800,
+                  createdAt: "2026-07-01T00:00:00Z",
+                },
+                score: 0.87,
+                snippet:
+                  "Revenue grew by 12% compared to the previous fiscal year.",
+              },
+            ],
+            fallbackUsed: false,
+          }),
+        }),
+      );
+
+      await page.goto("/search");
+      await page.locator(".search-input").fill("revenue growth");
+      await page.locator(".search-submit").click();
+
+      const resultList = page.locator(".search-result-list");
+      await expect(resultList).toBeVisible({ timeout: 5000 });
+
+      const firstResult = resultList.locator(".search-result-item").first();
+      await expect(firstResult).toBeVisible();
+      await expect(firstResult).toContainText("annual-report.pdf");
+      await expect(firstResult).toContainText("87%");
+      await expect(firstResult).toContainText(
+        "Revenue grew by 12% compared to the previous fiscal year.",
+      );
+    });
+
+    test("semantic result title links to the document detail page", async ({
+      page,
+    }) => {
+      const docId = "bbbbbbbb-0000-0000-0000-000000000002";
+
+      await page.route("/api/v1/knowledgebase/search/semantic*", (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            results: [
+              {
+                document: {
+                  id: docId,
+                  fileName: "linked-doc.pdf",
+                  fileType: "application/pdf",
+                  fileSize: 1024,
+                  createdAt: "2026-07-01T00:00:00Z",
+                },
+                score: 0.75,
+                snippet: "Some matching text.",
+              },
+            ],
+            fallbackUsed: false,
+          }),
+        }),
+      );
+
+      await page.route(`/api/v1/knowledgebase/documents/${docId}`, (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            id: docId,
+            fileName: "linked-doc.pdf",
+            objectKey: `users/u1/documents/${docId}/linked-doc.pdf`,
+            fileType: "application/pdf",
+            fileSize: 1024,
+            createdAt: "2026-07-01T00:00:00Z",
+            tags: [],
+            extractedEntities: [],
+            summary: null,
+          }),
+        }),
+      );
+
+      await page.goto("/search");
+      await page.locator(".search-input").fill("something");
+      await page.locator(".search-submit").click();
+
+      const link = page.locator(".search-result-title").first();
+      await expect(link).toBeVisible({ timeout: 5000 });
+      await link.click();
+
+      // Should navigate to the document detail route
+      await expect(page).toHaveURL(new RegExp(`/documents/${docId}`));
+    });
+
+    test("shows fallback notice when vector search fell back to keyword", async ({
+      page,
+    }) => {
+      await page.route("/api/v1/knowledgebase/search/semantic*", (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            results: [
+              {
+                document: {
+                  id: "bbbbbbbb-0000-0000-0000-000000000003",
+                  fileName: "fallback-result.pdf",
+                  fileType: "application/pdf",
+                  fileSize: 512,
+                  createdAt: "2026-07-01T00:00:00Z",
+                },
+                score: 0.5,
+                snippet: "Keyword match.",
+              },
+            ],
+            fallbackUsed: true,
+          }),
+        }),
+      );
+
+      await page.goto("/search");
+      await page.locator(".search-input").fill("some query");
+      await page.locator(".search-submit").click();
+
+      const notice = page.locator(".search-fallback-notice");
+      await expect(notice).toBeVisible({ timeout: 5000 });
+      await expect(notice).toContainText("keyword results");
+    });
+
+    test("keyword mode calls text search endpoint and shows results", async ({
+      page,
+    }) => {
+      await page.route("/api/v1/knowledgebase/search/text*", (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            results: [
+              {
+                id: "bbbbbbbb-0000-0000-0000-000000000004",
+                fileName: "keyword-match.pdf",
+                fileType: "application/pdf",
+                fileSize: 2048,
+                createdAt: "2026-07-01T00:00:00Z",
+              },
+            ],
+          }),
+        }),
+      );
+
+      await page.goto("/search");
+
+      // Switch to keyword mode
+      const keywordBtn = page
+        .locator(".search-mode-btn")
+        .filter({ hasText: "Keyword" });
+      await keywordBtn.click();
+      await expect(keywordBtn).toHaveClass(/search-mode-btn--active/);
+
+      await page.locator(".search-input").fill("keyword");
+      await page.locator(".search-submit").click();
+
+      await expect(page).toHaveURL(/[?&]mode=text/);
+
+      const resultList = page.locator(".search-result-list");
+      await expect(resultList).toBeVisible({ timeout: 5000 });
+      await expect(resultList).toContainText("keyword-match.pdf");
+    });
+
+    test("shows empty state when search returns no results", async ({
+      page,
+    }) => {
+      await page.route("/api/v1/knowledgebase/search/semantic*", (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ results: [], fallbackUsed: false }),
+        }),
+      );
+
+      await page.goto("/search");
+      await page.locator(".search-input").fill("nothing matches this");
+      await page.locator(".search-submit").click();
+
+      const empty = page.locator(".search-empty");
+      await expect(empty).toBeVisible({ timeout: 5000 });
+      await expect(empty).toContainText("No documents matched");
+    });
+
+    test("shows an error message when the search endpoint returns 500", async ({
+      page,
+    }) => {
+      await page.route("/api/v1/knowledgebase/search/semantic*", (route) =>
+        route.fulfill({ status: 500, body: "Internal Server Error" }),
+      );
+
+      await page.goto("/search");
+      await page.locator(".search-input").fill("error trigger");
+      await page.locator(".search-submit").click();
+
+      const error = page.locator(".search-error");
+      await expect(error).toBeVisible({ timeout: 15000 });
+      await expect(error).toContainText("Search failed");
+    });
+
+    test("shows authentication error when the search endpoint returns 401", async ({
+      page,
+    }) => {
+      await page.route("**/protocol/openid-connect/token", (route) =>
+        route.fulfill({ status: 401, body: "Unauthorized" }),
+      );
+      await page.route("/api/v1/knowledgebase/search/semantic*", (route) =>
+        route.fulfill({ status: 401, body: "Unauthorized" }),
+      );
+
+      await page.goto("/search");
+      await page.locator(".search-input").fill("auth check");
+      await page.locator(".search-submit").click();
+
+      const error = page.locator(".search-error");
+      await expect(error).toBeVisible({ timeout: 15000 });
+      await expect(error).toHaveText("Authentication error. Retrying login...");
+    });
+  });
 });

--- a/services/client/tests/app.spec.ts
+++ b/services/client/tests/app.spec.ts
@@ -1178,6 +1178,34 @@ test.describe("Alexandria client", () => {
       await expect(notice).toContainText("keyword results");
     });
 
+    test("shows fallback notice and empty state when vector search fell back to keyword with no results", async ({
+      page,
+    }) => {
+      await page.route("/api/v1/knowledgebase/search/semantic*", (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            results: [],
+            fallbackUsed: true,
+          }),
+        }),
+      );
+
+      await page.goto("/search");
+      await page.locator(".search-input").fill("empty query");
+      await page.locator(".search-submit").click();
+
+      // Both the fallback notice and empty state should be visible
+      const notice = page.locator(".search-fallback-notice");
+      const emptyState = page.locator(".search-empty");
+
+      await expect(notice).toBeVisible({ timeout: 5000 });
+      await expect(notice).toContainText("keyword results");
+      await expect(emptyState).toBeVisible({ timeout: 5000 });
+      await expect(emptyState).toContainText("No documents matched");
+    });
+
     test("keyword mode calls text search endpoint and shows results", async ({
       page,
     }) => {


### PR DESCRIPTION
## What does this PR do?

Adds a Search tab to the client, closes #276, closes #248.

The tab lives at `/search` and lets users search their documents in two modes -- semantic (default) and keyword -- via the endpoints introduced in #270. Semantic results show a relevance score and the matching text snippet from the document. Keyword results show file type and size as secondary metadata. The current query and mode are stored in the URL as `?q=` and `?mode=`, so searches are shareable and survive back/forward navigation.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [x] Docs
- [ ] CI / infra

## Definition of Done

- [x] CI is green
- [ ] If the API changed: `api/openapi.yaml` is updated and lint passes
- [x] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [x] Tests added or updated for the changed behaviour
- [x] Docs updated where it matters (README, ADRs, comments)

## Notes for the reviewer

The error tests for search use a 15s timeout instead of the usual 5s because the search endpoints use `useQuery` (not `useMutation`), which retries up to 3 times before surfacing the error -- by design, so a transient 401 triggers re-auth and the retry succeeds. With a permanently-stubbed failure the full retry backoff is ~7s.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Search page with semantic and keyword search modes.
  * Added relevance scores, snippets, result links, empty states, and fallback notices when semantic search is unavailable.
  * Added Search navigation and authenticated routing.
* **Bug Fixes**
  * Improved document size formatting and handling of missing values.
* **Documentation**
  * Documented search modes, result behavior, and fallback handling.
* **Tests**
  * Added coverage for search navigation, queries, results, errors, authentication, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->