### PR TITLE
CI: Pin Azure deploy to commit SHA, prune images, make Prometheus private

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,17 @@
 # PUBLIC_BASE_URL="http://localhost"
 
 # ----------------------------------------------------------------------------------
+# Image tag (deployment)
+# ----------------------------------------------------------------------------------
+
+# Which image tag docker-compose pulls for the app services (client, the three
+# Spring services, genai). Defaults to "latest". The Azure VM deploy pins this to
+# the commit SHA in CI so a deploy is traceable to a commit and can be rolled back
+# precisely; local dev leaves it at latest.
+
+# IMAGE_TAG="latest"
+
+# ----------------------------------------------------------------------------------
 # TLS / Let's Encrypt (docker-compose.letsencrypt.yml overlay)
 # ----------------------------------------------------------------------------------
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -933,10 +933,12 @@ jobs:
       - name: Deploy via Ansible
         env:
           ANSIBLE_CONFIG: infra/azure/ansible/ansible.cfg
+          IMAGE_TAG: ${{ needs.build-image.outputs.image-tag }}
         run: |
           ansible-playbook -i inventory.ini infra/azure/ansible/playbook.yml \
             --tags deploy \
-            -e "repo_root=${GITHUB_WORKSPACE}"
+            -e "repo_root=${GITHUB_WORKSPACE}" \
+            -e "image_tag=${IMAGE_TAG}"
 
   # ---------------------------------------------------------------------
   # Deploy to stud cluster (Rancher/k8s)

--- a/docker-compose.letsencrypt.yml
+++ b/docker-compose.letsencrypt.yml
@@ -31,5 +31,14 @@ services:
     volumes:
       - letsencrypt:/letsencrypt
 
+  prometheus:
+    # On a public deployment Prometheus is not exposed through Traefik, only
+    # Grafana is (behind Keycloak). Disable its router and publish the port on
+    # loopback instead, so you reach it with an SSH tunnel the same way you would port-forward it on k8s.
+    labels:
+      - "traefik.enable=false"
+    ports:
+      - "127.0.0.1:9090:9090"
+
 volumes:
   letsencrypt:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   client:
-    image: ghcr.io/aet-devops26/team-bnd/client:latest
+    image: ghcr.io/aet-devops26/team-bnd/client:${IMAGE_TAG:-latest}
     build:
       context: services/client/
       dockerfile: Dockerfile
@@ -55,7 +55,7 @@ services:
       - /app/node_modules
 
   user-service:
-    image: ghcr.io/aet-devops26/team-bnd/user-service:latest
+    image: ghcr.io/aet-devops26/team-bnd/user-service:${IMAGE_TAG:-latest}
     build:
       context: services/spring/
       dockerfile: Dockerfile
@@ -109,7 +109,7 @@ services:
         condition: service_started
 
   knowledgebase-service:
-    image: ghcr.io/aet-devops26/team-bnd/knowledgebase-service:latest
+    image: ghcr.io/aet-devops26/team-bnd/knowledgebase-service:${IMAGE_TAG:-latest}
     build:
       context: services/spring/
       dockerfile: Dockerfile
@@ -170,7 +170,7 @@ services:
         condition: service_started
 
   qa-service:
-    image: ghcr.io/aet-devops26/team-bnd/qa-service:latest
+    image: ghcr.io/aet-devops26/team-bnd/qa-service:${IMAGE_TAG:-latest}
     build:
       context: services/spring/
       dockerfile: Dockerfile
@@ -224,7 +224,7 @@ services:
         condition: service_started
 
   genai:
-    image: ghcr.io/aet-devops26/team-bnd/genai:latest
+    image: ghcr.io/aet-devops26/team-bnd/genai:${IMAGE_TAG:-latest}
     build: services/genai/
     container_name: genai
     # kics-scan ignore-block

--- a/infra/azure/README.md
+++ b/infra/azure/README.md
@@ -48,6 +48,17 @@ For HTTPS, pick Let's Encrypt in generate-env.sh (or set `PUBLIC_DOMAIN` and `AC
 
 Once the VM is provisioned, pushes to `main` redeploy automatically when the `DEPLOY_AZURE` variable is set. The `Deploy to Azure VM` job runs the same Ansible deploy role with `--tags deploy`, so CI shares the deploy path with provision.sh instead of using its own copy commands. It does not re-run the provisioning: it assumes Docker and the `.env` are already on the VM, skips the Docker install, and never generates or replaces the `.env` or the TLS override. The job only refreshes the compose files and infra config and re-deploys. It needs the `AZURE` environment with the `AZURE_PRIVATE_KEY` secret and the `AZURE_PUBLIC_IP` and `AZURE_USER` variables.
 
+CI passes the built commit's short SHA as `image_tag`, so the VM runs exactly the images built for that commit. This keeps a deploy traceable to a commit and precisely rollback-able, matching the Kubernetes path. After each deploy the role also prunes unused images older than a week so old SHA-tagged layers don't slowly fill the VM disk.
+
+## Monitoring access
+
+Grafana is reachable at `<base-url>/grafana/` (login through Keycloak). Prometheus is deliberately not exposed on a public deployment. Reach it with an SSH tunnel (same idea as with `kubectl port-forward` on the Kubernetes cluster):
+
+```bash
+ssh -L 9090:localhost:9090 <user>@<vm-ip>
+# then open http://localhost:9090/prometheus/
+```
+
 ## Update a running deployment by hand
 
 If the VM is already up and you just want to push new compose or infra changes without touching Terraform or the `.env`, run the deploy role on its own (this is exactly what the CI also does).

--- a/infra/azure/ansible/roles/deploy/tasks/main.yml
+++ b/infra/azure/ansible/roles/deploy/tasks/main.yml
@@ -63,14 +63,29 @@
         mode: "0600"
       when: env_file | length > 0
 
+    # CI passes the commit SHA as image_tag so the VM runs exactly what was built
+    # for this commit (traceable, precisely rollback-able).
     - name: Pull the images
       ansible.builtin.command:
         cmd: docker compose pull
         chdir: "{{ deploy_dir }}"
+      environment:
+        IMAGE_TAG: "{{ image_tag | default('latest', true) }}"
       changed_when: true
 
     - name: Start the stack
       ansible.builtin.command:
         cmd: docker compose up -d --remove-orphans
+        chdir: "{{ deploy_dir }}"
+      environment:
+        IMAGE_TAG: "{{ image_tag | default('latest', true) }}"
+      changed_when: true
+
+    # Every merge to main pulls fresh SHA-tagged images. Keep only the last
+    # week so a recent rollback still has its image locally, drop
+    # anything older that no container is using.
+    - name: Prune unused images older than a week
+      ansible.builtin.command:
+        cmd: docker image prune -af --filter until=168h
         chdir: "{{ deploy_dir }}"
       changed_when: true


### PR DESCRIPTION
## What does this PR do?

Brings the Azure VM deploy up to the same rigor the Kubernetes path already has, and closes an open Prometheus on the public deployment.

**Pin deployed images to the commit SHA + prune old ones.** The k8s deploy passes `image.tag=<sha>` to Helm, but the VM just did `docker compose pull` against `ghcr.io/...:latest`, so it ran "whatever latest was at pull time": not traceable to a commit, racy when two merges queue, and impossible to roll back precisely.

- `docker-compose.yml` now uses `:${IMAGE_TAG:-latest}` for the five app images, so it still defaults to `:latest` for local/manual use.
- The Ansible deploy role passes `IMAGE_TAG` (from the new `image_tag` var) into `docker compose pull` and `up`, defaulting to `latest` when unset.
- The CI `Deploy to Azure VM` job passes the built short SHA (`needs.build-image.outputs.image-tag`, the same value k8s already uses) as `image_tag`.
- The role also prunes unused images older than a week (`docker image prune -af --filter until=168h`) after each deploy, so old SHA-tagged layers stop piling up until the disk fills.

**Keep Prometheus off the public router.** On the public (Let's Encrypt) deployment, `/prometheus` was reachable unauthenticated: the TLS overlay only added TLS, no auth. In k8s Prometheus is private (port-forward only) and only Grafana is exposed (behind Keycloak). The overlay now disables the Prometheus Traefik router and publishes it on the VM's loopback (`127.0.0.1:9090`), so it's reachable via an SSH tunnel (`ssh -L 9090:localhost:9090 <vm>`), mirroring `kubectl port-forward`. Local dev is unchanged: it doesn't use the overlay, so `http://localhost/prometheus/` still works.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [x] CI / infra

## Definition of Done

- [ ] CI is green
- [ ] If the API changed: `api/openapi.yaml` is updated and lint passes
- [ ] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [ ] Tests added or updated for the changed behaviour
- [x] Docs updated where it matters (README, ADRs, comments)

## Notes for the reviewer
