### PR TITLE
Chore: Bump client version to 6.0.0

### DIFF
--- a/services/client/package-lock.json
+++ b/services/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "alexandria-client",
-  "version": "0.1.0",
+  "version": "6.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "alexandria-client",
-      "version": "0.1.0",
+      "version": "6.0.0",
       "dependencies": {
         "@tanstack/react-query": "~5.101.2",
         "oidc-client-ts": "~3.5.0",

--- a/services/client/package.json
+++ b/services/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alexandria-client",
-  "version": "0.1.0",
+  "version": "6.0.0",
   "engines": {
     "node": "^24"
   },


### PR DESCRIPTION
## What does this PR do?

Bumps the client version from `0.1.0` to `6.0.0` so it lines up with the other components (the Spring services and, after the genai hygiene PR, the GenAI service are all on 6.0.0). The client had just never been bumped past the initial scaffold version.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / cleanup
- [ ] Docs
- [ ] CI / infra

## Definition of Done

- [ ] CI is green
- [ ] If the API changed: `api/openapi.yaml` is updated and lint passes
- [ ] If a service was added or restructured: docker-compose still comes up cleanly (`docker compose up`)
- [ ] Tests added or updated for the changed behaviour
- [ ] Docs updated where it matters (README, ADRs, comments)

## Notes for the reviewer
