### PR TITLE
Feat: Expose Grafana via ingress with Keycloak OIDC login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -141,6 +141,16 @@
 
 # Grafana admin login. Defaults to "admin" / "admin" locally
 # GRAFANA_ADMIN_PASSWORD="secret-with-64-bit-entropy-eg-16-hex-chars"
+
+# Grafana login via Keycloak (generic OAuth). The client secret is shared between
+# Keycloak (realm import) and Grafana, so keep both sides identical.
+# GRAFANA_OIDC_CLIENT_SECRET="secret-with-64-bit-entropy-eg-16-hex-chars"
+# Callback URL Grafana redirects to after login; must match the grafana client in the realm.
+# GRAFANA_REDIRECT_URI="http://localhost/grafana/login/generic_oauth"
+# GRAFANA_WEB_ORIGIN="http://localhost"
+# Absolute base URL Grafana is served from (lets Grafana build the OAuth redirect).
+# GRAFANA_ROOT_URL="http://localhost/grafana"
+
 # S3 Object Storage (SeaweedFS)
 # ----------------------------------------------------------------------------------
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ env:
   S3_BUCKET: ${{ vars.S3_BUCKET }}
   # ----------- Monitoring -----------
   GRAFANA_ADMIN_PASSWORD: ${{ secrets.GRAFANA_ADMIN_PASSWORD }}
+  GRAFANA_OIDC_CLIENT_SECRET: ${{ secrets.GRAFANA_OIDC_CLIENT_SECRET }}
   # ----------- GenAI -----------
   LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
   # ----------- Internal service-to-service auth -----------
@@ -954,6 +955,7 @@ jobs:
             --from-literal=db-password="$POSTGRES_PASSWORD" \
             --from-literal=keycloak-admin-password="$KC_BOOTSTRAP_ADMIN_PASSWORD" \
             --from-literal=grafana-admin-password="$GRAFANA_ADMIN_PASSWORD" \
+            --from-literal=grafana-oidc-client-secret="$GRAFANA_OIDC_CLIENT_SECRET" \
             --from-literal=s3-access-key="$S3_ACCESS_KEY" \
             --from-literal=s3-secret-key="$S3_SECRET_KEY" \
             --from-literal=internal-shared-secret="$INTERNAL_SHARED_SECRET" \

--- a/README.md
+++ b/README.md
@@ -109,8 +109,10 @@ For local Python dev, see [`services/genai/README.md`](services/genai/README.md)
 
 Prometheus scrapes metrics from each Spring service (`/actuator/prometheus`, one job per service), GenAI (`/genai/metrics`), Traefik, and the SeaweedFS object storage (`s3-storage:9091/metrics`), and Grafana visualizes them. Both run as part of `docker compose up`.
 
-- Grafana: http://localhost/grafana/ (default login `admin` / `admin`, override with `GRAFANA_ADMIN_PASSWORD`)
+- Grafana: http://localhost/grafana/ (built-in admin login `admin` / `admin`, override with `GRAFANA_ADMIN_PASSWORD`; or "Sign in with Keycloak" using a realm user)
 - Prometheus: http://localhost/prometheus/
+
+Grafana login goes through Keycloak via OpenID Connect (generic OAuth against the `grafana` client in the `alexandria` realm). Realm users with the `grafana-admin` role land as Grafana Admins, everyone else as Viewers. The built-in admin login stays available as a fallback.
 
 Dashboards are provisioned automatically under the "Alexandria" folder: an overview (request rate, errors, latency across services), an aggregate Spring dashboard plus one per Spring service (JVM, GC, threads, DB pool), a GenAI dashboard (request rate, latency, process memory), and an object storage dashboard (S3 request rate and latency, in-flight requests, disk usage). Dashboard JSON and the Prometheus scrape and alert config live under [`infra/prometheus`](infra/prometheus) and [`infra/grafana`](infra/grafana).
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -294,6 +294,10 @@ services:
       KC_HOSTNAME_BACKCHANNEL_DYNAMIC: true
       KEYCLOAK_REDIRECT_URI: ${KEYCLOAK_REDIRECT_URI:-http://localhost/*}
       KEYCLOAK_WEB_ORIGIN: ${KEYCLOAK_WEB_ORIGIN:-http://localhost}
+      # Substituted into the grafana client in realm.json at import time.
+      GRAFANA_OIDC_CLIENT_SECRET: ${GRAFANA_OIDC_CLIENT_SECRET:-grafana-local-secret}
+      GRAFANA_REDIRECT_URI: ${GRAFANA_REDIRECT_URI:-http://localhost/grafana/login/generic_oauth}
+      GRAFANA_WEB_ORIGIN: ${GRAFANA_WEB_ORIGIN:-http://localhost}
     restart: unless-stopped
     networks:
       - alexandria
@@ -546,10 +550,22 @@ services:
     container_name: grafana
     # kics-scan ignore-block
     environment:
-      GF_SERVER_ROOT_URL: /grafana
+      # Absolute root URL so Grafana can build the OAuth redirect_uri.
+      GF_SERVER_ROOT_URL: ${GRAFANA_ROOT_URL:-http://localhost/grafana}
       GF_SERVER_SERVE_FROM_SUB_PATH: "true"
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
       GF_USERS_ALLOW_SIGN_UP: "false"
+      GF_AUTH_GENERIC_OAUTH_ENABLED: "true"
+      GF_AUTH_GENERIC_OAUTH_NAME: Keycloak
+      GF_AUTH_GENERIC_OAUTH_CLIENT_ID: grafana
+      GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET: ${GRAFANA_OIDC_CLIENT_SECRET:-grafana-local-secret}
+      GF_AUTH_GENERIC_OAUTH_SCOPES: "openid email profile"
+      GF_AUTH_GENERIC_OAUTH_AUTH_URL: http://localhost/auth/realms/alexandria/protocol/openid-connect/auth
+      GF_AUTH_GENERIC_OAUTH_TOKEN_URL: http://keycloak:8180/auth/realms/alexandria/protocol/openid-connect/token
+      GF_AUTH_GENERIC_OAUTH_API_URL: http://keycloak:8180/auth/realms/alexandria/protocol/openid-connect/userinfo
+      GF_AUTH_GENERIC_OAUTH_USE_PKCE: "true"
+      GF_AUTH_GENERIC_OAUTH_LOGIN_ATTRIBUTE_PATH: preferred_username
+      GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH: "contains(roles[*], 'grafana-admin') && 'Admin' || 'Viewer'"
     volumes:
       - grafana_data:/var/lib/grafana
       - ./infra/grafana/provisioning:/etc/grafana/provisioning:ro

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -30,13 +30,19 @@ upgrades. The only thing you need to provide is the LLM API key.
 
 Prometheus and Grafana live in their own namespace (`bnd-alexandria-monitoring`
 by default, i.e. `<release-namespace>-monitoring`; override via
-`monitoring.namespace`) and are intentionally not exposed through the ingress.
-To reach them, port-forward:
+`monitoring.namespace`).
+
+Grafana is exposed through the ingress at `https://<ingress.host>/grafana` (its own
+Ingress in the monitoring namespace), with Keycloak login enabled by default. Turn
+it off with `--set grafana.ingress.enabled=false` or `--set grafana.oauth.enabled=false`.
+
+Prometheus stays private, port-forward to reach it:
 
 ```bash
 kubectl -n bnd-alexandria-monitoring port-forward svc/alexandria-prometheus 9090:9090
 # open http://localhost:9090/prometheus
 
+# Grafana too, if you don't want to go through the ingress:
 kubectl -n bnd-alexandria-monitoring port-forward svc/alexandria-grafana 3000:3000
 # open http://localhost:3000
 ```

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -61,14 +61,15 @@ kubectl -n bnd-alexandria-monitoring delete secret --all
 
 `alexandria-secrets`:
 
-| Key                       | Purpose                                                      |
-| ------------------------- | ------------------------------------------------------------ |
-| `db-password`             | PostgreSQL password (Spring services, Keycloak, postgres-db) |
-| `keycloak-admin-password` | Keycloak admin console                                       |
-| `grafana-admin-password`  | Grafana admin UI                                             |
-| `s3-access-key`           | SeaweedFS S3 access key                                      |
-| `s3-secret-key`           | SeaweedFS S3 secret key                                      |
-| `internal-shared-secret`  | HMAC for service-to-service /internal/** auth                |
+| Key                          | Purpose                                                      |
+| ---------------------------- | ------------------------------------------------------------ |
+| `db-password`                | PostgreSQL password (Spring services, Keycloak, postgres-db) |
+| `keycloak-admin-password`    | Keycloak admin console                                       |
+| `grafana-admin-password`     | Grafana admin UI                                             |
+| `grafana-oidc-client-secret` | Grafana OIDC client secret                                   |
+| `s3-access-key`              | SeaweedFS S3 access key                                      |
+| `s3-secret-key`              | SeaweedFS S3 secret key                                      |
+| `internal-shared-secret`     | HMAC for service-to-service /internal/** auth                |
 
 `alexandria-genai-secrets`:
 
@@ -103,6 +104,7 @@ kubectl -n bnd-alexandria create secret generic alexandria-secrets \
   --from-literal=db-password="$POSTGRES_PASSWORD" \
   --from-literal=keycloak-admin-password="$KC_ADMIN_PASSWORD" \
   --from-literal=grafana-admin-password="$GRAFANA_ADMIN_PASSWORD" \
+  --from-literal=grafana-oidc-client-secret="$GRAFANA_OIDC_CLIENT_SECRET" \
   --from-literal=s3-access-key="$S3_ACCESS_KEY" \
   --from-literal=s3-secret-key="$S3_SECRET_KEY" \
   --from-literal=internal-shared-secret="$INTERNAL_SHARED_SECRET" \

--- a/infra/k8s/alexandria/templates/grafana-deployment.yaml
+++ b/infra/k8s/alexandria/templates/grafana-deployment.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.grafana.enabled }}
+{{- if and .Values.grafana.oauth.enabled (not .Values.grafana.oauth.rootUrl) }}
+{{- fail "grafana.oauth.enabled=true requires grafana.oauth.rootUrl (the public base URL Grafana is served from); without it Grafana builds a wrong OAuth redirect_uri." }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -51,6 +54,37 @@ spec:
                 secretKeyRef:
                   name: {{ include "alexandria.fullname" . }}-grafana
                   key: grafana-admin-password
+            {{- if .Values.grafana.oauth.enabled }}
+            - name: GF_SERVER_ROOT_URL
+              value: {{ .Values.grafana.oauth.rootUrl | quote }}
+            - name: GF_SERVER_SERVE_FROM_SUB_PATH
+              value: {{ .Values.grafana.oauth.serveFromSubPath | quote }}
+            - name: GF_AUTH_GENERIC_OAUTH_ENABLED
+              value: "true"
+            - name: GF_AUTH_GENERIC_OAUTH_NAME
+              value: {{ .Values.grafana.oauth.name | quote }}
+            - name: GF_AUTH_GENERIC_OAUTH_CLIENT_ID
+              value: {{ .Values.grafana.oauth.clientId | quote }}
+            - name: GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "alexandria.fullname" . }}-grafana
+                  key: grafana-oidc-client-secret
+            - name: GF_AUTH_GENERIC_OAUTH_SCOPES
+              value: {{ .Values.grafana.oauth.scopes | quote }}
+            - name: GF_AUTH_GENERIC_OAUTH_AUTH_URL
+              value: {{ .Values.grafana.oauth.authUrl | quote }}
+            - name: GF_AUTH_GENERIC_OAUTH_TOKEN_URL
+              value: {{ .Values.grafana.oauth.tokenUrl | quote }}
+            - name: GF_AUTH_GENERIC_OAUTH_API_URL
+              value: {{ .Values.grafana.oauth.apiUrl | quote }}
+            - name: GF_AUTH_GENERIC_OAUTH_USE_PKCE
+              value: "true"
+            - name: GF_AUTH_GENERIC_OAUTH_LOGIN_ATTRIBUTE_PATH
+              value: "preferred_username"
+            - name: GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH
+              value: {{ .Values.grafana.oauth.roleAttributePath | quote }}
+            {{- end }}
           ports:
             - name: http
               containerPort: 3000

--- a/infra/k8s/alexandria/templates/grafana-deployment.yaml
+++ b/infra/k8s/alexandria/templates/grafana-deployment.yaml
@@ -14,6 +14,9 @@
 {{- $oauthAuthUrl := .Values.grafana.oauth.authUrl | default (printf "https://%s/auth/realms/%s/protocol/openid-connect/auth" .Values.ingress.host $kcRealm) }}
 {{- $oauthTokenUrl := .Values.grafana.oauth.tokenUrl | default (printf "%s/token" $kcInternal) }}
 {{- $oauthApiUrl := .Values.grafana.oauth.apiUrl | default (printf "%s/userinfo" $kcInternal) }}
+{{- /* Grafana is reached under /grafana whenever its Ingress is on, so it has to serve from the
+       subpath and the health probes move under /grafana too, independent of whether OAuth is on. */}}
+{{- $grafanaSubPath := and .Values.grafana.ingress.enabled .Values.grafana.oauth.serveFromSubPath }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -66,11 +69,13 @@ spec:
                 secretKeyRef:
                   name: {{ include "alexandria.fullname" . }}-grafana
                   key: grafana-admin-password
-            {{- if .Values.grafana.oauth.enabled }}
+            {{- if or $grafanaSubPath .Values.grafana.oauth.enabled }}
             - name: GF_SERVER_ROOT_URL
               value: {{ $grafanaRootUrl | quote }}
             - name: GF_SERVER_SERVE_FROM_SUB_PATH
-              value: {{ .Values.grafana.oauth.serveFromSubPath | quote }}
+              value: {{ $grafanaSubPath | quote }}
+            {{- end }}
+            {{- if .Values.grafana.oauth.enabled }}
             - name: GF_AUTH_GENERIC_OAUTH_ENABLED
               value: "true"
             - name: GF_AUTH_GENERIC_OAUTH_NAME
@@ -119,7 +124,7 @@ spec:
             {{- toYaml .Values.grafana.resources | nindent 12 }}
           livenessProbe:
             httpGet:
-              path: /api/health
+              path: {{ if $grafanaSubPath }}/grafana/api/health{{ else }}/api/health{{ end }}
               port: http
             initialDelaySeconds: 30
             periodSeconds: 30
@@ -127,7 +132,7 @@ spec:
             failureThreshold: 3
           readinessProbe:
             httpGet:
-              path: /api/health
+              path: {{ if $grafanaSubPath }}/grafana/api/health{{ else }}/api/health{{ end }}
               port: http
             initialDelaySeconds: 10
             periodSeconds: 10

--- a/infra/k8s/alexandria/templates/grafana-deployment.yaml
+++ b/infra/k8s/alexandria/templates/grafana-deployment.yaml
@@ -6,6 +6,14 @@
 {{- if and .Values.grafana.oauth.enabled (not $grafanaRootUrl) }}
 {{- fail "grafana.oauth.enabled=true requires grafana.oauth.rootUrl, or ingress.host set so it can be derived." }}
 {{- end }}
+{{- $kcRealm := .Values.grafana.oauth.realm }}
+{{- /* Grafana runs in the monitoring namespace, so the backchannel token/userinfo URLs must
+       point at the namespace-qualified keycloak service in the release namespace, not a bare
+       service name (which only resolves inside the app namespace). authUrl is browser-facing. */}}
+{{- $kcInternal := printf "http://%s-keycloak.%s:8080/auth/realms/%s/protocol/openid-connect" (include "alexandria.fullname" .) .Release.Namespace $kcRealm }}
+{{- $oauthAuthUrl := .Values.grafana.oauth.authUrl | default (printf "https://%s/auth/realms/%s/protocol/openid-connect/auth" .Values.ingress.host $kcRealm) }}
+{{- $oauthTokenUrl := .Values.grafana.oauth.tokenUrl | default (printf "%s/token" $kcInternal) }}
+{{- $oauthApiUrl := .Values.grafana.oauth.apiUrl | default (printf "%s/userinfo" $kcInternal) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -77,11 +85,11 @@ spec:
             - name: GF_AUTH_GENERIC_OAUTH_SCOPES
               value: {{ .Values.grafana.oauth.scopes | quote }}
             - name: GF_AUTH_GENERIC_OAUTH_AUTH_URL
-              value: {{ .Values.grafana.oauth.authUrl | quote }}
+              value: {{ $oauthAuthUrl | quote }}
             - name: GF_AUTH_GENERIC_OAUTH_TOKEN_URL
-              value: {{ .Values.grafana.oauth.tokenUrl | quote }}
+              value: {{ $oauthTokenUrl | quote }}
             - name: GF_AUTH_GENERIC_OAUTH_API_URL
-              value: {{ .Values.grafana.oauth.apiUrl | quote }}
+              value: {{ $oauthApiUrl | quote }}
             - name: GF_AUTH_GENERIC_OAUTH_USE_PKCE
               value: "true"
             - name: GF_AUTH_GENERIC_OAUTH_LOGIN_ATTRIBUTE_PATH

--- a/infra/k8s/alexandria/templates/grafana-deployment.yaml
+++ b/infra/k8s/alexandria/templates/grafana-deployment.yaml
@@ -6,6 +6,9 @@
 {{- if and .Values.grafana.oauth.enabled (not $grafanaRootUrl) }}
 {{- fail "grafana.oauth.enabled=true requires grafana.oauth.rootUrl, or ingress.host set so it can be derived." }}
 {{- end }}
+{{- if and .Values.grafana.oauth.enabled (not .Values.grafana.oauth.authUrl) (not .Values.ingress.host) }}
+{{- fail "grafana.oauth.enabled=true requires grafana.oauth.authUrl, or ingress.host set so it can be derived." }}
+{{- end }}
 {{- $kcRealm := .Values.grafana.oauth.realm }}
 {{- /* Grafana runs in the monitoring namespace, so the backchannel token/userinfo URLs must
        point at the namespace-qualified keycloak service in the release namespace, not a bare

--- a/infra/k8s/alexandria/templates/grafana-deployment.yaml
+++ b/infra/k8s/alexandria/templates/grafana-deployment.yaml
@@ -1,6 +1,10 @@
 {{- if .Values.grafana.enabled }}
-{{- if and .Values.grafana.oauth.enabled (not .Values.grafana.oauth.rootUrl) }}
-{{- fail "grafana.oauth.enabled=true requires grafana.oauth.rootUrl (the public base URL Grafana is served from); without it Grafana builds a wrong OAuth redirect_uri." }}
+{{- $grafanaRootUrl := .Values.grafana.oauth.rootUrl }}
+{{- if and (not $grafanaRootUrl) .Values.ingress.host }}
+{{- $grafanaRootUrl = printf "https://%s/grafana" .Values.ingress.host }}
+{{- end }}
+{{- if and .Values.grafana.oauth.enabled (not $grafanaRootUrl) }}
+{{- fail "grafana.oauth.enabled=true requires grafana.oauth.rootUrl, or ingress.host set so it can be derived." }}
 {{- end }}
 apiVersion: apps/v1
 kind: Deployment
@@ -56,7 +60,7 @@ spec:
                   key: grafana-admin-password
             {{- if .Values.grafana.oauth.enabled }}
             - name: GF_SERVER_ROOT_URL
-              value: {{ .Values.grafana.oauth.rootUrl | quote }}
+              value: {{ $grafanaRootUrl | quote }}
             - name: GF_SERVER_SERVE_FROM_SUB_PATH
               value: {{ .Values.grafana.oauth.serveFromSubPath | quote }}
             - name: GF_AUTH_GENERIC_OAUTH_ENABLED

--- a/infra/k8s/alexandria/templates/grafana-ingress.yaml
+++ b/infra/k8s/alexandria/templates/grafana-ingress.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.grafana.enabled .Values.ingress.enabled .Values.grafana.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "alexandria.fullname" . }}-grafana
+  namespace: {{ include "alexandria.monitoringNamespace" . }}
+  labels:
+    {{- include "alexandria.labels" . | nindent 4 }}
+    app: grafana
+    app.kubernetes.io/component: monitoring
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /grafana
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "alexandria.fullname" . }}-grafana
+                port:
+                  number: 3000
+{{- end }}

--- a/infra/k8s/alexandria/templates/grafana-ingress.yaml
+++ b/infra/k8s/alexandria/templates/grafana-ingress.yaml
@@ -9,7 +9,9 @@ metadata:
     app: grafana
     app.kubernetes.io/component: monitoring
 spec:
+  {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
   rules:
     - host: {{ .Values.ingress.host }}
       http:

--- a/infra/k8s/alexandria/templates/secrets.yaml
+++ b/infra/k8s/alexandria/templates/secrets.yaml
@@ -19,6 +19,7 @@
 {{- $internalSecret := .Values.spring.internal.sharedSecret | default ($existing | dig "data" "internal-shared-secret" "" | b64dec) | default (randAlphaNum 32) }}
 {{- $keycloakAdminPassword := .Values.keycloak.keycloak.adminPassword | default ($existing | dig "data" "keycloak-admin-password" "" | b64dec) | default (randAlphaNum 24) }}
 {{- $grafanaAdminPassword := .Values.grafana.adminPassword | default ($existing | dig "data" "grafana-admin-password" "" | b64dec) | default (randAlphaNum 20) }}
+{{- $grafanaOidcClientSecret := ($existing | dig "data" "grafana-oidc-client-secret" "" | b64dec) | default (randAlphaNum 32) }}
 {{- $s3Config := printf "{\"identities\":[{\"name\":\"anvAdmin\",\"credentials\":[{\"accessKey\":%q,\"secretKey\":%q}],\"actions\":[\"Admin\",\"Read\",\"Write\"]}]}" $s3AccessKey $s3SecretKey }}
 
 {{- if .Values.existingSecret }}
@@ -41,6 +42,7 @@ stringData:
   db-password: {{ $dbPassword | quote }}
   keycloak-admin-password: {{ $keycloakAdminPassword | quote }}
   grafana-admin-password: {{ $grafanaAdminPassword | quote }}
+  grafana-oidc-client-secret: {{ $grafanaOidcClientSecret | quote }}
   s3-access-key: {{ $s3AccessKey | quote }}
   s3-secret-key: {{ $s3SecretKey | quote }}
   internal-shared-secret: {{ $internalSecret | quote }}
@@ -98,5 +100,6 @@ metadata:
 type: Opaque
 stringData:
   grafana-admin-password: {{ $grafanaAdminPassword | quote }}
+  grafana-oidc-client-secret: {{ $grafanaOidcClientSecret | quote }}
 {{- end }}
 {{- end }}

--- a/infra/k8s/alexandria/values.yaml
+++ b/infra/k8s/alexandria/values.yaml
@@ -207,6 +207,10 @@ grafana:
     tag: 13.0.2
   # Leave empty to auto-generate a random password on first install.
   adminPassword: ""
+  # Expose Grafana at <ingress.host>/grafana via its own Ingress in the monitoring
+  # namespace. Prometheus stays private (port-forward only).
+  ingress:
+    enabled: true
   persistence:
     size: 1Gi
   resources:
@@ -217,10 +221,11 @@ grafana:
       cpu: 200m
       memory: 256Mi
   oauth:
-    enabled: false
+    enabled: true
     name: Keycloak
     clientId: grafana
-    # Public base URL Grafana is served from, no trailing slash. Required when enabled.
+    # Public base URL Grafana is served from, no trailing slash. Leave empty to derive
+    # https://<ingress.host>/grafana; set it explicitly for a different external URL.
     rootUrl: ""
     # true if rootUrl serves Grafana under a subpath (e.g. .../grafana).
     serveFromSubPath: true

--- a/infra/k8s/alexandria/values.yaml
+++ b/infra/k8s/alexandria/values.yaml
@@ -229,10 +229,14 @@ grafana:
     rootUrl: ""
     # true if rootUrl serves Grafana under a subpath (e.g. .../grafana).
     serveFromSubPath: true
-    # Browser hits authUrl; the Grafana pod hits tokenUrl/apiUrl over the cluster network.
-    authUrl: "https://alexandria.stud.k8s.aet.cit.tum.de/auth/realms/alexandria/protocol/openid-connect/auth"
-    tokenUrl: "http://alexandria-keycloak:8080/auth/realms/alexandria/protocol/openid-connect/token"
-    apiUrl: "http://alexandria-keycloak:8080/auth/realms/alexandria/protocol/openid-connect/userinfo"
+    # Keycloak realm holding the grafana client.
+    realm: alexandria
+    # Leave these empty to derive them: authUrl (browser-facing) from ingress.host, and
+    # token/api (backchannel from the Grafana pod) from the keycloak service in the release
+    # namespace. Override only for an external Keycloak.
+    authUrl: ""
+    tokenUrl: ""
+    apiUrl: ""
     scopes: "openid email profile"
     roleAttributePath: "contains(roles[*], 'grafana-admin') && 'Admin' || 'Viewer'"
 

--- a/infra/k8s/alexandria/values.yaml
+++ b/infra/k8s/alexandria/values.yaml
@@ -43,8 +43,8 @@ spring:
 
 # Resource limits are sized to stay under the stud cluster ResourceQuota
 # `default-h2d5c` (3250m CPU / 5144Mi memory in the alexandria namespace).
-# Prometheus + Grafana live in alexandria-monitoring with its own 750m/1000Mi
-# quota, sized independently below.
+# Prometheus + Grafana live in alexandria-monitoring with its own 750m CPU /
+# 4096Mi memory quota, sized independently below.
 # Autoscaling is off by default.
 userService:
   resources:
@@ -213,13 +213,16 @@ grafana:
     enabled: true
   persistence:
     size: 1Gi
+  # Generous memory for dashboard rendering and query buffering, plus extra CPU so the
+  # liveness probe isn't starved under load. With Prometheus (300m/512Mi) this stays inside
+  # the alexandria-monitoring quota (750m CPU / 4096Mi memory).
   resources:
     requests:
-      cpu: 50m
-      memory: 128Mi
+      cpu: 100m
+      memory: 512Mi
     limits:
-      cpu: 200m
-      memory: 256Mi
+      cpu: 400m
+      memory: 2048Mi
   oauth:
     enabled: true
     name: Keycloak

--- a/infra/k8s/alexandria/values.yaml
+++ b/infra/k8s/alexandria/values.yaml
@@ -216,6 +216,20 @@ grafana:
     limits:
       cpu: 200m
       memory: 256Mi
+  oauth:
+    enabled: false
+    name: Keycloak
+    clientId: grafana
+    # Public base URL Grafana is served from, no trailing slash. Required when enabled.
+    rootUrl: ""
+    # true if rootUrl serves Grafana under a subpath (e.g. .../grafana).
+    serveFromSubPath: true
+    # Browser hits authUrl; the Grafana pod hits tokenUrl/apiUrl over the cluster network.
+    authUrl: "https://alexandria.stud.k8s.aet.cit.tum.de/auth/realms/alexandria/protocol/openid-connect/auth"
+    tokenUrl: "http://alexandria-keycloak:8080/auth/realms/alexandria/protocol/openid-connect/token"
+    apiUrl: "http://alexandria-keycloak:8080/auth/realms/alexandria/protocol/openid-connect/userinfo"
+    scopes: "openid email profile"
+    roleAttributePath: "contains(roles[*], 'grafana-admin') && 'Admin' || 'Viewer'"
 
 keycloak:
   keycloak:
@@ -238,6 +252,19 @@ keycloak:
       value: "https://alexandria.stud.k8s.aet.cit.tum.de/*"
     - name: KEYCLOAK_WEB_ORIGIN
       value: "https://alexandria.stud.k8s.aet.cit.tum.de"
+    - name: GRAFANA_REDIRECT_URI
+      value: "https://alexandria.stud.k8s.aet.cit.tum.de/grafana/login/generic_oauth"
+    - name: GRAFANA_WEB_ORIGIN
+      value: "https://alexandria.stud.k8s.aet.cit.tum.de"
+    # Substituted into the grafana client secret in realm.json at import time.
+    # optional so a Keycloak start never fails if the key is absent (e.g. a
+    # hand-made existingSecret); the grafana login just stays unconfigured.
+    - name: GRAFANA_OIDC_CLIENT_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: alexandria-secrets
+          key: grafana-oidc-client-secret
+          optional: true
   # CSS "alexandria" login theme for keycloak
   extraVolumes:
     - name: keycloak-theme

--- a/infra/oidc/realm.json
+++ b/infra/oidc/realm.json
@@ -720,6 +720,7 @@
         "oidc.ciba.grant.enabled": "false",
         "backchannel.logout.session.required": "true",
         "post.logout.redirect.uris": "${GRAFANA_REDIRECT_URI}",
+        "pkce.code.challenge.method": "S256",
         "standard.token.exchange.enabled": "false",
         "oauth2.jwt.authorization.grant.enabled": "false",
         "oauth2.device.authorization.grant.enabled": "false",

--- a/infra/oidc/realm.json
+++ b/infra/oidc/realm.json
@@ -87,6 +87,15 @@
         "clientRole": false,
         "containerId": "1d7956b6-0827-4d34-83ab-40cd47565f4b",
         "attributes": {}
+      },
+      {
+        "id": "d2c4f9a1-3e6b-4c88-9b1a-7f0c5e21ab34",
+        "name": "grafana-admin",
+        "description": "Grants Grafana org Admin via OIDC login. Users without it get Viewer.",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "1d7956b6-0827-4d34-83ab-40cd47565f4b",
+        "attributes": {}
       }
     ],
     "client": {
@@ -665,6 +674,79 @@
       "authenticationFlowBindingOverrides": {},
       "fullScopeAllowed": true,
       "nodeReRegistrationTimeout": -1,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "organization",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "b7f3d2c9-8a41-4e5f-9c02-1a2b3c4d5e6f",
+      "clientId": "grafana",
+      "name": "Grafana",
+      "description": "Grafana OIDC login via generic OAuth.",
+      "rootUrl": "",
+      "adminUrl": "",
+      "baseUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "${GRAFANA_OIDC_CLIENT_SECRET}",
+      "redirectUris": ["${GRAFANA_REDIRECT_URI}"],
+      "webOrigins": ["${GRAFANA_WEB_ORIGIN}"],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": true,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "oidc.ciba.grant.enabled": "false",
+        "backchannel.logout.session.required": "true",
+        "post.logout.redirect.uris": "${GRAFANA_REDIRECT_URI}",
+        "standard.token.exchange.enabled": "false",
+        "oauth2.jwt.authorization.grant.enabled": "false",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "backchannel.logout.revoke.offline.tokens": "false",
+        "dpop.bound.access.tokens": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "c1e2f3a4-b5c6-47d8-9e0f-1a2b3c4d5e60",
+          "name": "grafana realm roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "multivalued": "true",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "roles",
+            "jsonType.label": "String"
+          }
+        }
+      ],
       "defaultClientScopes": [
         "web-origins",
         "acr",


### PR DESCRIPTION
## What does this PR do?

Adds "Sign in with Keycloak" to Grafana via OIDC (generic OAuth), so we stop sharing the admin password to reach the dashboards. The built-in admin login stays as a fallback.

- New confidential `grafana` client in the `alexandria` realm and a `grafana-admin` role that maps to Grafana Admin (everyone else Viewer). A client-scoped mapper puts realm roles into a top-level `roles` claim, which is what Grafana's generic OAuth reads.
- Compose: Grafana gets the `GF_AUTH_GENERIC_OAUTH_*` env (auth_url via Traefik, token/api backchannel to Keycloak, PKCE on) and an absolute `GF_SERVER_ROOT_URL` so the redirect_uri is correct. Keycloak gets the client secret and redirect/origin for the realm import.
- Helm: Grafana is exposed at `https://<ingress.host>/grafana` through its own Ingress in the monitoring namespace (the app Ingress can't cross namespaces), with Keycloak OIDC on by default. The OAuth URLs derive automatically: root/auth from `ingress.host`, and token/userinfo from the Keycloak service in the release namespace (Grafana runs in the monitoring namespace, so those must be namespace-qualified). `secrets.yaml` generates `grafana-oidc-client-secret`; Keycloak reads it via `valueFrom` (optional). CI deploy secret includes the new key. Both `grafana.ingress.enabled` and `grafana.oauth.enabled` default true and can be turned off. Prometheus stays private (port-forward).
- Raised Grafana's limits (400m CPU / 2Gi memory) so the liveness probe isn't starved and dashboards have headroom; with Prometheus this stays inside the monitoring namespace quota (750m CPU / 4096Mi).

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [x] CI / infra

## Definition of Done

- [ ] CI is green
- [ ] If the API changed: `api/openapi.yaml` is updated and lint passes
- [ ] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [ ] Tests added or updated for the changed behaviour
- [ ] Docs updated where it matters (README, ADRs, comments)

## Notes for the reviewer


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Keycloak-based OAuth login for Grafana.
  * Added Grafana ingress access at the `/grafana` path.
  * Added role-based Grafana permissions, including `grafana-admin` access.
  * Added persistent Grafana OAuth configuration across deployments.

* **Documentation**
  * Updated local and Kubernetes deployment instructions with Grafana access, login, port-forwarding, and secret configuration details.
  * Documented built-in administrator login as a fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->