### PR TITLE
Fix: run the GenAI container as a non-root user

### DIFF
--- a/services/genai/Dockerfile
+++ b/services/genai/Dockerfile
@@ -43,6 +43,8 @@ RUN adduser -S -u 1000 -H genai
 WORKDIR /app
 COPY --from=builder --chown=genai:genai /app /app
 
+USER genai
+
 EXPOSE 8000
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \


### PR DESCRIPTION
## What does this PR do?

The GenAI Dockerfile created a `genai` user (uid 1000) and chowned the app directory to it, but never actually switched to that user, so the container ran as root. The Spring image already drops to `appuser` and the client runs on `nginx-unprivileged`, so genai was the only service still root by default.

Added the missing `USER genai` line after the `COPY --chown` and before `EXPOSE`/`HEALTHCHECK`/`ENTRYPOINT`, mirroring where `services/spring/Dockerfile` puts its `USER appuser`. The user and ownership were already set up, so this is a one-line fix that makes the runtime non-root.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] CI / infra

## Definition of Done

- [ ] CI is green
- [ ] If the API changed: `api/openapi.yaml` is updated and lint passes
- [ ] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [ ] Tests added or updated for the changed behaviour
- [ ] Docs updated where it matters (README, ADRs, comments)

## Notes for the reviewer


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * GenAI service containers now run as a non-root user, improving runtime isolation and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->