### PR TITLE
Chore: Add keycloak theme to helm deployment

### DIFF
--- a/infra/k8s/alexandria/files/keycloak-theme
+++ b/infra/k8s/alexandria/files/keycloak-theme
@@ -1,0 +1,1 @@
+../../../keycloak/themes/alexandria

--- a/infra/k8s/alexandria/templates/keycloak-theme-configmap.yaml
+++ b/infra/k8s/alexandria/templates/keycloak-theme-configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-keycloak-theme
+  labels:
+    {{- include "alexandria.labels" . | nindent 4 }}
+    app: keycloak
+data:
+  theme.properties: |
+    {{- .Files.Get "files/keycloak-theme/login/theme.properties" | nindent 4 }}
+  styles.css: |
+    {{- .Files.Get "files/keycloak-theme/login/resources/css/styles.css" | nindent 4 }}

--- a/infra/k8s/alexandria/values.yaml
+++ b/infra/k8s/alexandria/values.yaml
@@ -238,6 +238,20 @@ keycloak:
       value: "https://alexandria.stud.k8s.aet.cit.tum.de/*"
     - name: KEYCLOAK_WEB_ORIGIN
       value: "https://alexandria.stud.k8s.aet.cit.tum.de"
+  # CSS "alexandria" login theme for keycloak
+  extraVolumes:
+    - name: keycloak-theme
+      configMap:
+        name: '{{ .Release.Name }}-keycloak-theme'
+  extraVolumeMounts:
+    - name: keycloak-theme
+      mountPath: /opt/keycloak/themes/alexandria/login/theme.properties
+      subPath: theme.properties
+      readOnly: true
+    - name: keycloak-theme
+      mountPath: /opt/keycloak/themes/alexandria/login/resources/css/styles.css
+      subPath: styles.css
+      readOnly: true
   database:
     type: postgres
     host: "alexandria-postgres-db"


### PR DESCRIPTION
## What does this PR do?

<!-- Short description of the change. Reference any related issue: Closes #123 -->
Follow up to #331, adds the keycloak theme to the helm deployment as well. Was missed in `cfc53c0538e7782fdd8695c7666fb5922ed36ddf`.

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] CI / infra

## Definition of Done

- [ ] CI is green
- [ ] If the API changed: `api/openapi.yaml` is updated and lint passes
- [ ] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [ ] Tests added or updated for the changed behaviour
- [ ] Docs updated where it matters (README, ADRs, comments)

## Notes for the reviewer

<!-- Anything they should look at first, gotchas, screenshots, ... -->
