### PR TITLE
CI: Keep main deploys uncancellable and clean up failed helm rollouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,12 @@ on:
 
 # Cancel superseded runs on the same branch / PR. Saves runner minutes
 # and means the latest commit is always the one that gets verified.
+# The default branch is exempt: cancelling a run mid-deploy SIGKILLs helm
+# and leaves the release stuck in pending-upgrade. On main, runs queue and
+# each helm upgrade finishes before the next starts.
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
 
 permissions:
   contents: read
@@ -963,7 +966,8 @@ jobs:
             --set "genai.llmApiKey=$LLM_API_KEY" \
             --set "spring.internal.sharedSecret=$INTERNAL_SHARED_SECRET" \
             --wait \
-            --timeout 5m
+            --timeout 5m \
+            --cleanup-on-fail
 
       - name: Verify Deployment
         run: |


### PR DESCRIPTION
## What does this PR do?

Two changes to make the stud-cluster deploy stop wedging itself.

Sometimes, a `Error: UPGRADE FAILED: another operation (install/upgrade/rollback) is in progress` occurred.

The workflow runs with `cancel-in-progress: true`, and the deploy only runs on main. When a second commit lands on main while a deploy is mid `helm upgrade`, GitHub cancels the older run and SIGKILLs the runner. Helm never finishes and never rolls back, so the release is left stuck in `pending-upgrade` and every later run fails until someone clears it by hand.

So:

- `cancel-in-progress` is now exempt for the default branch. PRs and feature branches still cancel superseded runs to save minutes; main runs queue instead, so each `helm upgrade` finishes before the next one starts. At most one running plus one pending run per group, latest commit still wins.
- Added `--cleanup-on-fail` to the helm upgrade so a genuinely failed rollout removes the resources it created instead of leaking them into an already tight namespace quota.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [x] CI / infra

## Definition of Done

- [x] CI is green (actionlint passes locally)
- [ ] If the API changed: `api/openapi.yaml` is updated and lint passes
- [ ] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [ ] Tests added or updated for the changed behaviour
- [x] Docs updated where it matters (inline comment explains why main is exempt)

## Notes for the reviewer


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented default-branch deployment workflows from being cancelled mid-run.
  * Added automatic cleanup for failed Helm deployments to help avoid incomplete releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->