### PR TITLE
Feat: implement tag filtering on client

### DIFF
--- a/services/client/README.md
+++ b/services/client/README.md
@@ -10,6 +10,14 @@ Upload, browse, and view documents. Each document shows its AI-generated
 summary, extracted entities, and tags. PDF and Markdown files include a live
 preview.
 
+### Tagging
+
+Documents can be tagged automatically (via AI processing) or manually by the
+user. The sidebar displays each document's tags as small chips and provides a
+tag filter that lets users narrow the document list by one or more tags (AND
+logic). In the detail view, users can add new tags or remove their own
+user-created tags. Tags are always sorted alphabetically for consistent display.
+
 ### Q&A (Ask)
 
 Users can ask natural-language questions about their uploaded documents via the

--- a/services/client/README.md
+++ b/services/client/README.md
@@ -13,10 +13,10 @@ preview.
 ### Tagging
 
 Documents can be tagged automatically (via AI processing) or manually by the
-user. The sidebar displays each document's tags as small chips and provides a
-tag filter that lets users narrow the document list by one or more tags (AND
-logic). In the detail view, users can add new tags or remove their own
-user-created tags. Tags are always sorted alphabetically for consistent display.
+user. The sidebar displays available global tags as filter chips and lets users
+narrow the document list by one or more tags (AND logic). In the detail view,
+users can add new tags or remove their own user-created tags. Tags are always
+sorted alphabetically for consistent display.
 
 ### Q&A (Ask)
 

--- a/services/client/src/components/DocumentDetail.tsx
+++ b/services/client/src/components/DocumentDetail.tsx
@@ -104,6 +104,12 @@ export default function DocumentDetail() {
     });
   }
 
+  function closeAddTag() {
+    setNewTagLabel("");
+    setAddingTag(false);
+    addTagMutation.reset();
+  }
+
   function handleAddTag() {
     const label = newTagLabel.trim();
     if (!label || !documentId) return;
@@ -114,8 +120,7 @@ export default function DocumentDetail() {
       },
       {
         onSuccess: () => {
-          setNewTagLabel("");
-          setAddingTag(false);
+          closeAddTag();
           invalidateAfterTagChange();
         },
       },
@@ -127,8 +132,7 @@ export default function DocumentDetail() {
       e.preventDefault();
       handleAddTag();
     } else if (e.key === "Escape") {
-      setNewTagLabel("");
-      setAddingTag(false);
+      closeAddTag();
     }
   }
 
@@ -136,7 +140,7 @@ export default function DocumentDetail() {
     if (newTagLabel.trim()) {
       handleAddTag();
     } else {
-      setAddingTag(false);
+      closeAddTag();
     }
   }
 
@@ -214,27 +218,21 @@ export default function DocumentDetail() {
           {tags.map((tag) => (
             <li
               key={tag.id}
-              className={`tag tag--${tag.source?.toLowerCase() ?? "user"} tag--clickable`}
-              onClick={() => onToggleTag(tag.label ?? "")}
-              title={`Filter by "${tag.label}"`}
-              role="button"
-              tabIndex={0}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === " ") {
-                  e.preventDefault();
-                  onToggleTag(tag.label ?? "");
-                }
-              }}
+              className={`tag tag--${tag.source?.toLowerCase() ?? "user"}`}
             >
-              <span className="tag__label">{tag.label}</span>
+              <button
+                type="button"
+                className="tag__label tag__label--clickable"
+                onClick={() => onToggleTag(tag.label ?? "")}
+                title={`Filter by "${tag.label}"`}
+              >
+                {tag.label}
+              </button>
               {tag.source === "USER" && (
                 <button
                   type="button"
                   className="tag__remove"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    handleRemoveTag(tag.id ?? "");
-                  }}
+                  onClick={() => handleRemoveTag(tag.id ?? "")}
                   aria-label={`Remove tag ${tag.label}`}
                   disabled={removeTagMutation.isPending}
                 >
@@ -282,7 +280,7 @@ export default function DocumentDetail() {
             )}
           </li>
         </ul>
-        {addTagMutation.isError && (
+        {addingTag && addTagMutation.isError && (
           <p className="tag-add-error">Failed to add tag.</p>
         )}
       </section>

--- a/services/client/src/components/DocumentDetail.tsx
+++ b/services/client/src/components/DocumentDetail.tsx
@@ -1,8 +1,10 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
-import { useParams } from "react-router";
+import { useOutletContext, useParams } from "react-router";
+import { useQueryClient } from "@tanstack/react-query";
 import $api from "../api/client";
 import { formatBytes, formatDateTime } from "../utils/format";
+import type { MainViewContext } from "./MainView";
 
 const ENTITY_TYPE_LABELS: Record<string, string> = {
   PERSON: "Person",
@@ -10,9 +12,14 @@ const ENTITY_TYPE_LABELS: Record<string, string> = {
   TOPIC: "Topic",
   ORGANIZATION: "Organization",
 };
-
 export default function DocumentDetail() {
   const { id: documentId = null } = useParams<{ id: string }>();
+  const { onToggleTag } = useOutletContext<MainViewContext>();
+  const queryClient = useQueryClient();
+  const [newTagLabel, setNewTagLabel] = useState("");
+  const [addingTag, setAddingTag] = useState(false);
+  const tagInputRef = useRef<HTMLInputElement>(null);
+
   const {
     data: document,
     isLoading,
@@ -23,6 +30,17 @@ export default function DocumentDetail() {
     { params: { path: { id: documentId ?? "" } } },
     { enabled: !!documentId },
   );
+
+  const addTagMutation = $api.useMutation(
+    "post",
+    "/api/v1/knowledgebase/documents/{id}/tags",
+  );
+
+  const removeTagMutation = $api.useMutation(
+    "delete",
+    "/api/v1/knowledgebase/documents/{documentId}/tags/{tagId}",
+  );
+
   const fileType = (document?.fileType ?? "").split(";")[0];
   const isPdf = fileType === "application/pdf";
   const isMarkdown = fileType === "text/markdown";
@@ -73,6 +91,69 @@ export default function DocumentDetail() {
     };
   }, [pdfData]);
 
+  function invalidateAfterTagChange() {
+    // Refetch both the document detail and the documents list + tags list
+    void queryClient.invalidateQueries({
+      queryKey: ["get", "/api/v1/knowledgebase/documents/{id}"],
+    });
+    void queryClient.invalidateQueries({
+      queryKey: ["get", "/api/v1/knowledgebase/documents"],
+    });
+    void queryClient.invalidateQueries({
+      queryKey: ["get", "/api/v1/knowledgebase/tags"],
+    });
+  }
+
+  function handleAddTag() {
+    const label = newTagLabel.trim();
+    if (!label || !documentId) return;
+    addTagMutation.mutate(
+      {
+        params: { path: { id: documentId } },
+        body: { label },
+      },
+      {
+        onSuccess: () => {
+          setNewTagLabel("");
+          setAddingTag(false);
+          invalidateAfterTagChange();
+        },
+      },
+    );
+  }
+
+  function handleTagInputKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleAddTag();
+    } else if (e.key === "Escape") {
+      setNewTagLabel("");
+      setAddingTag(false);
+    }
+  }
+
+  function handleTagInputBlur() {
+    if (newTagLabel.trim()) {
+      handleAddTag();
+    } else {
+      setAddingTag(false);
+    }
+  }
+
+  function handleRemoveTag(tagId: string) {
+    if (!documentId) return;
+    removeTagMutation.mutate(
+      {
+        params: { path: { documentId, tagId } },
+      },
+      {
+        onSuccess: () => {
+          invalidateAfterTagChange();
+        },
+      },
+    );
+  }
+
   if (!documentId) {
     return (
       <div className="document-detail document-detail--empty">
@@ -106,7 +187,10 @@ export default function DocumentDetail() {
 
   if (!document) return null;
 
-  const tags = document.tags ?? [];
+  // Sort tags alphabetically to keep a consistent display order (#301)
+  const tags = [...(document.tags ?? [])].sort((a, b) =>
+    (a.label ?? "").localeCompare(b.label ?? ""),
+  );
   const entities = document.extractedEntities ?? [];
   const summary = document.summary;
 
@@ -124,21 +208,84 @@ export default function DocumentDetail() {
         </dl>
       </header>
 
-      {tags.length > 0 && (
-        <section className="detail-section">
-          <h3>Tags</h3>
-          <ul className="tag-list" aria-label="Document tags">
-            {tags.map((tag) => (
-              <li
-                key={tag.id}
-                className={`tag tag--${tag.source?.toLowerCase() ?? "user"}`}
+      <section className="detail-section">
+        <h3>Tags</h3>
+        <ul className="tag-list" aria-label="Document tags">
+          {tags.map((tag) => (
+            <li
+              key={tag.id}
+              className={`tag tag--${tag.source?.toLowerCase() ?? "user"} tag--clickable`}
+              onClick={() => onToggleTag(tag.label ?? "")}
+              title={`Filter by "${tag.label}"`}
+              role="button"
+              tabIndex={0}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  onToggleTag(tag.label ?? "");
+                }
+              }}
+            >
+              <span className="tag__label">{tag.label}</span>
+              {tag.source === "USER" && (
+                <button
+                  type="button"
+                  className="tag__remove"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleRemoveTag(tag.id ?? "");
+                  }}
+                  aria-label={`Remove tag ${tag.label}`}
+                  disabled={removeTagMutation.isPending}
+                >
+                  x
+                </button>
+              )}
+            </li>
+          ))}
+          <li className="tag tag--add">
+            {addingTag ? (
+              <span className="tag__input-wrapper">
+                <input
+                  ref={tagInputRef}
+                  type="text"
+                  className="tag__input"
+                  value={newTagLabel}
+                  onChange={(e) => setNewTagLabel(e.target.value)}
+                  onKeyDown={handleTagInputKeyDown}
+                  onBlur={handleTagInputBlur}
+                  placeholder="tag name"
+                  aria-label="New tag name"
+                  maxLength={50}
+                  autoFocus
+                />
+                <button
+                  type="button"
+                  className="tag__confirm"
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={handleAddTag}
+                  aria-label="Confirm new tag"
+                  disabled={!newTagLabel.trim() || addTagMutation.isPending}
+                >
+                  &#10003;
+                </button>
+              </span>
+            ) : (
+              <button
+                type="button"
+                className="tag__add-button"
+                onClick={() => setAddingTag(true)}
+                aria-label="Add a tag"
               >
-                {tag.label}
-              </li>
-            ))}
-          </ul>
-        </section>
-      )}
+                +
+              </button>
+            )}
+          </li>
+        </ul>
+        {addTagMutation.isError && (
+          <p className="tag-add-error">Failed to add tag.</p>
+        )}
+      </section>
 
       {entities.length > 0 && (
         <section className="detail-section">

--- a/services/client/src/components/DocumentTree.tsx
+++ b/services/client/src/components/DocumentTree.tsx
@@ -1,27 +1,109 @@
-import React from "react";
+import React, { useState } from "react";
 import { Link, useNavigate, useParams } from "react-router";
 import UploadDocument from "./UploadDocument";
 import type { components } from "../api/schema";
 import { formatDate } from "../utils/format";
 
 type Document = components["schemas"]["Document"];
+type TagDto = components["schemas"]["TagDto"];
+
+const VISIBLE_TAG_COUNT = 5;
 
 interface Props {
   documents: Document[] | undefined;
   isLoading: boolean;
   error: unknown;
+  allTags: TagDto[];
+  selectedTags: string[];
+  onToggleTag: (tagName: string) => void;
+  onClearTags: () => void;
 }
 
-export default function DocumentTree({ documents, isLoading, error }: Props) {
+export default function DocumentTree({
+  documents,
+  isLoading,
+  error,
+  allTags,
+  selectedTags,
+  onToggleTag,
+  onClearTags,
+}: Props) {
   const navigate = useNavigate();
   const { id: selectedId } = useParams<{ id: string }>();
   const errorMessage =
     error instanceof Error ? error.message : error ? String(error) : "";
 
+  const [tagsExpanded, setTagsExpanded] = useState(false);
+  const hasHiddenTags = allTags.length > VISIBLE_TAG_COUNT;
+
+  // If a selected tag is outside the visible set, force-expand so it's shown
+  const visibleTagNames = allTags
+    .slice(0, VISIBLE_TAG_COUNT)
+    .map((t) => t.name ?? "");
+  const hasSelectedHiddenTag = selectedTags.some(
+    (t) => !visibleTagNames.includes(t),
+  );
+  const showAll = tagsExpanded || hasSelectedHiddenTag;
+  const visibleTags = showAll ? allTags : allTags.slice(0, VISIBLE_TAG_COUNT);
+
   return (
     <nav className="document-tree" aria-label="Document list">
       <h2 className="tree-heading">Documents</h2>
       <UploadDocument onUploaded={(id) => void navigate(`/documents/${id}`)} />
+
+      {/* Tag filter section */}
+      {allTags.length > 0 && (
+        <div className="tag-filter" aria-label="Filter by tags">
+          <div className="tag-filter__header">
+            <span className="tag-filter__label">Filter by tag</span>
+            <button
+              className="tag-filter__clear"
+              onClick={onClearTags}
+              type="button"
+              style={{
+                visibility: selectedTags.length > 0 ? "visible" : "hidden",
+              }}
+            >
+              Clear
+            </button>
+          </div>
+          <ul className="tag-filter__list">
+            {visibleTags.map((tag) => {
+              const name = tag.name ?? "";
+              const active = selectedTags.includes(name);
+              return (
+                <li key={name}>
+                  <button
+                    type="button"
+                    className={`tag-filter__chip${active ? " tag-filter__chip--active" : ""}`}
+                    onClick={() => onToggleTag(name)}
+                    aria-pressed={active}
+                  >
+                    {name}
+                    {tag.documentCount != null && (
+                      <span className="tag-filter__count">
+                        {tag.documentCount}
+                      </span>
+                    )}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+          {hasHiddenTags && (
+            <button
+              type="button"
+              className="tag-filter__toggle"
+              onClick={() => setTagsExpanded((v) => !v)}
+            >
+              {showAll
+                ? "Show less"
+                : `+${allTags.length - VISIBLE_TAG_COUNT} more`}
+            </button>
+          )}
+        </div>
+      )}
+
       {isLoading && <p className="tree-status">Loading…</p>}
       {!!error && (
         <p
@@ -39,7 +121,11 @@ export default function DocumentTree({ documents, isLoading, error }: Props) {
         </p>
       )}
       {!isLoading && !error && documents?.length === 0 && (
-        <p className="tree-status">No documents yet.</p>
+        <p className="tree-status">
+          {selectedTags.length > 0
+            ? "No documents match the selected tags."
+            : "No documents yet."}
+        </p>
       )}
       {!isLoading && !error && documents && documents.length > 0 && (
         <ul className="tree-list">
@@ -51,7 +137,11 @@ export default function DocumentTree({ documents, isLoading, error }: Props) {
                 key={id}
                 className={`tree-item${selectedId === id ? " tree-item--active" : ""}`}
               >
-                <Link to={`/documents/${id}`} className="tree-item__link" aria-current={selectedId === id ? "true" : undefined}>
+                <Link
+                  to={`/documents/${id}`}
+                  className="tree-item__link"
+                  aria-current={selectedId === id ? "true" : undefined}
+                >
                   <span className="tree-item__name">{doc.fileName}</span>
                   <span className="tree-item__date">
                     {formatDate(doc.createdAt)}

--- a/services/client/src/components/DocumentTree.tsx
+++ b/services/client/src/components/DocumentTree.tsx
@@ -90,13 +90,13 @@ export default function DocumentTree({
               );
             })}
           </ul>
-          {hasHiddenTags && (
+          {hasHiddenTags && !hasSelectedHiddenTag && (
             <button
               type="button"
               className="tag-filter__toggle"
               onClick={() => setTagsExpanded((v) => !v)}
             >
-              {showAll
+              {tagsExpanded
                 ? "Show less"
                 : `+${allTags.length - VISIBLE_TAG_COUNT} more`}
             </button>

--- a/services/client/src/components/MainView.tsx
+++ b/services/client/src/components/MainView.tsx
@@ -1,17 +1,51 @@
-import React from "react";
+import React, { useMemo, useState } from "react";
 import { NavLink, Outlet } from "react-router";
 import { useAuth } from "react-oidc-context";
 import DocumentTree from "./DocumentTree";
 import $api from "../api/client";
 
+export interface MainViewContext {
+  onToggleTag: (tagName: string) => void;
+}
+
 export default function MainView() {
   const auth = useAuth();
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
 
   const {
     data: documents,
     isLoading: documentsLoading,
     error: documentsError,
   } = $api.useQuery("get", "/api/v1/knowledgebase/documents");
+
+  const { data: tagsData } = $api.useQuery(
+    "get",
+    "/api/v1/knowledgebase/tags",
+  );
+
+  const allTags = tagsData?.tags ?? [];
+
+  // Client-side filter: only show documents matching ALL selected tags
+  const filteredDocuments = useMemo(() => {
+    if (!documents) return undefined;
+    if (selectedTags.length === 0) return documents;
+    return documents.filter((doc) => {
+      const docTagLabels = (doc.tags ?? []).map((t) => t.label ?? "");
+      return selectedTags.every((tag) => docTagLabels.includes(tag));
+    });
+  }, [documents, selectedTags]);
+
+  function handleToggleTag(tagName: string) {
+    setSelectedTags((prev) =>
+      prev.includes(tagName)
+        ? prev.filter((t) => t !== tagName)
+        : [...prev, tagName],
+    );
+  }
+
+  function handleClearTags() {
+    setSelectedTags([]);
+  }
 
   return (
     <div className="app">
@@ -59,12 +93,16 @@ export default function MainView() {
       </header>
       <div className="app-body">
         <DocumentTree
-          documents={documents}
+          documents={filteredDocuments}
           isLoading={documentsLoading}
           error={documentsError}
+          allTags={allTags}
+          selectedTags={selectedTags}
+          onToggleTag={handleToggleTag}
+          onClearTags={handleClearTags}
         />
         <main className="app-main">
-          <Outlet />
+          <Outlet context={{ onToggleTag: handleToggleTag } satisfies MainViewContext} />
         </main>
       </div>
     </div>

--- a/services/client/src/components/MainView.tsx
+++ b/services/client/src/components/MainView.tsx
@@ -23,7 +23,13 @@ export default function MainView() {
     "/api/v1/knowledgebase/tags",
   );
 
-  const allTags = tagsData?.tags ?? [];
+  const allTags = useMemo(
+    () =>
+      [...(tagsData?.tags ?? [])].sort((a, b) =>
+        (a.name ?? "").localeCompare(b.name ?? ""),
+      ),
+    [tagsData],
+  );
 
   // Client-side filter: only show documents matching ALL selected tags
   const filteredDocuments = useMemo(() => {

--- a/services/client/src/styles/_detail.scss
+++ b/services/client/src/styles/_detail.scss
@@ -81,10 +81,18 @@
     list-style: none;
     margin: 0;
     padding: 0;
+
+    &--empty {
+        margin: 0;
+        font-size: 0.85rem;
+        color: $color-text-muted;
+    }
 }
 
 .tag {
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
     padding: 0.2rem 0.6rem;
     border-radius: 999px;
     font-size: 0.78rem;
@@ -101,6 +109,121 @@
         background: $color-bg-tag-user;
         color: $color-primary;
     }
+
+    &--clickable {
+        cursor: pointer;
+
+        &:hover {
+            filter: brightness(0.92);
+        }
+    }
+
+    &__label {
+        // just let the text flow naturally
+    }
+
+    &__remove {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border: none;
+        background: none;
+        color: inherit;
+        font-size: 0.7rem;
+        font-weight: 700;
+        cursor: pointer;
+        padding: 0;
+        opacity: 0.6;
+        line-height: 1;
+
+        &:hover {
+            opacity: 1;
+        }
+
+        &:disabled {
+            opacity: 0.3;
+            cursor: not-allowed;
+        }
+    }
+
+    &--add {
+        background: none;
+        padding: 0;
+    }
+
+    &__add-button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 1.5rem;
+        height: 1.5rem;
+        border: 1px dashed $color-border-input;
+        border-radius: 999px;
+        background: none;
+        color: $color-text-muted;
+        font-size: 0.9rem;
+        font-weight: 600;
+        line-height: 1;
+        cursor: pointer;
+
+        &:hover {
+            border-color: $color-primary;
+            color: $color-primary;
+            background: $color-bg-hover;
+        }
+    }
+
+    &__input-wrapper {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.2rem;
+    }
+
+    &__input {
+        width: 6rem;
+        padding: 0.15rem 0.5rem;
+        border: 1px solid $color-primary;
+        border-radius: 999px;
+        font-size: 0.78rem;
+        font-family: $font-family;
+        background: $color-bg-white;
+        color: $color-text-dark;
+
+        &:focus {
+            outline: none;
+            box-shadow: 0 0 0 2px rgba($color-primary, 0.2);
+        }
+    }
+
+    &__confirm {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 1.4rem;
+        height: 1.4rem;
+        border: none;
+        border-radius: 999px;
+        background: $color-primary;
+        color: #fff;
+        font-size: 0.7rem;
+        line-height: 1;
+        cursor: pointer;
+
+        &:hover:not(:disabled) {
+            background: $color-primary-dark;
+        }
+
+        &:disabled {
+            opacity: 0.4;
+            cursor: not-allowed;
+        }
+    }
+}
+
+.tag-add-error {
+    margin: 0.4rem 0 0;
+    font-size: 0.78rem;
+    color: $color-error;
 }
 
 // Entities

--- a/services/client/src/styles/_detail.scss
+++ b/services/client/src/styles/_detail.scss
@@ -110,16 +110,22 @@
         color: $color-primary;
     }
 
-    &--clickable {
-        cursor: pointer;
-
-        &:hover {
-            filter: brightness(0.92);
-        }
-    }
-
     &__label {
         // just let the text flow naturally
+        border: none;
+        background: none;
+        padding: 0;
+        font: inherit;
+        color: inherit;
+        cursor: default;
+
+        &--clickable {
+            cursor: pointer;
+
+            &:hover {
+                filter: brightness(0.85);
+            }
+        }
     }
 
     &__remove {

--- a/services/client/src/styles/_sidebar.scss
+++ b/services/client/src/styles/_sidebar.scss
@@ -85,3 +85,95 @@
         color: $color-text-muted;
     }
 }
+
+// Tag filter in the sidebar
+.tag-filter {
+    padding: 0.5rem 1rem;
+    border-bottom: 1px solid $color-border-light;
+
+    &__header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 0.4rem;
+    }
+
+    &__label {
+        font-size: 0.72rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: $color-text-muted;
+    }
+
+    &__clear {
+        border: none;
+        background: none;
+        color: $color-primary;
+        font-size: 0.72rem;
+        font-weight: 600;
+        cursor: pointer;
+        padding: 0;
+
+        &:hover {
+            text-decoration: underline;
+        }
+    }
+
+    &__list {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.3rem;
+        list-style: none;
+        margin: 0;
+        padding: 0;
+    }
+
+    &__chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.25rem;
+        padding: 0.15rem 0.5rem;
+        border-radius: 999px;
+        font-size: 0.72rem;
+        font-weight: 500;
+        border: 1px solid $color-border;
+        background: $color-bg-white;
+        color: $color-text-body;
+        cursor: pointer;
+        transition: background 0.1s, border-color 0.1s;
+
+        &:hover {
+            background: $color-bg-hover;
+            border-color: $color-primary;
+        }
+
+        &--active {
+            background: $color-bg-active;
+            border-color: $color-primary;
+            color: $color-primary;
+            font-weight: 600;
+        }
+    }
+
+    &__count {
+        font-size: 0.62rem;
+        opacity: 0.7;
+    }
+
+    &__toggle {
+        display: block;
+        margin-top: 0.35rem;
+        border: none;
+        background: none;
+        color: $color-primary;
+        font-size: 0.7rem;
+        font-weight: 600;
+        cursor: pointer;
+        padding: 0;
+
+        &:hover {
+            text-decoration: underline;
+        }
+    }
+}

--- a/services/client/tests/app.spec.ts
+++ b/services/client/tests/app.spec.ts
@@ -1500,10 +1500,14 @@ test.describe("Alexandria client", () => {
       const input = page.locator('[aria-label="New tag name"]');
       await expect(input).toBeVisible();
       await input.fill("new-tag");
-      await input.press("Enter");
 
-      // Give the mutation a moment to fire
-      await page.waitForTimeout(500);
+      const addRequest = page.waitForRequest(
+        (req) =>
+          req.url().includes("/api/v1/knowledgebase/documents/doc-tag-1/tags") &&
+          req.method() === "POST",
+      );
+      await input.press("Enter");
+      await addRequest;
       expect(addTagCalled).toBe(true);
     });
 
@@ -1529,9 +1533,15 @@ test.describe("Alexandria client", () => {
       // beta is USER, second in sorted order
       const tags = tagList.locator('.tag[role="button"]');
       const removeButton = tags.nth(1).locator(".tag__remove");
-      await removeButton.click();
 
-      await page.waitForTimeout(500);
+      const deleteRequest = page.waitForRequest(
+        (req) =>
+          /\/api\/v1\/knowledgebase\/documents\/doc-tag-1\/tags\/t-b/.test(
+            req.url(),
+          ) && req.method() === "DELETE",
+      );
+      await removeButton.click();
+      await deleteRequest;
       expect(removeTagCalled).toBe(true);
     });
 

--- a/services/client/tests/app.spec.ts
+++ b/services/client/tests/app.spec.ts
@@ -1222,6 +1222,86 @@ test.describe("Alexandria client", () => {
                 fileSize: 2048,
                 createdAt: "2026-07-01T00:00:00Z",
               },
+            ],
+          }),
+        }),
+      );
+
+      await page.goto("/search");
+
+      // Switch to keyword mode
+      const keywordBtn = page
+        .locator(".search-mode-btn")
+        .filter({ hasText: "Keyword" });
+      await keywordBtn.click();
+      await expect(keywordBtn).toHaveClass(/search-mode-btn--active/);
+
+      await page.locator(".search-input").fill("keyword");
+      await page.locator(".search-submit").click();
+
+      await expect(page).toHaveURL(/[?&]mode=text/);
+
+      const resultList = page.locator(".search-result-list");
+      await expect(resultList).toBeVisible({ timeout: 5000 });
+      await expect(resultList).toContainText("keyword-match.pdf");
+    });
+
+    test("shows empty state when search returns no results", async ({
+      page,
+    }) => {
+      await page.route("/api/v1/knowledgebase/search/semantic*", (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ results: [], fallbackUsed: false }),
+        }),
+      );
+
+      await page.goto("/search");
+      await page.locator(".search-input").fill("nothing matches this");
+      await page.locator(".search-submit").click();
+
+      const empty = page.locator(".search-empty");
+      await expect(empty).toBeVisible({ timeout: 5000 });
+      await expect(empty).toContainText("No documents matched");
+    });
+
+    test("shows an error message when the search endpoint returns 500", async ({
+      page,
+    }) => {
+      await page.route("/api/v1/knowledgebase/search/semantic*", (route) =>
+        route.fulfill({ status: 500, body: "Internal Server Error" }),
+      );
+
+      await page.goto("/search");
+      await page.locator(".search-input").fill("error trigger");
+      await page.locator(".search-submit").click();
+
+      const error = page.locator(".search-error");
+      await expect(error).toBeVisible({ timeout: 15000 });
+      await expect(error).toContainText("Search failed");
+    });
+
+    test("shows authentication error when the search endpoint returns 401", async ({
+      page,
+    }) => {
+      await page.route("**/protocol/openid-connect/token", (route) =>
+        route.fulfill({ status: 401, body: "Unauthorized" }),
+      );
+      await page.route("/api/v1/knowledgebase/search/semantic*", (route) =>
+        route.fulfill({ status: 401, body: "Unauthorized" }),
+      );
+
+      await page.goto("/search");
+      await page.locator(".search-input").fill("auth check");
+      await page.locator(".search-submit").click();
+
+      const error = page.locator(".search-error");
+      await expect(error).toBeVisible({ timeout: 15000 });
+      await expect(error).toHaveText("Authentication error. Retrying login...");
+    });
+  });
+
   test.describe("Tag display and filtering", () => {
     const mockDocuments = [
       {
@@ -1450,7 +1530,7 @@ test.describe("Alexandria client", () => {
       const tagList = page.locator('[aria-label="Document tags"]');
       await expect(tagList).toBeVisible({ timeout: 5000 });
 
-      const tags = tagList.locator('.tag[role="button"]');
+      const tags = tagList.locator(".tag:not(.tag--add)");
       await expect(tags).toHaveCount(2);
       // "alpha" should come before "beta" regardless of API order
       await expect(tags.first().locator(".tag__label")).toHaveText("alpha");
@@ -1465,9 +1545,7 @@ test.describe("Alexandria client", () => {
       const tagList = page.locator('[aria-label="Document tags"]');
       await expect(tagList).toBeVisible({ timeout: 5000 });
 
-      const tags = tagList.locator('.tag[role="button"]');
-
-      // alpha is AUTO -- no remove button
+      const tags = tagList.locator(".tag:not(.tag--add)");
       const alphaTag = tags.first();
       await expect(alphaTag.locator(".tag__remove")).toHaveCount(0);
 
@@ -1500,14 +1578,10 @@ test.describe("Alexandria client", () => {
       const input = page.locator('[aria-label="New tag name"]');
       await expect(input).toBeVisible();
       await input.fill("new-tag");
-
-      const addRequest = page.waitForRequest(
-        (req) =>
-          req.url().includes("/api/v1/knowledgebase/documents/doc-tag-1/tags") &&
-          req.method() === "POST",
-      );
       await input.press("Enter");
-      await addRequest;
+
+      // Give the mutation a moment to fire
+      await page.waitForTimeout(500);
       expect(addTagCalled).toBe(true);
     });
 
@@ -1531,17 +1605,11 @@ test.describe("Alexandria client", () => {
       await expect(tagList).toBeVisible({ timeout: 5000 });
 
       // beta is USER, second in sorted order
-      const tags = tagList.locator('.tag[role="button"]');
+      const tags = tagList.locator(".tag:not(.tag--add)");
       const removeButton = tags.nth(1).locator(".tag__remove");
-
-      const deleteRequest = page.waitForRequest(
-        (req) =>
-          /\/api\/v1\/knowledgebase\/documents\/doc-tag-1\/tags\/t-b/.test(
-            req.url(),
-          ) && req.method() === "DELETE",
-      );
       await removeButton.click();
-      await deleteRequest;
+
+      await page.waitForTimeout(500);
       expect(removeTagCalled).toBe(true);
     });
 
@@ -1613,23 +1681,26 @@ test.describe("Alexandria client", () => {
         }),
       );
 
-      await page.goto("/search");
+      await page.goto("/documents/doc-tag-1");
 
-      // Switch to keyword mode
-      const keywordBtn = page
-        .locator(".search-mode-btn")
-        .filter({ hasText: "Keyword" });
-      await keywordBtn.click();
-      await expect(keywordBtn).toHaveClass(/search-mode-btn--active/);
+      const tagList = page.locator('[aria-label="Document tags"]');
+      await expect(tagList).toBeVisible({ timeout: 5000 });
 
-      await page.locator(".search-input").fill("keyword");
-      await page.locator(".search-submit").click();
+      // Click the whole "alpha" tag chip (not just text)
+      const alphaChip = tagList.locator(".tag__label--clickable").first();
+      await alphaChip.click();
 
-      await expect(page).toHaveURL(/[?&]mode=text/);
+      // Sidebar should now filter: only doc-tag-1 has "alpha"
+      await expect(page.locator(".tree-item")).toHaveCount(1);
+      await expect(page.locator(".tree-item").first()).toContainText(
+        "taggable.pdf",
+      );
 
-      const resultList = page.locator(".search-result-list");
-      await expect(resultList).toBeVisible({ timeout: 5000 });
-      await expect(resultList).toContainText("keyword-match.pdf");
+      // The sidebar filter chip for "alpha" should be active
+      const sidebarChip = page.locator(".tag-filter__chip", {
+        hasText: "alpha",
+      });
+      await expect(sidebarChip).toHaveClass(/tag-filter__chip--active/);
     });
 
     test("shows empty state when search returns no results", async ({
@@ -1685,26 +1756,6 @@ test.describe("Alexandria client", () => {
       const error = page.locator(".search-error");
       await expect(error).toBeVisible({ timeout: 15000 });
       await expect(error).toHaveText("Authentication error. Retrying login...");
-      await page.goto("/documents/doc-tag-1");
-
-      const tagList = page.locator('[aria-label="Document tags"]');
-      await expect(tagList).toBeVisible({ timeout: 5000 });
-
-      // Click the whole "alpha" tag chip (not just text)
-      const alphaChip = tagList.locator('.tag[role="button"]').first();
-      await alphaChip.click();
-
-      // Sidebar should now filter: only doc-tag-1 has "alpha"
-      await expect(page.locator(".tree-item")).toHaveCount(1);
-      await expect(page.locator(".tree-item").first()).toContainText(
-        "taggable.pdf",
-      );
-
-      // The sidebar filter chip for "alpha" should be active
-      const sidebarChip = page.locator(".tag-filter__chip", {
-        hasText: "alpha",
-      });
-      await expect(sidebarChip).toHaveClass(/tag-filter__chip--active/);
     });
 
     test("confirm button submits the new tag", async ({ page }) => {
@@ -1815,7 +1866,7 @@ test.describe("Alexandria client", () => {
       // Click the "ggg" tag in the detail view
       const tagList = page.locator('[aria-label="Document tags"]');
       await expect(tagList).toBeVisible({ timeout: 5000 });
-      await tagList.locator('.tag[role="button"]').first().click();
+      await tagList.locator(".tag__label--clickable").first().click();
 
       // Now all 7 chips should be visible (auto-expanded)
       await expect(chips).toHaveCount(7);

--- a/services/client/tests/app.spec.ts
+++ b/services/client/tests/app.spec.ts
@@ -1222,6 +1222,382 @@ test.describe("Alexandria client", () => {
                 fileSize: 2048,
                 createdAt: "2026-07-01T00:00:00Z",
               },
+  test.describe("Tag display and filtering", () => {
+    const mockDocuments = [
+      {
+        id: "doc-1",
+        fileName: "report.pdf",
+        fileType: "application/pdf",
+        fileSize: 2048,
+        createdAt: "2026-06-01T10:00:00Z",
+        tags: [
+          { id: "t1", label: "finance", source: "AUTO" },
+          { id: "t2", label: "quarterly", source: "USER" },
+        ],
+        extractedEntities: [],
+        summary: null,
+      },
+      {
+        id: "doc-2",
+        fileName: "notes.txt",
+        fileType: "text/plain",
+        fileSize: 512,
+        createdAt: "2026-06-02T10:00:00Z",
+        tags: [{ id: "t3", label: "meeting", source: "AUTO" }],
+        extractedEntities: [],
+        summary: null,
+      },
+      {
+        id: "doc-3",
+        fileName: "summary.md",
+        fileType: "text/markdown",
+        fileSize: 1024,
+        createdAt: "2026-06-03T10:00:00Z",
+        tags: [
+          { id: "t4", label: "finance", source: "AUTO" },
+          { id: "t5", label: "meeting", source: "USER" },
+        ],
+        extractedEntities: [],
+        summary: null,
+      },
+    ];
+
+    const mockTagList = {
+      tags: [
+        { name: "finance", documentCount: 2 },
+        { name: "meeting", documentCount: 2 },
+        { name: "quarterly", documentCount: 1 },
+      ],
+    };
+
+    test.beforeEach(async ({ page }) => {
+      await page.route("/api/v1/knowledgebase/documents", (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(mockDocuments),
+        }),
+      );
+      await page.route("/api/v1/knowledgebase/tags", (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(mockTagList),
+        }),
+      );
+    });
+
+    test("renders the tag filter chips", async ({ page }) => {
+      await page.goto("/documents");
+
+      const filterSection = page.locator(".tag-filter");
+      await expect(filterSection).toBeVisible({ timeout: 5000 });
+
+      const chips = filterSection.locator(".tag-filter__chip");
+      await expect(chips).toHaveCount(3);
+    });
+
+    test("clicking a tag filter chip filters the document list", async ({
+      page,
+    }) => {
+      await page.goto("/documents");
+
+      // Initially 3 documents
+      await expect(page.locator(".tree-item")).toHaveCount(3, {
+        timeout: 5000,
+      });
+
+      // Click "quarterly" filter
+      await page
+        .locator(".tag-filter__chip", { hasText: "quarterly" })
+        .click();
+
+      // Only report.pdf has "quarterly"
+      await expect(page.locator(".tree-item")).toHaveCount(1);
+      await expect(page.locator(".tree-item").first()).toContainText(
+        "report.pdf",
+      );
+    });
+
+    test("selecting multiple tags narrows results (AND logic)", async ({
+      page,
+    }) => {
+      await page.goto("/documents");
+      await expect(page.locator(".tree-item")).toHaveCount(3, {
+        timeout: 5000,
+      });
+
+      // Select "finance" (2 docs) then "meeting" (overlap is summary.md only)
+      await page.locator(".tag-filter__chip", { hasText: "finance" }).click();
+      await expect(page.locator(".tree-item")).toHaveCount(2);
+
+      await page.locator(".tag-filter__chip", { hasText: "meeting" }).click();
+      await expect(page.locator(".tree-item")).toHaveCount(1);
+      await expect(page.locator(".tree-item").first()).toContainText(
+        "summary.md",
+      );
+    });
+
+    test("clear button removes all active filters", async ({ page }) => {
+      await page.goto("/documents");
+      await expect(page.locator(".tree-item")).toHaveCount(3, {
+        timeout: 5000,
+      });
+
+      await page.locator(".tag-filter__chip", { hasText: "quarterly" }).click();
+      await expect(page.locator(".tree-item")).toHaveCount(1);
+
+      await page.locator(".tag-filter__clear").click();
+      await expect(page.locator(".tree-item")).toHaveCount(3);
+    });
+
+    test("shows empty message when no documents match filter", async ({
+      page,
+    }) => {
+      // Override with a doc that has no tags
+      await page.unroute("/api/v1/knowledgebase/documents");
+      await page.route("/api/v1/knowledgebase/documents", (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify([
+            {
+              id: "doc-x",
+              fileName: "untagged.txt",
+              fileType: "text/plain",
+              fileSize: 100,
+              createdAt: "2026-06-01T10:00:00Z",
+              tags: [],
+              extractedEntities: [],
+              summary: null,
+            },
+          ]),
+        }),
+      );
+
+      await page.goto("/documents");
+      await expect(page.locator(".tree-item")).toHaveCount(1, {
+        timeout: 5000,
+      });
+
+      // Filter by "finance" -- untagged doc should not match
+      await page.locator(".tag-filter__chip", { hasText: "finance" }).click();
+      await expect(page.locator(".tree-item")).toHaveCount(0);
+      await expect(page.locator(".tree-status")).toContainText(
+        "No documents match the selected tags",
+      );
+    });
+  });
+
+  test.describe("Tag management in detail view", () => {
+    test.beforeEach(async ({ page }) => {
+      await page.route("/api/v1/knowledgebase/documents", (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify([
+            {
+              id: "doc-tag-1",
+              fileName: "taggable.pdf",
+              fileType: "application/pdf",
+              fileSize: 4096,
+              createdAt: "2026-06-10T10:00:00Z",
+              tags: [
+                { id: "t-b", label: "beta", source: "USER" },
+                { id: "t-a", label: "alpha", source: "AUTO" },
+              ],
+              extractedEntities: [],
+              summary: null,
+            },
+          ]),
+        }),
+      );
+      await page.route("/api/v1/knowledgebase/tags", (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ tags: [] }),
+        }),
+      );
+      await page.route(
+        "/api/v1/knowledgebase/documents/doc-tag-1",
+        (route) =>
+          route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify({
+              id: "doc-tag-1",
+              fileName: "taggable.pdf",
+              fileType: "application/pdf",
+              fileSize: 4096,
+              createdAt: "2026-06-10T10:00:00Z",
+              tags: [
+                { id: "t-b", label: "beta", source: "USER" },
+                { id: "t-a", label: "alpha", source: "AUTO" },
+              ],
+              extractedEntities: [],
+              summary: null,
+            }),
+          }),
+      );
+    });
+
+    test("tags are displayed in alphabetical order (fixes #301)", async ({
+      page,
+    }) => {
+      await page.goto("/documents/doc-tag-1");
+
+      const tagList = page.locator('[aria-label="Document tags"]');
+      await expect(tagList).toBeVisible({ timeout: 5000 });
+
+      const tags = tagList.locator('.tag[role="button"]');
+      await expect(tags).toHaveCount(2);
+      // "alpha" should come before "beta" regardless of API order
+      await expect(tags.first().locator(".tag__label")).toHaveText("alpha");
+      await expect(tags.nth(1).locator(".tag__label")).toHaveText("beta");
+    });
+
+    test("USER tags have a remove button, AUTO tags do not", async ({
+      page,
+    }) => {
+      await page.goto("/documents/doc-tag-1");
+
+      const tagList = page.locator('[aria-label="Document tags"]');
+      await expect(tagList).toBeVisible({ timeout: 5000 });
+
+      const tags = tagList.locator('.tag[role="button"]');
+
+      // alpha is AUTO -- no remove button
+      const alphaTag = tags.first();
+      await expect(alphaTag.locator(".tag__remove")).toHaveCount(0);
+
+      // beta is USER -- has remove button
+      const betaTag = tags.nth(1);
+      await expect(betaTag.locator(".tag__remove")).toHaveCount(1);
+    });
+
+    test("add tag form submits to the API", async ({ page }) => {
+      let addTagCalled = false;
+      await page.route(
+        "/api/v1/knowledgebase/documents/doc-tag-1/tags",
+        (route, request) => {
+          if (request.method() === "POST") {
+            addTagCalled = true;
+            route.fulfill({ status: 204 });
+          } else {
+            route.continue();
+          }
+        },
+      );
+
+      await page.goto("/documents/doc-tag-1");
+
+      // Click the "+" button to open the inline input
+      const addBtn = page.locator('[aria-label="Add a tag"]');
+      await expect(addBtn).toBeVisible({ timeout: 5000 });
+      await addBtn.click();
+
+      const input = page.locator('[aria-label="New tag name"]');
+      await expect(input).toBeVisible();
+      await input.fill("new-tag");
+      await input.press("Enter");
+
+      // Give the mutation a moment to fire
+      await page.waitForTimeout(500);
+      expect(addTagCalled).toBe(true);
+    });
+
+    test("remove tag button calls the delete endpoint", async ({ page }) => {
+      let removeTagCalled = false;
+      await page.route(
+        /\/api\/v1\/knowledgebase\/documents\/doc-tag-1\/tags\/t-b/,
+        (route, request) => {
+          if (request.method() === "DELETE") {
+            removeTagCalled = true;
+            route.fulfill({ status: 204 });
+          } else {
+            route.continue();
+          }
+        },
+      );
+
+      await page.goto("/documents/doc-tag-1");
+
+      const tagList = page.locator('[aria-label="Document tags"]');
+      await expect(tagList).toBeVisible({ timeout: 5000 });
+
+      // beta is USER, second in sorted order
+      const tags = tagList.locator('.tag[role="button"]');
+      const removeButton = tags.nth(1).locator(".tag__remove");
+      await removeButton.click();
+
+      await page.waitForTimeout(500);
+      expect(removeTagCalled).toBe(true);
+    });
+
+    test("plus button opens an inline input for adding tags", async ({
+      page,
+    }) => {
+      await page.goto("/documents/doc-tag-1");
+
+      const addBtn = page.locator('[aria-label="Add a tag"]');
+      await expect(addBtn).toBeVisible({ timeout: 5000 });
+
+      // Input should not be visible yet
+      await expect(page.locator('[aria-label="New tag name"]')).toHaveCount(0);
+
+      await addBtn.click();
+
+      // Now the input should appear and the "+" button should be gone
+      await expect(page.locator('[aria-label="New tag name"]')).toBeVisible();
+      await expect(addBtn).toHaveCount(0);
+    });
+
+    test("clicking the whole tag chip activates the sidebar filter", async ({
+      page,
+    }) => {
+      await page.unroute("/api/v1/knowledgebase/documents");
+      await page.unroute("/api/v1/knowledgebase/tags");
+      await page.route("/api/v1/knowledgebase/documents", (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify([
+            {
+              id: "doc-tag-1",
+              fileName: "taggable.pdf",
+              fileType: "application/pdf",
+              fileSize: 4096,
+              createdAt: "2026-06-10T10:00:00Z",
+              tags: [
+                { id: "t-a", label: "alpha", source: "AUTO" },
+                { id: "t-b", label: "beta", source: "USER" },
+              ],
+              extractedEntities: [],
+              summary: null,
+            },
+            {
+              id: "doc-tag-2",
+              fileName: "other.txt",
+              fileType: "text/plain",
+              fileSize: 100,
+              createdAt: "2026-06-11T10:00:00Z",
+              tags: [{ id: "t-c", label: "gamma", source: "AUTO" }],
+              extractedEntities: [],
+              summary: null,
+            },
+          ]),
+        }),
+      );
+      await page.route("/api/v1/knowledgebase/tags", (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            tags: [
+              { name: "alpha", documentCount: 1 },
+              { name: "beta", documentCount: 1 },
+              { name: "gamma", documentCount: 1 },
             ],
           }),
         }),
@@ -1299,6 +1675,145 @@ test.describe("Alexandria client", () => {
       const error = page.locator(".search-error");
       await expect(error).toBeVisible({ timeout: 15000 });
       await expect(error).toHaveText("Authentication error. Retrying login...");
+      await page.goto("/documents/doc-tag-1");
+
+      const tagList = page.locator('[aria-label="Document tags"]');
+      await expect(tagList).toBeVisible({ timeout: 5000 });
+
+      // Click the whole "alpha" tag chip (not just text)
+      const alphaChip = tagList.locator('.tag[role="button"]').first();
+      await alphaChip.click();
+
+      // Sidebar should now filter: only doc-tag-1 has "alpha"
+      await expect(page.locator(".tree-item")).toHaveCount(1);
+      await expect(page.locator(".tree-item").first()).toContainText(
+        "taggable.pdf",
+      );
+
+      // The sidebar filter chip for "alpha" should be active
+      const sidebarChip = page.locator(".tag-filter__chip", {
+        hasText: "alpha",
+      });
+      await expect(sidebarChip).toHaveClass(/tag-filter__chip--active/);
+    });
+
+    test("confirm button submits the new tag", async ({ page }) => {
+      let addTagCalled = false;
+      await page.route(
+        "/api/v1/knowledgebase/documents/doc-tag-1/tags",
+        (route, request) => {
+          if (request.method() === "POST") {
+            addTagCalled = true;
+            route.fulfill({ status: 204 });
+          } else {
+            route.continue();
+          }
+        },
+      );
+
+      await page.goto("/documents/doc-tag-1");
+
+      const addBtn = page.locator('[aria-label="Add a tag"]');
+      await expect(addBtn).toBeVisible({ timeout: 5000 });
+      await addBtn.click();
+
+      const input = page.locator('[aria-label="New tag name"]');
+      await input.fill("new-tag");
+
+      // Click the checkmark confirm button
+      const confirmBtn = page.locator('[aria-label="Confirm new tag"]');
+      await expect(confirmBtn).toBeVisible();
+      await confirmBtn.click();
+
+      await page.waitForTimeout(500);
+      expect(addTagCalled).toBe(true);
+    });
+  });
+
+  test.describe("Tag filter auto-expand", () => {
+    test("sidebar expands when a selected tag is beyond the visible 5", async ({
+      page,
+    }) => {
+      // Set up 7 tags so only 5 are shown initially
+      const mockTagList = {
+        tags: [
+          { name: "aaa", documentCount: 1 },
+          { name: "bbb", documentCount: 1 },
+          { name: "ccc", documentCount: 1 },
+          { name: "ddd", documentCount: 1 },
+          { name: "eee", documentCount: 1 },
+          { name: "fff", documentCount: 1 },
+          { name: "ggg", documentCount: 1 },
+        ],
+      };
+
+      await page.route("/api/v1/knowledgebase/documents", (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify([
+            {
+              id: "doc-expand-1",
+              fileName: "expand-test.pdf",
+              fileType: "application/pdf",
+              fileSize: 1024,
+              createdAt: "2026-06-10T10:00:00Z",
+              tags: [{ id: "t-g", label: "ggg", source: "AUTO" }],
+              extractedEntities: [],
+              summary: null,
+            },
+          ]),
+        }),
+      );
+      await page.route("/api/v1/knowledgebase/tags", (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(mockTagList),
+        }),
+      );
+      await page.route(
+        "/api/v1/knowledgebase/documents/doc-expand-1",
+        (route) =>
+          route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify({
+              id: "doc-expand-1",
+              fileName: "expand-test.pdf",
+              fileType: "application/pdf",
+              fileSize: 1024,
+              createdAt: "2026-06-10T10:00:00Z",
+              tags: [{ id: "t-g", label: "ggg", source: "AUTO" }],
+              extractedEntities: [],
+              summary: null,
+            }),
+          }),
+      );
+
+      await page.goto("/documents/doc-expand-1");
+
+      // Initially only 5 chips should be visible
+      const chips = page.locator(".tag-filter__chip");
+      await expect(chips).toHaveCount(5, { timeout: 5000 });
+
+      // "ggg" should not be visible yet
+      await expect(
+        page.locator(".tag-filter__chip", { hasText: "ggg" }),
+      ).toHaveCount(0);
+
+      // Click the "ggg" tag in the detail view
+      const tagList = page.locator('[aria-label="Document tags"]');
+      await expect(tagList).toBeVisible({ timeout: 5000 });
+      await tagList.locator('.tag[role="button"]').first().click();
+
+      // Now all 7 chips should be visible (auto-expanded)
+      await expect(chips).toHaveCount(7);
+
+      // "ggg" chip should now be active
+      const gggChip = page.locator(".tag-filter__chip", { hasText: "ggg" });
+      await expect(gggChip).toBeVisible();
+      await expect(gggChip).toHaveClass(/tag-filter__chip--active/);
     });
   });
 });


### PR DESCRIPTION
## What does this PR do?

Implements the tag UI for the client. Closes #246, closes #301.

Users can now filter the document list by tags, and manage tags (add/remove)
from the detail view. Tags are always sorted alphabetically which fixes the
inconsistent ordering reported in #301.

Changes:
- MainView fetches the global tag list (`GET /tags`) and manages filter state,
  passes filtered documents to the sidebar
- DocumentTree renders a tag filter section with clickable chips (multi-select,
  AND logic). Only 5 tags shown by default, with a "+N more" toggle for the
  rest. Auto-expands when a selected tag is outside the visible set.
- DocumentDetail sorts tags alphabetically, makes entire tag chips clickable to
  activate the sidebar filter, and provides inline tag management: a "+" button
  that morphs into a pill-shaped input with a checkmark confirm button. USER
  tags also get a remove "x" button.
- Cache invalidation after add/remove keeps sidebar and detail in sync
- Styles for filter chips, inline add-tag input, clickable tags
- Playwright tests cover: filter logic (single, multi, clear, empty state),
  alphabetical sort, add/remove API calls, confirm button, full-chip click
  activating sidebar filter, auto-expand behavior

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] CI / infra

## Definition of Done

- [x] CI is green
- [ ] If the API changed: `api/openapi.yaml` is updated and lint passes
- [ ] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [x] Tests added or updated for the changed behaviour
- [x] Docs updated where it matters (README, ADRs, comments)

## Notes for the reviewer

The tag filter uses AND logic (selecting multiple tags narrows results to
documents that have all selected tags). Felt more useful than OR for drilling
down in a knowledge base.

Only USER tags get the remove button in the detail view. AUTO tags from AI
processing are clickable (to filter) but can't be deleted.

Filtering is purely client-side since the documents endpoint doesn't accept a
`?tag=` query param. Works fine for the library sizes we're dealing with.

The inline add-tag input submits on Enter, on clicking the checkmark, or on
blur (if non-empty). Escape or empty blur cancels. The confirm button uses
`onMouseDown` with `preventDefault` to avoid the blur handler racing with the
click.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added document tagging support, including automatic and manual tags.
  * Added sidebar tag filters with multi-tag AND filtering, clear controls, and expandable tag lists.
  * Added the ability to add and remove user-created tags from document details.
  * Tags are displayed alphabetically and can be selected to filter documents.
* **Documentation**
  * Updated the feature documentation with tagging behavior and usage details.
* **Tests**
  * Added coverage for filtering, tag management, sorting, and filter expansion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->