### PR TITLE
Docs: link team responsibilities from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Alexandria consists of three main subsystems orchestrated via Docker Compose and
 - **Server**: Three Spring Boot microservices (user-service, knowledgebase-service, qa-service) exposing REST APIs, backed by PostgreSQL with a schema per service.
 - **GenAI**: A Python/FastAPI service using LangChain to extract entities and summarize uploaded documents.
 
+## Team responsibilities
+
+Each subsystem lists its responsible team member in the [System Overview](docs/System_Overview.md).
+
 ## Test coverage
 
 | Service                      | Coverage                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |


### PR DESCRIPTION
## What does this PR do?

Adds a short "Team responsibilities" section to the root README that points to the System Overview, where each subsystem already names its responsible team member. No change to `docs/System_Overview.md` itself; the per-subsystem ownership lines there are accurate and stay as the single source.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Docs
- [ ] CI / infra

## Definition of Done

- [ ] CI is green
- [ ] If the API changed: `api/openapi.yaml` is updated and lint passes
- [ ] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [ ] Tests added or updated for the changed behaviour
- [x] Docs updated where it matters (README, ADRs, comments)

## Notes for the reviewer

Placed the new section right after the Overview so "who owns what" is easy to find from the README, per the deliverable checklist. It links to `docs/System_Overview.md` rather than restating the owners, so there's nothing to keep in sync.
