### PR TITLE
Feat: Configurable client API base URL and gateway CORS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,15 @@
 # INTERNAL_CLOCK_SKEW_SECONDS=300
 
 # ----------------------------------------------------------------------------------
+# API Gateway (Traefik CORS)
+# ----------------------------------------------------------------------------------
+
+# Allowed browser origins for the Spring API, applied as a Traefik CORS middleware.
+# Comma-separated list. Only needed when the client is served from a different
+# origin than the API; the default keeps same-origin requests working.
+# CORS_ALLOWED_ORIGINS="http://localhost"
+
+# ----------------------------------------------------------------------------------
 # GenAI Service
 # ----------------------------------------------------------------------------------
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,6 +89,7 @@ services:
       - "traefik.http.routers.user-service.rule=PathPrefix(`/api/v1/users`) || PathPrefix(`/user-service/docs`) || PathPrefix(`/user-service/swagger-ui`) || PathPrefix(`/user-service/v3/api-docs`)"
       - "traefik.http.routers.user-service.entrypoints=web"
       - "traefik.http.routers.user-service.priority=20"
+      - "traefik.http.routers.user-service.middlewares=api-cors@docker"
       - "traefik.http.services.user-service.loadbalancer.server.port=8080"
     healthcheck:
       test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8080/actuator/health/readiness"]
@@ -147,6 +148,7 @@ services:
       - "traefik.http.routers.knowledgebase-service.rule=PathPrefix(`/api/v1/knowledgebase`) || PathPrefix(`/knowledgebase-service/docs`) || PathPrefix(`/knowledgebase-service/swagger-ui`) || PathPrefix(`/knowledgebase-service/v3/api-docs`)"
       - "traefik.http.routers.knowledgebase-service.entrypoints=web"
       - "traefik.http.routers.knowledgebase-service.priority=20"
+      - "traefik.http.routers.knowledgebase-service.middlewares=api-cors@docker"
       - "traefik.http.services.knowledgebase-service.loadbalancer.server.port=8080"
     healthcheck:
       test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8080/actuator/health/readiness"]
@@ -202,6 +204,7 @@ services:
       - "traefik.http.routers.qa-service.rule=PathPrefix(`/api/v1/qa`) || PathPrefix(`/qa-service/docs`) || PathPrefix(`/qa-service/swagger-ui`) || PathPrefix(`/qa-service/v3/api-docs`)"
       - "traefik.http.routers.qa-service.entrypoints=web"
       - "traefik.http.routers.qa-service.priority=20"
+      - "traefik.http.routers.qa-service.middlewares=api-cors@docker"
       - "traefik.http.services.qa-service.loadbalancer.server.port=8080"
     healthcheck:
       test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8080/actuator/health/readiness"]
@@ -489,6 +492,13 @@ services:
       - "traefik.http.routers.dashboard.entrypoints=web"
       - "traefik.http.routers.dashboard.service=api@internal"
       - "traefik.http.services.dashboard.loadbalancer.server.port=9999"
+      # Shared CORS middleware for the Spring API, attached to the three service routers.
+      # Origins are env-driven so a cross-origin client can be allowed per deployment.
+      - "traefik.http.middlewares.api-cors.headers.accesscontrolalloworiginlist=${CORS_ALLOWED_ORIGINS:-http://localhost}"
+      - "traefik.http.middlewares.api-cors.headers.accesscontrolallowmethods=GET,POST,PUT,PATCH,DELETE,OPTIONS"
+      - "traefik.http.middlewares.api-cors.headers.accesscontrolallowheaders=Authorization,Content-Type"
+      - "traefik.http.middlewares.api-cors.headers.accesscontrolmaxage=3600"
+      - "traefik.http.middlewares.api-cors.headers.addvaryheader=true"
     healthcheck:
       test: ["CMD", "traefik", "healthcheck", "--ping"]
       interval: 30s

--- a/infra/k8s/alexandria/templates/ingress.yaml
+++ b/infra/k8s/alexandria/templates/ingress.yaml
@@ -6,6 +6,10 @@ metadata:
   annotations:
       cert-manager.io/cluster-issuer: "letsencrypt-prod"
       nginx.ingress.kubernetes.io/proxy-body-size: {{ .Values.ingress.maxBodySize | quote }}
+      nginx.ingress.kubernetes.io/enable-cors: "true"
+      nginx.ingress.kubernetes.io/cors-allow-origin: {{ .Values.ingress.corsAllowOrigin | quote }}
+      nginx.ingress.kubernetes.io/cors-allow-methods: "GET, POST, PUT, PATCH, DELETE, OPTIONS"
+      nginx.ingress.kubernetes.io/cors-allow-headers: "Authorization, Content-Type"
   labels:
     {{- include "alexandria.labels" . | nindent 4 }}
 spec:

--- a/infra/k8s/alexandria/values.yaml
+++ b/infra/k8s/alexandria/values.yaml
@@ -148,6 +148,10 @@ ingress:
   # nginx client_max_body_size, kept a bit above Spring MAX_UPLOAD_SIZE
   # so oversized uploads get the Spring 413 error response
   maxBodySize: "30m"
+  # Browser origin allowed to call the API cross-origin. Same-origin traffic
+  # through this ingress is unaffected; override when the client is hosted
+  # elsewhere.
+  corsAllowOrigin: "http://localhost"
 
 # NetworkPolicies: default-deny ingress with explicit allow rules.
 # Off by default.

--- a/infra/k8s/alexandria/values.yaml
+++ b/infra/k8s/alexandria/values.yaml
@@ -148,10 +148,10 @@ ingress:
   # nginx client_max_body_size, kept a bit above Spring MAX_UPLOAD_SIZE
   # so oversized uploads get the Spring 413 error response
   maxBodySize: "30m"
-  # Browser origin allowed to call the API cross-origin. Same-origin traffic
-  # through this ingress is unaffected; override when the client is hosted
-  # elsewhere.
-  corsAllowOrigin: "http://localhost"
+  # Browser origin allowed to call the API cross-origin. Set to the ingress
+  # origin so no external origin is granted access; change it when the client is
+  # served from a different origin.
+  corsAllowOrigin: "https://alexandria.stud.k8s.aet.cit.tum.de"
 
 # NetworkPolicies: default-deny ingress with explicit allow rules.
 # Off by default.

--- a/services/client/README.md
+++ b/services/client/README.md
@@ -18,6 +18,26 @@ rendered with Markdown support. Each answer includes references to the source
 documents it was derived from; clicking a source reference switches back to
 the **Documents** tab and opens that document.
 
+Configuration
+-------------
+
+The client reads a single build-time variable:
+
+| Variable       | Default | Purpose                                                                 |
+| -------------- | ------- | ----------------------------------------------------------------------- |
+| `VITE_API_URL` | `""`    | Base URL prefixed to every API request made by the generated SDK client |
+
+Vite inlines `VITE_*` variables at build time, so this is set when the image is
+built, not at container runtime. The empty default keeps requests same-origin,
+which is what we want behind Traefik and the k8s ingress. Set it only when the
+client is served from a different origin than the API, e.g.
+
+```bash
+VITE_API_URL=https://api.example.com npm run build
+```
+
+or via a `.env` file in this directory (see the [Vite env docs](https://vite.dev/guide/env-and-mode)).
+
 Production
 ----------
 

--- a/services/client/README.md
+++ b/services/client/README.md
@@ -18,8 +18,7 @@ rendered with Markdown support. Each answer includes references to the source
 documents it was derived from; clicking a source reference switches back to
 the **Documents** tab and opens that document.
 
-Configuration
--------------
+## Configuration
 
 The client reads a single build-time variable:
 
@@ -38,8 +37,7 @@ VITE_API_URL=https://api.example.com npm run build
 
 or via a `.env` file in this directory (see the [Vite env docs](https://vite.dev/guide/env-and-mode)).
 
-Production
-----------
+## Production
 
 Build and run the production image (uses the multi-stage Dockerfile):
 
@@ -56,8 +54,7 @@ docker compose up -d client --build
 # then open http://localhost/
 ```
 
-Development
------------
+## Development
 
 A development image is provided which runs the Vite dev server inside the container. It is useful for working in a containerised dev environment and supports live reload. The Spring server and Keycloak are proxied at `http://localhost:5173/api` and `http://localhost:5173/auth`.
 
@@ -69,8 +66,7 @@ docker compose --profile dev up client-dev -d --build --renew-anon-volumes
 # then open http://localhost:5173
 ```
 
-Testing
--------
+## Testing
 
 Playwright is used for end-to-end tests. The tests run against a remote browser served by a Playwright Docker container.
 
@@ -87,8 +83,7 @@ cd services/client
 npm run test:e2e
 ```
 
-Notes
------
+## Notes
 - The dev Dockerfile starts Vite with --host 0.0.0.0 so the dev server is reachable from the host when running in a container.
 - The production image is based on `nginxinc/nginx-unprivileged` and serves the built files on port 8080 inside the container (Traefik in docker-compose routes to it via the internal network, no host port published by default).
 - When starting the development server, `--build --renew-anon-volumes` has to be specified.

--- a/services/client/src/api/client.ts
+++ b/services/client/src/api/client.ts
@@ -3,7 +3,11 @@ import createQueryClient from "openapi-react-query";
 import type { paths } from "./schema";
 import { userManager } from "../oidcConfig";
 
-export const fetchClient = createFetchClient<paths>({ baseUrl: "" });
+// Empty default keeps same-origin behaviour behind Traefik. Override with
+// VITE_API_URL at build time when the client is served from a different origin.
+export const fetchClient = createFetchClient<paths>({
+  baseUrl: import.meta.env.VITE_API_URL ?? "",
+});
 
 fetchClient.use({
   async onRequest({ request }) {

--- a/services/client/src/vite-env.d.ts
+++ b/services/client/src/vite-env.d.ts
@@ -1,5 +1,13 @@
 /// <reference types="vite/client" />
 
+interface ImportMetaEnv {
+  readonly VITE_API_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}
+
 declare module "*.scss" {
   const content: string;
   export default content;


### PR DESCRIPTION
## What does this PR do?

Two related bits of config, both around the client talking to the API from a
different origin.

First, the client API base URL is no longer hardcoded to `""`. It now reads
`import.meta.env.VITE_API_URL` and falls back to `""`, so same-origin behaviour
behind Traefik stays exactly as before, but the base URL can be pointed
somewhere else at build time. Closes #278.

Second, since a cross-origin client would immediately hit CORS, I added a CORS
config on both gateways: a Traefik middleware in docker-compose attached to the
three Spring API routers, and the matching nginx-ingress CORS annotations on the
k8s side. The allowed origin is env-driven (`CORS_ALLOWED_ORIGINS` for compose,
`ingress.corsAllowOrigin` in the Helm values) and defaults to `http://localhost`,
so nothing changes for the current same-origin setup. This ticks the CORS box in
the compliance checklist (#219).

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [x] CI / infra

## Definition of Done

- [ ] CI is green
- [x] If the API changed: `api/openapi.yaml` is updated and lint passes (no API change)
- [x] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [ ] Tests added or updated for the changed behaviour (config-only change, no unit test hook; validated with `docker compose config`, `helm template`, and tsc)
- [x] Docs updated where it matters (README, ADRs, comments)

## Notes for the reviewer

- Default origin is `http://localhost` on purpose so this is a no-op for the
  current deployment. Override it per environment when the client moves to its
  own origin.
- `VITE_API_URL` is a Vite build-time var, so it gets baked into the image at
  build, not read at container runtime. Documented that in
  `services/client/README.md`.
- Traefik middleware is defined once on the traefik container and referenced as
  `api-cors@docker` from the user/knowledgebase/qa routers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable CORS support for API access from approved web origins.
  * Added build-time configuration for setting a custom API base URL.
  * API requests now use the configured base URL when provided, with same-origin access as the default.

* **Documentation**
  * Documented CORS and API URL configuration, including setup examples and environment variable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->