### PR TITLE
Chore: GenAI hygiene and Spring->GenAI read timeout

### DIFF
--- a/services/genai/Dockerfile
+++ b/services/genai/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/astral-sh/uv:python3.14-alpine AS builder
+FROM ghcr.io/astral-sh/uv:python3.14-alpine@sha256:7a6d8c4ff34812917124c77a8559458488f09d5e52e7646c04599f007956966c AS builder
 
 ENV PYTHONFAULTHANDLER=1 \
     PYTHONUNBUFFERED=1 \
@@ -24,11 +24,7 @@ RUN --mount=type=cache,target=$UV_CACHE_DIR \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     uv sync --frozen --no-dev
 
-FROM python:3.14-alpine AS runtime
-
-ARG RELEASE_TYPE=staging
-ARG APP_VERSION=dev
-ARG IMAGE_TAG=unknown
+FROM python:3.14-alpine@sha256:26730869004e2b9c4b9ad09cab8625e81d256d1ce97e72df5520e806b1709f92 AS runtime
 
 ENV PYTHONFAULTHANDLER=1 \
     PYTHONUNBUFFERED=1 \
@@ -40,7 +36,6 @@ ENV PYTHONFAULTHANDLER=1 \
 WORKDIR /app
 
 RUN adduser -S -u 1000 -H genai
-WORKDIR /app
 COPY --from=builder --chown=genai:genai /app /app
 
 USER genai
@@ -51,4 +46,3 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/genai/health').read()" || exit 1
 
 ENTRYPOINT ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
-# ENTRYPOINT ["sleep", "600"]

--- a/services/genai/app/main.py
+++ b/services/genai/app/main.py
@@ -20,7 +20,7 @@ from app.tracing import setup_tracing
 from app.vectorstore import close_client, delete_document, index_chunks
 
 SERVICE_NAME = "alexandria-genai"
-SERVICE_VERSION = "5.0.0"
+SERVICE_VERSION = "6.0.0"
 
 
 @asynccontextmanager

--- a/services/genai/pyproject.toml
+++ b/services/genai/pyproject.toml
@@ -1,13 +1,10 @@
 [project]
 name = "alexandria-genai"
-version = "5.0.0"
+version = "6.0.0"
 description = "GenAI microservice for Alexandria"
 requires-python = "~=3.14.0"
 dependencies = [
     "fastapi~=0.139.0",
-    "uvicorn[standard]~=0.51.0",
-    "pydantic~=2.13.4",
-    "langchain-openai~=1.3.5",
     "uvicorn[standard]~=0.51.0",
     "pydantic~=2.13.4",
     "langchain-openai~=1.3.5",

--- a/services/genai/uv.lock
+++ b/services/genai/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.14.*"
 
 [[package]]
 name = "alexandria-genai"
-version = "5.0.0"
+version = "6.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/services/spring/knowledgebase-service/src/main/java/com/alexandria/knowledgebase/integration/GenAiClient.java
+++ b/services/spring/knowledgebase-service/src/main/java/com/alexandria/knowledgebase/integration/GenAiClient.java
@@ -42,7 +42,10 @@ public class GenAiClient {
     public GenAiClient(@Value("${genai.base-url:http://localhost:8000}") String baseUrl, MeterRegistry meterRegistry) {
         HttpClient httpClient = HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).connectTimeout(Duration.ofSeconds(5)).build();
         JdkClientHttpRequestFactory factory = new JdkClientHttpRequestFactory(httpClient);
-        factory.setReadTimeout(Duration.ofSeconds(30));
+        // Long-document LLM calls are slow by design. This must sit above the GenAI service's
+        // worst-case budget for a single call (LLM_TIMEOUT_SECONDS * (1 + LLM_MAX_RETRIES) =
+        // 60s * 3 = 180s), so Spring doesn't abandon a request GenAI is still working on.
+        factory.setReadTimeout(Duration.ofSeconds(200));
         RestClient restClient = ApiClient.buildRestClientBuilder().requestFactory(factory).build();
         ApiClient apiClient = new ApiClient(restClient).setBasePath(baseUrl);
         this.genaiClient = new AiApi(apiClient);

--- a/services/spring/qa-service/src/main/java/com/alexandria/qa/integration/GenAiClient.java
+++ b/services/spring/qa-service/src/main/java/com/alexandria/qa/integration/GenAiClient.java
@@ -34,7 +34,10 @@ public class GenAiClient {
     public GenAiClient(@Value("${genai.base-url:http://localhost:8000}") String baseUrl, MeterRegistry meterRegistry) {
         HttpClient httpClient = HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).connectTimeout(Duration.ofSeconds(5)).build();
         JdkClientHttpRequestFactory factory = new JdkClientHttpRequestFactory(httpClient);
-        factory.setReadTimeout(Duration.ofSeconds(30));
+        // Long-document LLM calls are slow by design. This must sit above the GenAI service's
+        // worst-case budget for a single call (LLM_TIMEOUT_SECONDS * (1 + LLM_MAX_RETRIES) =
+        // 60s * 3 = 180s), so Spring doesn't abandon a request GenAI is still working on.
+        factory.setReadTimeout(Duration.ofSeconds(200));
         RestClient restClient = ApiClient.buildRestClientBuilder().requestFactory(factory).build();
         ApiClient apiClient = new ApiClient(restClient).setBasePath(baseUrl);
         this.genaiClient = new AiApi(apiClient);


### PR DESCRIPTION
## What does this PR do?

Cleanup around the GenAI service plus one cross-service timeout fix. No behaviour change to the AI endpoints themselves.

- **Dockerfile cleanup.** Dropped the three declared-but-unused build args (`RELEASE_TYPE`, `APP_VERSION`, `IMAGE_TAG`), the commented-out `# ENTRYPOINT ["sleep", "600"]` debug line, and the duplicate `WORKDIR /app`. Also pinned both base images by digest (`ghcr.io/astral-sh/uv:python3.14-alpine` and `python:3.14-alpine`), which is what the client and Spring Dockerfiles already do.
- **pyproject dedupe + version.** `dependencies` listed `uvicorn`, `pydantic`, and `langchain-openai` twice; removed the duplicates. Bumped the version from 5.0.0 to 6.0.0 so genai lines up with the Spring services (also updated `app/main.py`'s `SERVICE_VERSION`, which feeds the FastAPI version and the `application_version` metric, and the `alexandria-genai` entry in `uv.lock`).
- **Spring to GenAI read timeout.** Both `GenAiClient`s (knowledgebase- and qa-service) used a 30s read timeout, but the GenAI chat budget is `LLM_TIMEOUT_SECONDS`=60 with 2 retries, i.e. up to 180s worst case. So Spring could abandon a long-document request at 30s while GenAI kept working (and spending tokens) on something nobody was waiting for. Raised the read timeout to 200s so it sits above GenAI's worst case, rather than shortening GenAI, so the long-document requests the system is built for don't get cut off mid-flight.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / cleanup
- [ ] Docs
- [ ] CI / infra

## Definition of Done

- [ ] CI is green
- [ ] If the API changed: `api/openapi.yaml` is updated and lint passes
- [ ] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [ ] Tests added or updated for the changed behaviour
- [x] Docs updated where it matters (README, ADRs, comments)

## Notes for the reviewer

- On the timeout: 200s covers the chat model's worst case (60s x 3). The qa `/ask` path does an embedding call plus the chat call, so in a pathological double-worst-case (both maxing out their retries) it could exceed 200s, but that only happens if GenAI is already badly degraded. If you'd rather cap the total instead, the alternative was shortening GenAI's own budget; I went with raising Spring per our discussion.
